### PR TITLE
refactored module name

### DIFF
--- a/cmd/butleradm/main.go
+++ b/cmd/butleradm/main.go
@@ -17,9 +17,9 @@
 package main
 
 import (
-	"butler/internal/cli/adm"
-	_ "butler/internal/cli/adm/generate"
-	"butler/internal/logger"
+	"github.com/butlerdotdev/butler/internal/cli/adm"
+	_ "github.com/butlerdotdev/butler/internal/cli/adm/generate"
+	"github.com/butlerdotdev/butler/internal/logger"
 )
 
 // main initializes the logger and executes the Butler CLI.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module butler
+module github.com/butlerdotdev/butler
 
 go 1.23.0
 

--- a/internal/cli/adm/bootstrap/bootstrap.go
+++ b/internal/cli/adm/bootstrap/bootstrap.go
@@ -17,8 +17,9 @@
 package bootstrap
 
 import (
-	"butler/internal/logger"
 	"fmt"
+
+	"github.com/butlerdotdev/butler/internal/logger"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/internal/cli/adm/bootstrap/providers/nutanix.go
+++ b/internal/cli/adm/bootstrap/providers/nutanix.go
@@ -17,10 +17,11 @@
 package providers
 
 import (
-	bootstrap "butler/internal/handlers/bootstrap/nutanix"
-	"butler/internal/logger"
-	"butler/internal/tui"
 	"context"
+
+	bootstrap "github.com/butlerdotdev/butler/internal/handlers/bootstrap/nutanix"
+	"github.com/butlerdotdev/butler/internal/logger"
+	"github.com/butlerdotdev/butler/internal/tui"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/internal/cli/adm/bootstrap/providers/proxmox.go
+++ b/internal/cli/adm/bootstrap/providers/proxmox.go
@@ -17,9 +17,10 @@
 package providers
 
 import (
-	bootstrap "butler/internal/handlers/bootstrap/proxmox"
-	"butler/internal/logger"
 	"context"
+
+	bootstrap "github.com/butlerdotdev/butler/internal/handlers/bootstrap/proxmox"
+	"github.com/butlerdotdev/butler/internal/logger"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/internal/cli/adm/generate/docs.go
+++ b/internal/cli/adm/generate/docs.go
@@ -17,7 +17,7 @@
 package generate
 
 import (
-	"butler/internal/logger"
+	"github.com/butlerdotdev/butler/internal/logger"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"

--- a/internal/cli/adm/generate/generate.go
+++ b/internal/cli/adm/generate/generate.go
@@ -17,7 +17,7 @@
 package generate
 
 import (
-	"butler/internal/logger"
+	"github.com/butlerdotdev/butler/internal/logger"
 
 	"github.com/spf13/cobra"
 )

--- a/internal/cli/adm/root.go
+++ b/internal/cli/adm/root.go
@@ -17,12 +17,13 @@
 package adm
 
 import (
-	"butler/internal/cli/adm/bootstrap"
-	"butler/internal/cli/adm/bootstrap/providers"
-	"butler/internal/cli/adm/generate"
-	"butler/internal/logger"
 	"os"
 	"strings"
+
+	"github.com/butlerdotdev/butler/internal/cli/adm/bootstrap"
+	"github.com/butlerdotdev/butler/internal/cli/adm/bootstrap/providers"
+	"github.com/butlerdotdev/butler/internal/cli/adm/generate"
+	"github.com/butlerdotdev/butler/internal/logger"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/internal/handlers/bootstrap/nutanix/handler.go
+++ b/internal/handlers/bootstrap/nutanix/handler.go
@@ -17,10 +17,11 @@
 package bootstrap
 
 import (
-	"butler/internal/models"
-	service "butler/internal/services/bootstrap/nutanix"
 	"context"
 	"fmt"
+
+	"github.com/butlerdotdev/butler/internal/models"
+	service "github.com/butlerdotdev/butler/internal/services/bootstrap/nutanix"
 
 	"github.com/spf13/viper"
 	"go.uber.org/zap"

--- a/internal/handlers/bootstrap/proxmox/handler.go
+++ b/internal/handlers/bootstrap/proxmox/handler.go
@@ -17,10 +17,11 @@
 package bootstrap
 
 import (
-	"butler/internal/models"
-	service "butler/internal/services/bootstrap/proxmox"
 	"context"
 	"fmt"
+
+	"github.com/butlerdotdev/butler/internal/models"
+	service "github.com/butlerdotdev/butler/internal/services/bootstrap/proxmox"
 
 	"github.com/spf13/viper"
 	"go.uber.org/zap"

--- a/internal/mappers/mappers.go
+++ b/internal/mappers/mappers.go
@@ -20,7 +20,7 @@
 
 package mappers
 
-import "butler/internal/models"
+import "github.com/butlerdotdev/butler/internal/models"
 
 func NewMapping(provider string, config models.ManagementClusterConfig) map[string]string {
 	switch provider {

--- a/internal/mappers/nutanix.go
+++ b/internal/mappers/nutanix.go
@@ -21,7 +21,7 @@
 package mappers
 
 import (
-	"butler/internal/models"
+	"github.com/butlerdotdev/butler/internal/models"
 )
 
 func NutanixToMap(cfg models.NutanixConfig) map[string]string {

--- a/internal/mappers/proxmox.go
+++ b/internal/mappers/proxmox.go
@@ -21,9 +21,10 @@
 package mappers
 
 import (
-	"butler/internal/models"
 	"fmt"
 	"strings"
+
+	"github.com/butlerdotdev/butler/internal/models"
 )
 
 func ProxmoxToMap(cfg models.ProxmoxConfig) map[string]string {

--- a/internal/services/bootstrap/nutanix/flux.go
+++ b/internal/services/bootstrap/nutanix/flux.go
@@ -16,12 +16,13 @@
 package bootstrap
 
 import (
-	"butler/internal/models"
-	"butler/pkg/adapters/platforms/flux"
 	"context"
 	"fmt"
 	"os"
 	"time"
+
+	"github.com/butlerdotdev/butler/internal/models"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/flux"
 
 	"go.uber.org/zap"
 )

--- a/internal/services/bootstrap/nutanix/healthchecker.go
+++ b/internal/services/bootstrap/nutanix/healthchecker.go
@@ -17,11 +17,12 @@
 package bootstrap
 
 import (
-	"butler/internal/models"
-	"butler/pkg/adapters/providers"
 	"fmt"
-	"go.uber.org/zap"
 	"time"
+
+	"github.com/butlerdotdev/butler/internal/models"
+	"github.com/butlerdotdev/butler/pkg/adapters/providers"
+	"go.uber.org/zap"
 )
 
 // HealthChecker waits for VMs to report healthy and have allocated IPs.

--- a/internal/services/bootstrap/nutanix/kubeconfig.go
+++ b/internal/services/bootstrap/nutanix/kubeconfig.go
@@ -17,11 +17,12 @@
 package bootstrap
 
 import (
-	"butler/pkg/adapters/platforms"
 	"context"
 	"fmt"
 	"os"
 	"time"
+
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms"
 
 	"go.uber.org/zap"
 )

--- a/internal/services/bootstrap/nutanix/kubeovn.go
+++ b/internal/services/bootstrap/nutanix/kubeovn.go
@@ -17,10 +17,6 @@ package bootstrap
 
 import (
 	"bufio"
-	"butler/internal/models"
-	"butler/pkg/adapters/platforms/helm"
-	"butler/pkg/adapters/platforms/kubectl"
-	"butler/pkg/adapters/platforms/talos"
 	"bytes"
 	"context"
 	_ "embed"
@@ -29,6 +25,11 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/butlerdotdev/butler/internal/models"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/helm"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/kubectl"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/talos"
 
 	"go.uber.org/zap"
 )

--- a/internal/services/bootstrap/nutanix/kubevip.go
+++ b/internal/services/bootstrap/nutanix/kubevip.go
@@ -17,13 +17,14 @@
 package bootstrap
 
 import (
-	"butler/internal/models"
-	"butler/pkg/adapters/platforms/docker"
-	"butler/pkg/adapters/platforms/kubectl"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/butlerdotdev/butler/internal/models"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/docker"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/kubectl"
 
 	"go.uber.org/zap"
 )

--- a/internal/services/bootstrap/nutanix/provisioner.go
+++ b/internal/services/bootstrap/nutanix/provisioner.go
@@ -17,9 +17,10 @@
 package bootstrap
 
 import (
-	"butler/internal/models"
-	"butler/pkg/adapters/providers"
 	"fmt"
+
+	"github.com/butlerdotdev/butler/internal/models"
+	"github.com/butlerdotdev/butler/pkg/adapters/providers"
 	"go.uber.org/zap"
 )
 

--- a/internal/services/bootstrap/nutanix/service.go
+++ b/internal/services/bootstrap/nutanix/service.go
@@ -17,19 +17,20 @@
 package bootstrap
 
 import (
-	"butler/internal/mappers"
-	"butler/internal/models"
-	"butler/pkg/adapters/exec"
-	"butler/pkg/adapters/platforms"
-	"butler/pkg/adapters/platforms/docker"
-	"butler/pkg/adapters/platforms/flux"
-	"butler/pkg/adapters/platforms/helm"
-	"butler/pkg/adapters/platforms/kubectl"
-	"butler/pkg/adapters/platforms/talos"
-	"butler/pkg/adapters/providers"
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/butlerdotdev/butler/internal/mappers"
+	"github.com/butlerdotdev/butler/internal/models"
+	"github.com/butlerdotdev/butler/pkg/adapters/exec"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/docker"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/flux"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/helm"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/kubectl"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/talos"
+	"github.com/butlerdotdev/butler/pkg/adapters/providers"
 
 	"go.uber.org/zap"
 )
@@ -230,9 +231,9 @@ func (b *BootstrapService) ProvisionManagementCluster() error {
 	// We will install this similarly to kube ovn, Outside of the flux process. BUT, we can still use flux to manage parts of linstor.
 
 	// Bootstrap Flux
-	if err := b.fluxInit.FluxBootstrap(context.Background(), config); err != nil {
-		return fmt.Errorf("failed to bootstrap Flux: %w", err)
-	}
+	// if err := b.fluxInit.FluxBootstrap(context.Background(), config); err != nil {
+	// 	return fmt.Errorf("failed to bootstrap Flux: %w", err)
+	// }
 
 	// After Flux is bootstrapped the following should be provisioned Via Flux:
 	// MetalLB

--- a/internal/services/bootstrap/nutanix/talos.go
+++ b/internal/services/bootstrap/nutanix/talos.go
@@ -17,11 +17,12 @@
 package bootstrap
 
 import (
-	"butler/internal/models"
-	"butler/pkg/adapters/platforms/talos"
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/butlerdotdev/butler/internal/models"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/talos"
 
 	"go.uber.org/zap"
 )

--- a/internal/services/bootstrap/proxmox/flux.go
+++ b/internal/services/bootstrap/proxmox/flux.go
@@ -16,12 +16,13 @@
 package bootstrap
 
 import (
-	"butler/internal/models"
-	"butler/pkg/adapters/platforms/flux"
 	"context"
 	"fmt"
 	"os"
 	"time"
+
+	"github.com/butlerdotdev/butler/internal/models"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/flux"
 
 	"go.uber.org/zap"
 )

--- a/internal/services/bootstrap/proxmox/healthchecker.go
+++ b/internal/services/bootstrap/proxmox/healthchecker.go
@@ -17,11 +17,12 @@
 package bootstrap
 
 import (
-	"butler/internal/models"
-	"butler/pkg/adapters/providers"
 	"fmt"
-	"go.uber.org/zap"
 	"time"
+
+	"github.com/butlerdotdev/butler/internal/models"
+	"github.com/butlerdotdev/butler/pkg/adapters/providers"
+	"go.uber.org/zap"
 )
 
 // HealthChecker waits for VMs to report healthy and have allocated IPs.

--- a/internal/services/bootstrap/proxmox/kubeconfig.go
+++ b/internal/services/bootstrap/proxmox/kubeconfig.go
@@ -17,11 +17,12 @@
 package bootstrap
 
 import (
-	"butler/pkg/adapters/platforms"
 	"context"
 	"fmt"
 	"os"
 	"time"
+
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms"
 
 	"go.uber.org/zap"
 )

--- a/internal/services/bootstrap/proxmox/kubevip.go
+++ b/internal/services/bootstrap/proxmox/kubevip.go
@@ -17,13 +17,14 @@
 package bootstrap
 
 import (
-	"butler/internal/models"
-	"butler/pkg/adapters/platforms/docker"
-	"butler/pkg/adapters/platforms/kubectl"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/butlerdotdev/butler/internal/models"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/docker"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/kubectl"
 
 	"go.uber.org/zap"
 )

--- a/internal/services/bootstrap/proxmox/provisioner.go
+++ b/internal/services/bootstrap/proxmox/provisioner.go
@@ -17,9 +17,10 @@
 package bootstrap
 
 import (
-	"butler/internal/models"
-	"butler/pkg/adapters/providers"
 	"fmt"
+
+	"github.com/butlerdotdev/butler/internal/models"
+	"github.com/butlerdotdev/butler/pkg/adapters/providers"
 
 	"go.uber.org/zap"
 )

--- a/internal/services/bootstrap/proxmox/service.go
+++ b/internal/services/bootstrap/proxmox/service.go
@@ -17,18 +17,19 @@
 package bootstrap
 
 import (
-	"butler/internal/mappers"
-	"butler/internal/models"
-	"butler/pkg/adapters/exec"
-	"butler/pkg/adapters/platforms"
-	"butler/pkg/adapters/platforms/docker"
-	"butler/pkg/adapters/platforms/flux"
-	"butler/pkg/adapters/platforms/kubectl"
-	"butler/pkg/adapters/platforms/talos"
-	"butler/pkg/adapters/providers"
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/butlerdotdev/butler/internal/mappers"
+	"github.com/butlerdotdev/butler/internal/models"
+	"github.com/butlerdotdev/butler/pkg/adapters/exec"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/docker"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/flux"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/kubectl"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/talos"
+	"github.com/butlerdotdev/butler/pkg/adapters/providers"
 
 	"go.uber.org/zap"
 )

--- a/internal/services/bootstrap/proxmox/talos.go
+++ b/internal/services/bootstrap/proxmox/talos.go
@@ -17,11 +17,12 @@
 package bootstrap
 
 import (
-	"butler/internal/models"
-	"butler/pkg/adapters/platforms/talos"
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/butlerdotdev/butler/internal/models"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/talos"
 
 	"go.uber.org/zap"
 )

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -17,10 +17,11 @@
 package tui
 
 import (
-	"butler/pkg/adapters/providers/nutanix"
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/butlerdotdev/butler/pkg/adapters/providers/nutanix"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"

--- a/pkg/adapters/exec/client.go
+++ b/pkg/adapters/exec/client.go
@@ -22,7 +22,7 @@ import (
 	"os/exec"
 	"time"
 
-	"butler/pkg/adapters/exec/models"
+	"github.com/butlerdotdev/butler/pkg/adapters/exec/models"
 	"go.uber.org/zap"
 )
 

--- a/pkg/adapters/exec/interface.go
+++ b/pkg/adapters/exec/interface.go
@@ -17,8 +17,9 @@
 package exec
 
 import (
-	"butler/pkg/adapters/exec/models"
 	"context"
+
+	"github.com/butlerdotdev/butler/pkg/adapters/exec/models"
 )
 
 // ExecAdapter defines an interface for executing system commands.

--- a/pkg/adapters/platforms/docker/adapter.go
+++ b/pkg/adapters/platforms/docker/adapter.go
@@ -17,8 +17,9 @@
 package docker
 
 import (
-	"butler/pkg/adapters/exec"
 	"context"
+
+	"github.com/butlerdotdev/butler/pkg/adapters/exec"
 	"go.uber.org/zap"
 )
 

--- a/pkg/adapters/platforms/docker/client.go
+++ b/pkg/adapters/platforms/docker/client.go
@@ -17,9 +17,10 @@
 package docker
 
 import (
-	"butler/pkg/adapters/exec"
 	"context"
 	"fmt"
+
+	"github.com/butlerdotdev/butler/pkg/adapters/exec"
 	"go.uber.org/zap"
 )
 

--- a/pkg/adapters/platforms/factory.go
+++ b/pkg/adapters/platforms/factory.go
@@ -16,13 +16,14 @@
 package platforms
 
 import (
-	"butler/pkg/adapters/exec"
-	"butler/pkg/adapters/platforms/docker"
-	"butler/pkg/adapters/platforms/flux"
-	"butler/pkg/adapters/platforms/helm"
-	"butler/pkg/adapters/platforms/kubectl"
-	"butler/pkg/adapters/platforms/talos"
 	"fmt"
+
+	"github.com/butlerdotdev/butler/pkg/adapters/exec"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/docker"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/flux"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/helm"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/kubectl"
+	"github.com/butlerdotdev/butler/pkg/adapters/platforms/talos"
 
 	"go.uber.org/zap"
 )

--- a/pkg/adapters/platforms/flux/adapter.go
+++ b/pkg/adapters/platforms/flux/adapter.go
@@ -15,8 +15,9 @@
 package flux
 
 import (
-	"butler/pkg/adapters/exec"
 	"context"
+
+	"github.com/butlerdotdev/butler/pkg/adapters/exec"
 	"go.uber.org/zap"
 )
 

--- a/pkg/adapters/platforms/flux/client.go
+++ b/pkg/adapters/platforms/flux/client.go
@@ -17,9 +17,10 @@
 package flux
 
 import (
-	"butler/pkg/adapters/exec"
 	"context"
 	"fmt"
+
+	"github.com/butlerdotdev/butler/pkg/adapters/exec"
 
 	"go.uber.org/zap"
 )

--- a/pkg/adapters/platforms/helm/adapter.go
+++ b/pkg/adapters/platforms/helm/adapter.go
@@ -17,8 +17,9 @@
 package helm
 
 import (
-	"butler/pkg/adapters/exec"
 	"context"
+
+	"github.com/butlerdotdev/butler/pkg/adapters/exec"
 
 	"go.uber.org/zap"
 )

--- a/pkg/adapters/platforms/helm/client.go
+++ b/pkg/adapters/platforms/helm/client.go
@@ -17,9 +17,10 @@
 package helm
 
 import (
-	"butler/pkg/adapters/exec"
 	"context"
 	"fmt"
+
+	"github.com/butlerdotdev/butler/pkg/adapters/exec"
 
 	"go.uber.org/zap"
 )

--- a/pkg/adapters/platforms/kubectl/adapter.go
+++ b/pkg/adapters/platforms/kubectl/adapter.go
@@ -15,8 +15,9 @@
 package kubectl
 
 import (
-	"butler/pkg/adapters/exec"
 	"context"
+
+	"github.com/butlerdotdev/butler/pkg/adapters/exec"
 	"go.uber.org/zap"
 )
 

--- a/pkg/adapters/platforms/kubectl/client.go
+++ b/pkg/adapters/platforms/kubectl/client.go
@@ -17,9 +17,10 @@
 package kubectl
 
 import (
-	"butler/pkg/adapters/exec"
 	"context"
 	"fmt"
+
+	"github.com/butlerdotdev/butler/pkg/adapters/exec"
 
 	"go.uber.org/zap"
 )

--- a/pkg/adapters/platforms/talos/adapter.go
+++ b/pkg/adapters/platforms/talos/adapter.go
@@ -17,8 +17,9 @@
 package talos
 
 import (
-	"butler/pkg/adapters/exec"
 	"context"
+
+	"github.com/butlerdotdev/butler/pkg/adapters/exec"
 	"go.uber.org/zap"
 )
 

--- a/pkg/adapters/platforms/talos/client.go
+++ b/pkg/adapters/platforms/talos/client.go
@@ -17,9 +17,10 @@
 package talos
 
 import (
-	"butler/pkg/adapters/exec"
 	"context"
 	"fmt"
+
+	"github.com/butlerdotdev/butler/pkg/adapters/exec"
 	"go.uber.org/zap"
 )
 

--- a/pkg/adapters/providers/factory.go
+++ b/pkg/adapters/providers/factory.go
@@ -1,10 +1,11 @@
 package providers
 
 import (
-	"butler/pkg/adapters/providers/nutanix"
-	"butler/pkg/adapters/providers/proxmox"
 	"context"
 	"errors"
+
+	"github.com/butlerdotdev/butler/pkg/adapters/providers/nutanix"
+	"github.com/butlerdotdev/butler/pkg/adapters/providers/proxmox"
 
 	"go.uber.org/zap"
 )

--- a/pkg/adapters/providers/interface.go
+++ b/pkg/adapters/providers/interface.go
@@ -1,6 +1,6 @@
 package providers
 
-import "butler/internal/models"
+import "github.com/butlerdotdev/butler/internal/models"
 
 // ProviderInterface defines required cloud provider operations.
 type ProviderInterface interface {

--- a/pkg/adapters/providers/nutanix/adapter.go
+++ b/pkg/adapters/providers/nutanix/adapter.go
@@ -17,12 +17,13 @@
 package nutanix
 
 import (
-	sharedModels "butler/internal/models"
-	"butler/pkg/adapters/providers/nutanix/models"
 	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
+
+	sharedModels "github.com/butlerdotdev/butler/internal/models"
+	"github.com/butlerdotdev/butler/pkg/adapters/providers/nutanix/models"
 
 	"go.uber.org/zap"
 )

--- a/pkg/adapters/providers/nutanix/utils.go
+++ b/pkg/adapters/providers/nutanix/utils.go
@@ -17,9 +17,10 @@
 package nutanix
 
 import (
-	sharedModels "butler/internal/models"
-	"butler/pkg/adapters/providers/nutanix/models"
 	"fmt"
+
+	sharedModels "github.com/butlerdotdev/butler/internal/models"
+	"github.com/butlerdotdev/butler/pkg/adapters/providers/nutanix/models"
 )
 
 // parseRAM converts "8GB" to MiB

--- a/pkg/adapters/providers/proxmox/adapter.go
+++ b/pkg/adapters/providers/proxmox/adapter.go
@@ -17,8 +17,6 @@
 package proxmox
 
 import (
-	sharedModels "butler/internal/models"
-	"butler/pkg/adapters/providers/proxmox/models"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -26,6 +24,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	sharedModels "github.com/butlerdotdev/butler/internal/models"
+	"github.com/butlerdotdev/butler/pkg/adapters/providers/proxmox/models"
 
 	"go.uber.org/zap"
 )

--- a/pkg/adapters/providers/proxmox/client.go
+++ b/pkg/adapters/providers/proxmox/client.go
@@ -17,7 +17,6 @@
 package proxmox
 
 import (
-	"butler/pkg/adapters/providers/proxmox/models"
 	"bytes"
 	"context"
 	"crypto/tls"
@@ -27,6 +26,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/butlerdotdev/butler/pkg/adapters/providers/proxmox/models"
 
 	"go.uber.org/zap"
 )


### PR DESCRIPTION
This PR updates the go.mod module path from module `butler` to module `github.com/butlerdotdev/butler` to ensure it:

- Follows Go module naming conventions (lowercase, canonical import path)

- Enables other projects (e.g., butler-nutanix-controller) to import shared packages from pkg/ cleanly

- Prevents future go mod and dependency resolution issues related to inconsistent or non-canonical module paths

- This change is required for cross-project reuse of adapters and interfaces.