### PR TITLE
fix: resolve CI failures in link-check and markdown-lint

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -28,7 +28,6 @@ jobs:
           args: >-
             --verbose
             --no-progress
-            --exclude-mail
             --exclude "^https://github.com/butlerdotdev/butler-provider-proxmox"
             --exclude "^https://github.com/butlerdotdev/butler-controller"
             --exclude "^https://github.com/butlerdotdev/butler-provider-nutanix"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -14,5 +14,6 @@
   "MD036": false,
   "MD040": false,
   "MD041": false,
-  "MD042": false
+  "MD042": false,
+  "MD060": false
 }


### PR DESCRIPTION
## Summary

- Remove deprecated `--exclude-mail` flag from lychee link checker (removed in v0.21.0, mail exclusion is now default)
- Disable MD060 (table-column-style) rule in markdownlint config — flags separator rows using compact style alongside padded data rows

## Test plan

- [ ] Link Check workflow passes
- [ ] Markdown Lint workflow passes