### PR TITLE
fix: correct CLI installation commands in documentation

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -68,7 +68,16 @@ sudo mv butleradm butlerctl /usr/local/bin/
 ### Windows (Chocolatey)
 
 ```powershell
-choco install butler
+choco install butler-cli
+```
+
+### Windows (Direct Download)
+
+```powershell
+$arch = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "amd64" }
+Invoke-WebRequest -Uri "https://github.com/butlerdotdev/butler-cli/releases/latest/download/butler_windows_${arch}.tar.gz" -OutFile butler.tar.gz
+tar xzf butler.tar.gz
+Move-Item butleradm.exe, butlerctl.exe -Destination "$env:LOCALAPPDATA\Microsoft\WindowsApps\"
 ```
 
 ### Verify Installation

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -22,7 +22,7 @@ This separation follows the `kubectl`/`kubeadm` pattern, providing focused tools
 brew install butlerdotdev/tap/butler
 ```
 
-### Direct Download
+### Direct Download (macOS/Linux)
 
 ```bash
 # Detect OS and architecture
@@ -37,6 +37,21 @@ tar xzf butler_${OS}_${ARCH}.tar.gz
 
 # Install
 sudo mv butleradm butlerctl /usr/local/bin/
+```
+
+### Chocolatey (Windows)
+
+```powershell
+choco install butler-cli
+```
+
+### Direct Download (Windows)
+
+```powershell
+$arch = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "amd64" }
+Invoke-WebRequest -Uri "https://github.com/butlerdotdev/butler-cli/releases/latest/download/butler_windows_${arch}.tar.gz" -OutFile butler.tar.gz
+tar xzf butler.tar.gz
+Move-Item butleradm.exe, butlerctl.exe -Destination "$env:LOCALAPPDATA\Microsoft\WindowsApps\"
 ```
 
 ### Verify Installation


### PR DESCRIPTION
## Summary

- Fix Chocolatey package name: `choco install butler` -> `choco install butler-cli` (matching the published package on chocolatey.org)
- Add Windows direct download instructions with PowerShell for both Getting Started and CLI Reference docs
- Add platform labels (macOS/Linux vs Windows) to direct download sections

These docs auto-sync to butlerlabs-docs via daily CI.

## Test plan

- [ ] Verify no remaining `choco install butler` (without `-cli`) references
- [ ] Verify Windows PowerShell download commands are syntactically correct
- [ ] After butlerlabs-docs CI runs, verify synced docs reflect these changes