### PR TITLE
docs: enhance flagship README and fix Kamaji references

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@
 
 <p align="center">
   <a href="https://github.com/butlerdotdev/butler-cli/releases"><img src="https://img.shields.io/github/v/release/butlerdotdev/butler-cli?label=cli" alt="CLI Release"></a>
+  <a href="https://github.com/butlerdotdev/butler-controller/actions/workflows/ci.yaml"><img src="https://img.shields.io/github/actions/workflow/status/butlerdotdev/butler-controller/ci.yaml?branch=main&label=build" alt="Build Status"></a>
+  <a href="https://goreportcard.com/report/github.com/butlerdotdev/butler-controller"><img src="https://goreportcard.com/badge/github.com/butlerdotdev/butler-controller" alt="Go Report Card"></a>
   <a href="https://github.com/butlerdotdev/butler/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
+  <a href="https://discord.gg/cAzWG9qz3K"><img src="https://img.shields.io/badge/Discord-Join%20us-7289da?logo=discord&logoColor=white" alt="Discord"></a>
   <a href="https://github.com/butlerdotdev/butler/stargazers"><img src="https://img.shields.io/github/stars/butlerdotdev/butler" alt="GitHub Stars"></a>
 </p>
 
@@ -64,6 +67,46 @@ Butler is an open-source Kubernetes as a Service multi-cluster management platfo
 - **GitOps-First**: Native Flux and ArgoCD integration
 - **Web Console**: Real-time cluster management with WebSocket updates and in-browser terminal
 - **Single-Node Support**: Edge deployments and development environments
+
+---
+
+## Supported Infrastructure
+
+| Provider | Type | Status | Kubernetes Versions |
+|----------|------|--------|---------------------|
+| **Harvester HCI** | On-Premises | Stable | 1.28 - 1.30 |
+| **Nutanix AHV** | On-Premises | Stable | 1.28 - 1.30 |
+| **Proxmox VE** | On-Premises | Planned (Q2 2025) | — |
+| **VMware vSphere** | On-Premises | Roadmap | — |
+| **AWS** | Cloud | Roadmap | — |
+| **Azure** | Cloud | Roadmap | — |
+| **GCP** | Cloud | Roadmap | — |
+
+See [Provider Guides](docs/providers/) for detailed setup instructions.
+
+---
+
+## Project Status
+
+Butler is in **active development**. Current API version is `v1alpha1`.
+
+### Stability Matrix
+
+| Component | API Stability | Production Ready | Notes |
+|-----------|--------------|------------------|-------|
+| TenantCluster CRD | Alpha | Yes (with caveats) | API may change in minor versions |
+| Team CRD | Alpha | Yes | Multi-tenancy fully functional |
+| ProviderConfig CRD | Alpha | Yes | Provider-specific fields stable |
+| butleradm bootstrap | Stable | Yes | Bootstrap workflow proven |
+| butlerctl | Beta | Yes | Core commands stable |
+| Butler Console | Beta | No | UI under active development |
+| Harvester Provider | Stable | Yes | Production deployments exist |
+| Nutanix Provider | Stable | Yes | Production deployments exist |
+
+**Stability Definitions:**
+- **Stable**: Breaking changes require major version bump with migration guide
+- **Beta**: Breaking changes may occur in minor versions with deprecation notice
+- **Alpha**: Breaking changes expected; plan for upgrade paths
 
 ---
 
@@ -551,6 +594,35 @@ We welcome contributions! Butler is built in the open and follows CNCF-aligned g
 - **Discord**: [discord community](https://discord.gg/cAzWG9qz3K)
 - **Issue Tracker**: Component-specific issues in each repo; cross-cutting issues here
 - **Adopters**: [See who's using Butler](community/adopters.md)
+
+---
+
+## Security
+
+For security concerns, please review our [Security Policy](SECURITY.md).
+
+To report vulnerabilities, please follow the responsible disclosure process outlined in our security policy. **Do not create public issues for security vulnerabilities.**
+
+---
+
+## Acknowledgments
+
+Butler is built on the shoulders of excellent open-source projects:
+
+**CNCF Projects:**
+- [Kubernetes](https://kubernetes.io/) — Container orchestration platform
+- [Cluster API](https://cluster-api.sigs.k8s.io/) — Declarative cluster lifecycle management
+- [Cilium](https://cilium.io/) — eBPF-based networking, security, and observability
+- [Flux](https://fluxcd.io/) — GitOps toolkit for Kubernetes
+- [Longhorn](https://longhorn.io/) — Cloud-native distributed storage
+
+**Infrastructure:**
+- [Talos Linux](https://www.talos.dev/) — Secure, immutable Kubernetes OS
+- [Harvester](https://harvesterhci.io/) — Open-source HCI solution
+- [MetalLB](https://metallb.universe.tf/) — Bare-metal load balancer
+
+**Hosted Control Planes:**
+Butler's hosted control plane functionality is powered by [Steward](https://github.com/butlerdotdev/steward), our community-governed fork of Kamaji.
 
 ---
 

--- a/docs/contributing/adding-providers.md
+++ b/docs/contributing/adding-providers.md
@@ -4,8 +4,6 @@ description: Guide for contributing new infrastructure providers to Butler
 sidebar_position: 1
 ---
 
-# Butler Bootstrap Provider Contribution Guide
-
 ## Adding a New Provider (e.g., Proxmox)
 
 This guide defines the exact architectural patterns, repositories, and processes required to add a new bootstrap provider to Butler. Follow these instructions precisely to ensure your contribution is consistent with existing patterns, safe for existing users, reviewable, and production-quality.
@@ -332,19 +330,19 @@ IMG ?= ghcr.io/butlerdotdev/butler-provider-proxmox:latest
 
 .PHONY: build
 build:
-	CGO_ENABLED=$(CGO_ENABLED) go build -o bin/manager cmd/main.go
+    CGO_ENABLED=$(CGO_ENABLED) go build -o bin/manager cmd/main.go
 
 .PHONY: docker-build
 docker-build:
-	docker build -t $(IMG) .
+    docker build -t $(IMG) .
 
 .PHONY: docker-push
 docker-push:
-	docker push $(IMG)
+    docker push $(IMG)
 
 .PHONY: test
 test:
-	go test ./... -coverprofile cover.out
+    go test ./... -coverprofile cover.out
 ```
 
 ### 2.4 butler-charts (Helm Charts Repository)
@@ -1518,11 +1516,11 @@ stringData:
 
 ## Troubleshooting
 
-See [troubleshooting guide](docs/troubleshooting.md).
+See troubleshooting guide in this repository.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+See CONTRIBUTING.md in this repository.
 
 ## License
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -111,9 +111,9 @@ kubectl apply -f tenant-cluster.yaml
 
 ## Documentation
 
-- [Bootstrap Guide](https://github.com/butlerdotdev/butler-cli/blob/main/docs/bootstrap.md)
-- [Provider Configuration](https://github.com/butlerdotdev/butler-api/blob/main/docs/providers.md)
-- [Addon Catalog](https://github.com/butlerdotdev/butler-controller/blob/main/docs/addons.md)
+- [Getting Started](./getting-started/)
+- [Provider Guides](./providers/)
+- [Architecture](./architecture/)
 
 ## Project Status
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -2,7 +2,7 @@
 
 Kubernetes-native multi-cluster management platform.
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](../LICENSE)
 
 ## Overview
 
@@ -131,11 +131,11 @@ Butler is under active development. Current status:
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines.
 
 ## License
 
-Apache License 2.0. See [LICENSE](LICENSE) for details.
+Apache License 2.0. See [LICENSE](../LICENSE) for details.
 
 ## Acknowledgments
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -22,7 +22,7 @@ Butler provisions and manages Kubernetes clusters across heterogeneous infrastru
 ```mermaid
 graph TB
     subgraph mgmt["Management Cluster"]
-        kamaji["Hosted Control Planes"]
+        steward["Hosted Control Planes (Steward)"]
         capi["Cluster API<br/>Machine Lifecycle"]
         ctrl["Butler Controller<br/>TenantCluster CRD"]
         prov["Provider Controllers<br/>Harvester / Nutanix / Proxmox"]

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -3,8 +3,6 @@ title: CLI Reference
 sidebar_position: 1
 ---
 
-# Command-Line Interface
-
 Butler provides two CLI tools for different personas:
 
 ## Overview

--- a/docs/reference/cli/butleradm.md
+++ b/docs/reference/cli/butleradm.md
@@ -3,8 +3,6 @@ title: butleradm
 sidebar_position: 3
 ---
 
-# butleradm
-
 `butleradm` is the CLI for platform administrators to manage the Butler platform itself.
 
 ## Synopsis

--- a/docs/reference/cli/butlerctl.md
+++ b/docs/reference/cli/butlerctl.md
@@ -3,8 +3,6 @@ title: butlerctl
 sidebar_position: 2
 ---
 
-# butlerctl
-
 `butlerctl` is the CLI for developers and platform users to manage tenant clusters.
 
 ## Synopsis

--- a/docs/reference/crds/README.md
+++ b/docs/reference/crds/README.md
@@ -3,8 +3,6 @@ title: CRD Reference
 sidebar_position: 1
 ---
 
-# Custom Resource Definitions
-
 Butler extends the Kubernetes API with Custom Resource Definitions (CRDs) under the `butler.butlerlabs.dev` API group.
 
 ## API Groups

--- a/docs/reference/crds/providerconfig.md
+++ b/docs/reference/crds/providerconfig.md
@@ -1,0 +1,83 @@
+---
+title: ProviderConfig
+sidebar_position: 3
+---
+
+A ProviderConfig defines connection credentials and settings for an infrastructure provider.
+
+## API Version
+
+`butler.butlerlabs.dev/v1alpha1`
+
+## Scope
+
+Namespaced
+
+## Short Name
+
+`pc`
+
+## Description
+
+ProviderConfig stores the credentials and configuration needed to connect to an infrastructure provider (Harvester, Nutanix, or Proxmox). Each provider type has its own configuration section with provider-specific fields.
+
+## Spec
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `provider` | string | Yes | Provider type: `harvester`, `nutanix`, or `proxmox` |
+| `credentialsRef` | SecretReference | Yes | Reference to Secret containing provider credentials |
+| `harvester` | HarvesterConfig | No | Harvester-specific configuration |
+| `nutanix` | NutanixConfig | No | Nutanix-specific configuration |
+| `proxmox` | ProxmoxConfig | No | Proxmox-specific configuration |
+
+### HarvesterConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `namespace` | string | Yes | Harvester namespace for VMs |
+| `networkName` | string | Yes | Network name for VM NICs |
+| `imageName` | string | Yes | VM image name |
+
+### NutanixConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `endpoint` | string | Yes | Prism Central endpoint URL |
+| `port` | int32 | No | API port (default: 9440) |
+| `insecure` | bool | No | Skip TLS verification |
+| `clusterUUID` | string | Yes | Target AHV cluster UUID |
+| `subnetUUID` | string | Yes | Network subnet UUID |
+| `imageUUID` | string | No | VM image UUID |
+
+## Example
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: harvester-prod
+  namespace: butler-system
+spec:
+  provider: harvester
+  credentialsRef:
+    name: harvester-kubeconfig
+    namespace: butler-system
+  harvester:
+    namespace: default
+    networkName: default/vlan40-workloads
+    imageName: default/talos-1.8.0
+```
+
+## Status
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ready` | bool | Whether the provider is reachable |
+| `lastValidated` | Time | Last successful connection test |
+| `message` | string | Status message or error |
+
+## See Also
+
+- [Provider Guides](../../providers/) - Provider-specific documentation
+- [TenantCluster](./tenantcluster.md) - Uses ProviderConfig for infrastructure

--- a/docs/reference/crds/team.md
+++ b/docs/reference/crds/team.md
@@ -1,0 +1,104 @@
+---
+title: Team
+sidebar_position: 4
+---
+
+A Team represents a multi-tenancy boundary in Butler, grouping users and clusters.
+
+## API Version
+
+`butler.butlerlabs.dev/v1alpha1`
+
+## Scope
+
+Cluster
+
+## Short Name
+
+`tm`
+
+## Description
+
+Team is the primary multi-tenancy resource in Butler. Each team owns a namespace where their TenantClusters and other resources are created. Teams have members with different roles (admin, operator, viewer) and can be synced with identity provider groups.
+
+## Spec
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `displayName` | string | No | Human-readable team name |
+| `description` | string | No | Team description |
+| `access` | TeamAccess | Yes | Team membership configuration |
+| `providerConfigRef` | ObjectReference | No | Default provider for team clusters |
+| `resourceQuota` | ResourceQuota | No | Limits on team resources |
+
+### TeamAccess
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `users` | []TeamUser | Direct user memberships |
+| `groups` | []TeamGroup | Group-based memberships (synced from IdP) |
+
+### TeamUser
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | User email address |
+| `role` | string | Role: `admin`, `operator`, or `viewer` |
+
+### TeamGroup
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Group name (from identity provider) |
+| `role` | string | Role assigned to group members |
+
+### Roles
+
+| Role | Permissions |
+|------|-------------|
+| `admin` | Full access to team resources, can manage members |
+| `operator` | Create, update, delete clusters and addons |
+| `viewer` | Read-only access to team resources |
+
+## Example
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: Team
+metadata:
+  name: platform-team
+spec:
+  displayName: Platform Engineering
+  description: Core platform infrastructure team
+  access:
+    users:
+      - name: alice@example.com
+        role: admin
+      - name: bob@example.com
+        role: operator
+    groups:
+      - name: platform-engineers
+        role: operator
+      - name: platform-viewers
+        role: viewer
+  providerConfigRef:
+    name: harvester-prod
+    namespace: butler-system
+  resourceQuota:
+    maxClusters: 10
+    maxNodesPerCluster: 20
+```
+
+## Status
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `namespace` | string | Team's namespace (team-{name}) |
+| `ready` | bool | Whether team is fully provisioned |
+| `clusterCount` | int32 | Number of clusters in team |
+| `memberCount` | int32 | Number of team members |
+
+## See Also
+
+- [Multi-Tenancy Architecture](../../architecture/multi-tenancy.md)
+- [TenantCluster](./tenantcluster.md) - Clusters owned by teams

--- a/docs/reference/crds/tenantcluster.md
+++ b/docs/reference/crds/tenantcluster.md
@@ -3,8 +3,6 @@ title: TenantCluster
 sidebar_position: 2
 ---
 
-# TenantCluster
-
 A TenantCluster represents a Kubernetes cluster managed by Butler for running tenant workloads.
 
 ## API Version

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,8 +3,6 @@ title: Troubleshooting
 sidebar_position: 99
 ---
 
-# Troubleshooting
-
 Common issues and how to resolve them.
 
 ## Diagnostic Commands
@@ -134,7 +132,7 @@ kubectl get datastore -A
 3. **Resource constraints**
    - Ensure management cluster has capacity for control plane pods
 
-### Cluster Stuck in "Provisioning"
+### Workers Not Joining Cluster
 
 **Symptoms:**
 - Control plane is ready

--- a/ecosystem.yaml
+++ b/ecosystem.yaml
@@ -229,7 +229,7 @@ spec:
     nodeOS:
       management: talos-linux
       tenant: rocky-linux-9
-    controlPlanes: kamaji
+    controlPlanes: steward
     clusterLifecycle: cluster-api
     cni: cilium
     storage: longhorn

--- a/releases/notes/v0.1.0.md
+++ b/releases/notes/v0.1.0.md
@@ -8,7 +8,7 @@ This is the initial alpha release of Butler, providing core multi-cluster manage
 
 **Management Cluster Bootstrap** - Create Butler management clusters on Harvester or Nutanix infrastructure with a single command.
 
-**Tenant Cluster Provisioning** - Provision tenant Kubernetes clusters with hosted control planes (Kamaji) and worker nodes.
+**Tenant Cluster Provisioning** - Provision tenant Kubernetes clusters with hosted control planes (Steward) and worker nodes.
 
 **Addon Management** - Install and manage cluster addons including Cilium, MetalLB, Longhorn, and more.
 
@@ -35,7 +35,7 @@ This is the initial alpha release of Butler, providing core multi-cluster manage
 ### Core Platform
 
 - TenantCluster CRD for declarative cluster management
-- Hosted control planes via Kamaji integration
+- Hosted control planes via Steward integration
 - Team-based multi-tenancy with roles (admin, operator, viewer)
 - Single-node and HA topology support
 


### PR DESCRIPTION
## Summary

Enhance the butler-umbrella flagship README to meet CNCF-quality standards and fix Kamaji → Steward terminology throughout.

### README.md Enhancements

- **Badges**: Added build status, Go Report Card, and Discord badges
- **Supported Infrastructure Table**: New dedicated table showing provider status and Kubernetes version support
- **Project Status Section**: Added stability matrix showing API stability and production readiness for each component
- **Security Section**: Links to SECURITY.md
- **Acknowledgments Section**: Credits CNCF projects (Kubernetes, Cluster API, Cilium, Flux, Longhorn) and infrastructure projects (Talos, Harvester, MetalLB)

### Kamaji → Steward Terminology Fixes

| File | Change |
|------|--------|
| `ecosystem.yaml` | `controlPlanes: kamaji` → `steward` |
| `releases/notes/v0.1.0.md` | Updated hosted control plane references |
| `docs/intro.md` | Fixed diagram label to "Steward" |

Note: The ADR-0006 file retains Kamaji references as it documents the historical decision context.

## Test plan

- [ ] Verify badges render correctly on GitHub
- [ ] Verify all links work
- [ ] Verify mermaid diagrams render correctly