### PR TITLE
docs: add IPAM networking, resource quotas, and cloud provider documentation

### DIFF
--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -44,6 +44,7 @@ This document provides the authoritative registry of all repositories in the But
 |-----------|------------|---------|------------|--------|
 | Homebrew Tap | [homebrew-tap](https://github.com/butlerdotdev/homebrew-tap) | macOS/Linux CLI installation | @core-maintainers | Stable |
 | Chocolatey | [chocolatey](https://community.chocolatey.org/packages/butler-cli) | Windows CLI installation | @core-maintainers | Stable |
+
 ---
 
 ## Status Definitions

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -145,6 +145,19 @@ Installs an addon on a cluster:
 
 [Detailed addon system](addon-system.md)
 
+### IP Address Management
+
+Allocates IP addresses to tenant clusters from shared pools:
+
+1. Platform admin creates NetworkPool with CIDR range
+2. ProviderConfig references pools via poolRefs
+3. TenantCluster provisioning creates IPAllocation (Pending)
+4. NetworkPool controller allocates IPs using best-fit algorithm
+5. TenantCluster configures MetalLB with allocated ranges
+6. On deletion, IPs are released back to the pool
+
+[Detailed networking architecture](networking.md)
+
 ---
 
 ## Detailed Documentation
@@ -155,7 +168,7 @@ Installs an addon on a cluster:
 | [Tenant Lifecycle](tenant-lifecycle.md) | Tenant cluster provisioning and management |
 | [Addon System](addon-system.md) | Addon catalog and installation |
 | [Multi-Tenancy](multi-tenancy.md) | Teams, RBAC, and isolation |
-| [Networking](networking.md) | Network architecture and configuration |
+| [Networking](networking.md) | Network architecture, IPAM, and IP allocation |
 | [Security Model](security-model.md) | Authentication, authorization, and secrets |
 
 ---

--- a/docs/architecture/networking.md
+++ b/docs/architecture/networking.md
@@ -31,43 +31,23 @@ Butler's networking subsystem provides automated IP address management for on-pr
 
 The subsystem consists of three CRDs and four cooperating controllers:
 
-```
-                    ┌──────────────────────────────────────────────────┐
-                    │              Management Cluster                  │
-                    │                                                  │
-                    │   ┌─────────────┐    ┌────────────────────────┐  │
-                    │   │ NetworkPool │    │ ProviderConfig         │  │
-                    │   │ 10.40.0.0/21│    │ mode: ipam             │  │
-                    │   │             │    │ poolRefs:              │  │
-                    │   │  Reserved:  │    │   - name: lab-pool     │  │
-                    │   │  .0-.10 mgmt│    │     priority: 0        │  │
-                    │   └──────┬──────┘    └────────────┬───────────┘  │
-                    │          │                        │              │
-                    │          ▼                        │              │
-                    │   ┌─────────────┐                │              │
-                    │   │ NetworkPool │◄───────────────┘              │
-                    │   │ Controller  │                               │
-                    │   │             │                               │
-                    │   │ Bitmap      │   ┌─────────────────────┐     │
-                    │   │ Allocator   │──▶│ IPAllocation         │     │
-                    │   └─────────────┘   │ phase: Allocated     │     │
-                    │                     │ start: 10.40.1.0     │     │
-                    │                     │ end:   10.40.1.7     │     │
-                    │                     └──────────┬──────────┘     │
-                    │                                │                │
-                    └────────────────────────────────┼────────────────┘
-                                                     │
-                                                     ▼
-                    ┌──────────────────────────────────────────────────┐
-                    │              Tenant Cluster                      │
-                    │                                                  │
-                    │   ┌──────────────────────────┐                  │
-                    │   │ MetalLB IPAddressPool     │                  │
-                    │   │ addresses:                │                  │
-                    │   │   - 10.40.1.0-10.40.1.7  │                  │
-                    │   └──────────────────────────┘                  │
-                    │                                                  │
-                    └──────────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    subgraph MC["Management Cluster"]
+        NP["NetworkPool\n10.40.0.0/21\nReserved: .0-.10 mgmt"]
+        PC["ProviderConfig\nmode: ipam\npoolRefs:\n  - lab-pool (priority: 0)"]
+        NPC["NetworkPool Controller\nBitmap Allocator"]
+        IPA["IPAllocation\nphase: Allocated\nstart: 10.40.1.0\nend: 10.40.1.7"]
+    end
+
+    subgraph TC["Tenant Cluster"]
+        MLBPool["MetalLB IPAddressPool\naddresses:\n  - 10.40.1.0-10.40.1.7"]
+    end
+
+    NP --> NPC
+    PC --> NPC
+    NPC --> IPA
+    IPA --> MLBPool
 ```
 
 Key design principles:

--- a/docs/architecture/networking.md
+++ b/docs/architecture/networking.md
@@ -1,0 +1,1151 @@
+# Networking Architecture
+
+This document describes Butler's networking subsystem, including IP Address Management (IPAM), network pool allocation, elastic scaling, and integration with MetalLB on tenant clusters.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Networking Modes](#networking-modes)
+- [CRD Resources](#crd-resources)
+  - [NetworkPool](#networkpool)
+  - [IPAllocation](#ipallocation)
+  - [ProviderConfig Network Configuration](#providerconfig-network-configuration)
+- [Controllers](#controllers)
+- [Allocation Flow](#allocation-flow)
+  - [Static IPAM](#static-ipam)
+  - [Elastic IPAM](#elastic-ipam)
+  - [Cloud Provider Bypass](#cloud-provider-bypass)
+- [Best-Fit Bitmap Allocator](#best-fit-bitmap-allocator)
+- [Cleanup and Garbage Collection](#cleanup-and-garbage-collection)
+- [Labels and Discovery](#labels-and-discovery)
+- [Quotas and Capacity Planning](#quotas-and-capacity-planning)
+- [Observability](#observability)
+- [Examples](#examples)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+Butler's networking subsystem provides automated IP address management for on-premises tenant clusters. When tenant clusters run on bare-metal or hyperconverged infrastructure (Harvester, Nutanix, Proxmox), there is no cloud provider to assign LoadBalancer IPs. Butler fills this gap with a CRD-driven IPAM system that allocates contiguous IP ranges from administrator-defined pools and configures MetalLB on each tenant cluster.
+
+The subsystem consists of three CRDs and four cooperating controllers:
+
+```
+                    ┌──────────────────────────────────────────────────┐
+                    │              Management Cluster                  │
+                    │                                                  │
+                    │   ┌─────────────┐    ┌────────────────────────┐  │
+                    │   │ NetworkPool │    │ ProviderConfig         │  │
+                    │   │ 10.40.0.0/21│    │ mode: ipam             │  │
+                    │   │             │    │ poolRefs:              │  │
+                    │   │  Reserved:  │    │   - name: lab-pool     │  │
+                    │   │  .0-.10 mgmt│    │     priority: 0        │  │
+                    │   └──────┬──────┘    └────────────┬───────────┘  │
+                    │          │                        │              │
+                    │          ▼                        │              │
+                    │   ┌─────────────┐                │              │
+                    │   │ NetworkPool │◄───────────────┘              │
+                    │   │ Controller  │                               │
+                    │   │             │                               │
+                    │   │ Bitmap      │   ┌─────────────────────┐     │
+                    │   │ Allocator   │──▶│ IPAllocation         │     │
+                    │   └─────────────┘   │ phase: Allocated     │     │
+                    │                     │ start: 10.40.1.0     │     │
+                    │                     │ end:   10.40.1.7     │     │
+                    │                     └──────────┬──────────┘     │
+                    │                                │                │
+                    └────────────────────────────────┼────────────────┘
+                                                     │
+                                                     ▼
+                    ┌──────────────────────────────────────────────────┐
+                    │              Tenant Cluster                      │
+                    │                                                  │
+                    │   ┌──────────────────────────┐                  │
+                    │   │ MetalLB IPAddressPool     │                  │
+                    │   │ addresses:                │                  │
+                    │   │   - 10.40.1.0-10.40.1.7  │                  │
+                    │   └──────────────────────────┘                  │
+                    │                                                  │
+                    └──────────────────────────────────────────────────┘
+```
+
+Key design principles:
+
+- **Single allocator**: The NetworkPool controller is the sole writer of IPAllocation status. This eliminates race conditions without distributed locking.
+- **Best-fit allocation**: The bitmap allocator selects the smallest free block that satisfies each request, reducing fragmentation over the pool's lifetime.
+- **Three-layer cleanup**: TenantCluster deletion, IPAllocation finalizers, and orphan garbage collection ensure IP addresses are always returned to the pool.
+- **Cloud-native bypass**: Cloud providers skip the entire IPAM subsystem. When `spec.network.mode` is `cloud`, the TenantCluster controller returns early and the cloud provider's native LoadBalancer handles IP assignment.
+
+---
+
+## Networking Modes
+
+Butler supports two networking modes, configured per ProviderConfig:
+
+| Mode | IPAM Active | MetalLB Installed | Use Case |
+|------|-------------|-------------------|----------|
+| `ipam` | Yes | Yes | On-premises: Harvester, Nutanix, Proxmox |
+| `cloud` | No | No | Cloud providers with native LoadBalancers |
+
+The mode is set on the ProviderConfig:
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: harvester-prod
+  namespace: butler-system
+spec:
+  provider: harvester
+  network:
+    mode: ipam  # or "cloud"
+```
+
+When mode is `cloud` (the default), the TenantCluster controller's `reconcileIPAllocation()` returns immediately with `(true, nil)`, and `isElasticIPAM()` returns `false`. No NetworkPool, IPAllocation, or MetalLB resources are created.
+
+---
+
+## CRD Resources
+
+### NetworkPool
+
+A **NetworkPool** defines a block of IP addresses available for allocation to tenant clusters. It is a namespaced resource (typically created in `butler-system`) that tracks capacity, fragmentation, and allocation count.
+
+**API Group**: `butler.butlerlabs.dev/v1alpha1`
+**Scope**: Namespaced
+**Short Name**: `np`
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: NetworkPool
+metadata:
+  name: lab-pool
+  namespace: butler-system
+spec:
+  # The full CIDR block owned by this pool
+  cidr: "10.40.0.0/21"
+
+  # Ranges excluded from tenant allocation (e.g., management cluster, gateways)
+  reserved:
+    - cidr: "10.40.0.0/28"
+      description: "Management cluster nodes and VIP"
+    - cidr: "10.40.0.16/28"
+      description: "Management cluster MetalLB pool"
+
+  # Optional: constrain tenant allocations to a subset of the CIDR
+  tenantAllocation:
+    start: "10.40.1.0"
+    end: "10.40.7.254"
+    defaults:
+      nodesPerTenant: 5    # Default node IPs per tenant (if IPAllocation.spec.count is unset)
+      lbPoolPerTenant: 8   # Default LB IPs per tenant (if IPAllocation.spec.count is unset)
+```
+
+#### NetworkPool Status
+
+The status is computed by the NetworkPool controller on every reconciliation cycle:
+
+```yaml
+status:
+  totalIPs: 1774          # Usable IPs (total minus reserved)
+  allocatedIPs: 48        # IPs assigned to active IPAllocations
+  availableIPs: 1726      # totalIPs - allocatedIPs
+  allocationCount: 6      # Number of active IPAllocations
+  fragmentationPercent: 12 # 0 = contiguous free space, 100 = maximally fragmented
+  largestFreeBlock: 1680  # Largest contiguous block available
+  observedGeneration: 2
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Ready
+      message: "1726/1774 IPs available (6 allocations)"
+```
+
+#### Spec Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `spec.cidr` | string | CIDR notation for the pool's address space (e.g., `10.40.0.0/21`) |
+| `spec.reserved[]` | array | Ranges excluded from allocation |
+| `spec.reserved[].cidr` | string | Reserved range in CIDR notation |
+| `spec.reserved[].description` | string | Human-readable reason for the reservation |
+| `spec.tenantAllocation` | object | Optional: constrains tenant allocations to a sub-range |
+| `spec.tenantAllocation.start` | string | First allocatable IP |
+| `spec.tenantAllocation.end` | string | Last allocatable IP |
+| `spec.tenantAllocation.defaults.nodesPerTenant` | int32 | Default node IP count per tenant (default: 5) |
+| `spec.tenantAllocation.defaults.lbPoolPerTenant` | int32 | Default LB IP count per tenant (default: 8) |
+
+#### Status Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status.totalIPs` | int32 | Total usable IPs (excludes reserved) |
+| `status.allocatedIPs` | int32 | IPs currently allocated |
+| `status.availableIPs` | int32 | IPs available for new allocations |
+| `status.allocationCount` | int32 | Number of active IPAllocations |
+| `status.fragmentationPercent` | int32 | Free space fragmentation (0-100) |
+| `status.largestFreeBlock` | int32 | Size of largest contiguous free block |
+| `status.conditions[]` | []Condition | Standard Kubernetes conditions |
+| `status.observedGeneration` | int64 | Last observed generation |
+
+### IPAllocation
+
+An **IPAllocation** represents a request for (and eventual assignment of) a contiguous block of IP addresses from a NetworkPool. It is created by the TenantCluster controller and fulfilled by the NetworkPool controller.
+
+**API Group**: `butler.butlerlabs.dev/v1alpha1`
+**Scope**: Namespaced
+**Short Name**: `ipa`
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: IPAllocation
+metadata:
+  name: team-platform-prod-cluster-lb
+  namespace: butler-system
+  labels:
+    butler.butlerlabs.dev/team: team-platform
+    butler.butlerlabs.dev/tenant: prod-cluster
+    butler.butlerlabs.dev/network-pool: lab-pool
+    butler.butlerlabs.dev/allocation-type: loadbalancer
+spec:
+  poolRef:
+    name: lab-pool
+  tenantClusterRef:
+    name: prod-cluster
+    namespace: team-platform
+  type: loadbalancer    # "nodes" or "loadbalancer"
+  count: 8              # Optional; defaults to pool's tenantAllocation.defaults
+```
+
+#### IPAllocation with Pinned Range
+
+For cases where a specific IP range is required (for example, to preserve stable addresses across recreation):
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: IPAllocation
+metadata:
+  name: team-platform-prod-cluster-lb
+  namespace: butler-system
+spec:
+  poolRef:
+    name: lab-pool
+  tenantClusterRef:
+    name: prod-cluster
+    namespace: team-platform
+  type: loadbalancer
+  pinnedRange:
+    startAddress: "10.40.2.0"
+    endAddress: "10.40.2.7"
+```
+
+#### IPAllocation Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending: IPAllocation created
+    Pending --> Allocated: NetworkPool controller fulfills
+    Pending --> Failed: Pool exhausted / conflict
+
+    Allocated --> Released: Deletion initiated
+    Released --> [*]: Finalizer removed
+
+    Failed --> Pending: Retry (event-driven)
+    Failed --> Released: Deletion initiated
+```
+
+| Phase | Description |
+|-------|-------------|
+| `Pending` | Created by TenantCluster controller, awaiting fulfillment |
+| `Allocated` | NetworkPool controller assigned an IP range |
+| `Failed` | Allocation could not be fulfilled (pool exhausted, conflict) |
+| `Released` | Deletion in progress; audit timestamp recorded |
+
+#### Spec Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `spec.poolRef` | LocalObjectReference | Name of the NetworkPool to allocate from |
+| `spec.tenantClusterRef` | NamespacedObjectReference | The TenantCluster this allocation serves |
+| `spec.type` | string | `nodes` or `loadbalancer` |
+| `spec.count` | *int32 | Number of IPs requested (min: 1, optional) |
+| `spec.pinnedRange` | object | Request a specific range instead of best-fit |
+| `spec.pinnedRange.startAddress` | string | First IP of the pinned range |
+| `spec.pinnedRange.endAddress` | string | Last IP of the pinned range |
+
+#### Status Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status.phase` | string | Current lifecycle phase |
+| `status.cidr` | string | Allocated range in CIDR or `start-end` format |
+| `status.startAddress` | string | First IP in the allocated range |
+| `status.endAddress` | string | Last IP in the allocated range |
+| `status.addresses[]` | []string | All individual IPs in the allocated range |
+| `status.allocatedCount` | int32 | Number of IPs allocated |
+| `status.allocatedAt` | *Time | Timestamp of allocation |
+| `status.allocatedBy` | string | Controller that performed the allocation |
+| `status.releasedAt` | *Time | Timestamp of release (audit trail) |
+| `status.conditions[]` | []Condition | Standard Kubernetes conditions |
+
+### ProviderConfig Network Configuration
+
+The ProviderConfig's `spec.network` section configures IPAM behavior for all tenant clusters using that provider.
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: harvester-prod
+  namespace: butler-system
+spec:
+  provider: harvester
+  credentialsRef:
+    name: harvester-kubeconfig
+
+  network:
+    # Networking mode: "ipam" for Butler-managed, "cloud" for provider-native
+    mode: ipam
+
+    # Ordered list of NetworkPools (lower priority = tried first)
+    poolRefs:
+      - name: lab-pool-primary
+        priority: 0
+      - name: lab-pool-secondary
+        priority: 10
+
+    # Layer 2/3 network settings for provisioned VMs
+    subnet: "10.40.0.0/21"
+    gateway: "10.40.0.1"
+    dnsServers:
+      - "10.40.0.2"
+      - "10.40.0.3"
+
+    # LoadBalancer allocation configuration
+    loadBalancer:
+      defaultPoolSize: 8         # Static mode: IPs per tenant (default: 8)
+      allocationMode: static     # "static" or "elastic" (default: static)
+      initialPoolSize: 2         # Elastic mode: starting IPs (default: 2)
+      growthIncrement: 2         # Elastic mode: IPs added per growth event (default: 2)
+
+    # Per-tenant IP limits
+    quotaPerTenant:
+      maxNodeIPs: 20
+      maxLoadBalancerIPs: 32
+```
+
+#### Network Field Reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | string | `cloud` | `ipam` for Butler-managed IPAM, `cloud` for provider-native |
+| `poolRefs[]` | array | - | Ordered list of NetworkPool references |
+| `poolRefs[].name` | string | - | NetworkPool name |
+| `poolRefs[].priority` | int32 | 0 | Lower value = higher priority |
+| `subnet` | string | - | Network subnet for VM provisioning |
+| `gateway` | string | - | Default gateway |
+| `dnsServers[]` | []string | - | DNS server addresses |
+| `loadBalancer.defaultPoolSize` | int32 | 8 | IPs allocated per tenant in static mode |
+| `loadBalancer.allocationMode` | string | `static` | `static` (fixed) or `elastic` (auto-scaling) |
+| `loadBalancer.initialPoolSize` | int32 | 2 | Starting IPs per tenant in elastic mode |
+| `loadBalancer.growthIncrement` | int32 | 2 | IPs added per elastic growth event |
+| `quotaPerTenant.maxNodeIPs` | *int32 | - | Maximum node IPs per tenant (unset = unlimited) |
+| `quotaPerTenant.maxLoadBalancerIPs` | *int32 | - | Maximum LB IPs per tenant (unset = unlimited) |
+
+---
+
+## Controllers
+
+Four controllers cooperate to manage IP allocation:
+
+| Controller | Package | Responsibility |
+|------------|---------|----------------|
+| **NetworkPool** | `internal/controller/networkpool/` | Sole allocator. Processes Pending IPAllocations using best-fit bitmap. Computes pool status. Runs orphan GC. |
+| **IPAllocation** | `internal/controller/ipallocation/` | Thin lifecycle. Adds finalizer, sets initial Pending phase. On deletion: sets Released phase with timestamp, removes finalizer. |
+| **TenantCluster** | `internal/controller/tenantcluster/` | Creates IPAllocations during provisioning. Runs elastic IPAM on Ready clusters. Cleans up allocations on deletion. |
+| **ProviderConfig** | `internal/controller/providerconfig/` | Validates pool availability for IPAM mode. Estimates tenant capacity from available IPs. |
+
+### Controller Interaction
+
+```mermaid
+flowchart TB
+    subgraph TC["TenantCluster Controller"]
+        TC1["reconcileIPAllocation()"]
+        TC2["reconcileElasticIPAM()"]
+        TC3["cleanupIPAllocations()"]
+    end
+
+    subgraph IPA["IPAllocation Controller"]
+        IPA1["Add finalizer"]
+        IPA2["Set Pending phase"]
+        IPA3["On delete: Released + remove finalizer"]
+    end
+
+    subgraph NP["NetworkPool Controller"]
+        NP1["processPendingAllocations()"]
+        NP2["Best-fit bitmap allocator"]
+        NP3["updatePoolStatus()"]
+        NP4["gcOrphanedAllocations()"]
+    end
+
+    TC1 -->|"creates"| IPAllocation["IPAllocation CR"]
+    IPAllocation -->|"triggers"| IPA1
+    IPA1 --> IPA2
+
+    IPAllocation -->|"triggers via watch"| NP1
+    NP1 --> NP2
+    NP2 -->|"updates status"| IPAllocation
+
+    NP1 --> NP3
+    NP4 -->|"deletes orphans"| IPAllocation
+
+    TC3 -->|"deletes on TC deletion"| IPAllocation
+    IPA3 -->|"on deletion"| IPAllocation
+```
+
+### Reconciliation Intervals
+
+| Controller | Normal Requeue | Special Cases |
+|------------|---------------|---------------|
+| NetworkPool | 60 seconds | 5 seconds after processing pending allocations or GC |
+| IPAllocation (Pending) | 15 seconds | Backstop; primary fulfillment is event-driven |
+| IPAllocation (Failed) | 30 seconds | Backstop retry |
+| IPAllocation (Allocated) | 5 minutes | Health check |
+| TenantCluster (non-Ready) | 30 seconds | - |
+| TenantCluster (Ready, < 1h old) | 1 minute | Elastic IPAM runs on each reconcile |
+| TenantCluster (Ready, 1-24h old) | 5 minutes | - |
+| TenantCluster (Ready, > 24h old) | 15 minutes | - |
+
+---
+
+## Allocation Flow
+
+### Static IPAM
+
+Static IPAM allocates a fixed number of LoadBalancer IPs when a TenantCluster is created. The allocation size does not change for the lifetime of the cluster.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant API as K8s API
+    participant TC as TenantCluster Controller
+    participant IPA as IPAllocation Controller
+    participant NP as NetworkPool Controller
+    participant Tenant as Tenant Cluster (MetalLB)
+
+    User->>API: Create TenantCluster
+    API->>TC: Reconcile event
+
+    rect rgb(230, 245, 255)
+        Note over TC,NP: IP Allocation
+        TC->>TC: reconcileIPAllocation()
+        TC->>TC: getInitialLBPoolSize()<br/>TC override > provider defaultPoolSize > fallback 8
+        TC->>TC: Enforce quotaPerTenant.maxLoadBalancerIPs
+        loop Try each pool in priority order
+            TC->>API: Get NetworkPool status
+            alt Pool has sufficient capacity
+                TC->>API: Create IPAllocation (Pending)<br/>with labels: team, tenant, pool, type
+                Note over TC: Break loop
+            else Pool exhausted
+                Note over TC: Try next pool
+            end
+        end
+    end
+
+    rect rgb(255, 245, 230)
+        Note over IPA,NP: Fulfillment
+        API->>IPA: IPAllocation created
+        IPA->>API: Add finalizer, set Pending phase
+
+        API->>NP: Watch triggers reconcile
+        NP->>NP: Build bitmap from pool state
+        NP->>NP: Sort pending allocations by creation time (FIFO)
+        NP->>NP: Best-fit: find smallest free block >= requested size
+        NP->>API: Update IPAllocation status<br/>phase: Allocated, startAddress, endAddress, addresses[]
+    end
+
+    rect rgb(230, 255, 230)
+        Note over TC,Tenant: MetalLB Configuration
+        API->>TC: Reconcile (IPAllocation now Allocated)
+        TC->>TC: reconcileIPAllocation() returns (true, nil)
+        TC->>Tenant: Install MetalLB with IPAddressPool<br/>addresses: ["10.40.1.0-10.40.1.7"]
+    end
+```
+
+**Step-by-step**:
+
+1. A TenantCluster CR is created. The TenantCluster controller calls `reconcileIPAllocation()`.
+2. The controller checks `ProviderConfig.spec.network.mode`. If not `ipam`, it returns immediately.
+3. `getInitialLBPoolSize()` determines the allocation size using this precedence:
+   - TenantCluster `spec.networking.lbPoolSize` override
+   - ProviderConfig `spec.network.loadBalancer.defaultPoolSize`
+   - Fallback: 8
+4. The count is clamped to `quotaPerTenant.maxLoadBalancerIPs` if set.
+5. The controller iterates through `spec.network.poolRefs` in priority order (lower value = higher priority).
+6. For each pool, it checks `pool.status.availableIPs >= lbCount`. On the first pool with capacity, it creates an IPAllocation with standard labels.
+7. The IPAllocation controller adds a finalizer and sets the phase to `Pending`.
+8. The IPAllocation creation triggers the NetworkPool controller via a watch. The NetworkPool controller builds a bitmap, sorts pending allocations by creation timestamp (FIFO), and runs the best-fit allocator.
+9. On success, the IPAllocation status is updated with the allocated range. On failure (pool exhausted), the phase is set to `Failed`.
+10. On the next TenantCluster reconcile, `reconcileIPAllocation()` sees the Allocated phase and returns `(true, nil)`. The controller then installs MetalLB on the tenant cluster with the allocated address range.
+
+### Elastic IPAM
+
+Elastic IPAM starts with a small initial allocation and automatically grows or shrinks based on actual LoadBalancer usage on the tenant cluster.
+
+```mermaid
+flowchart TB
+    subgraph Init["Initial Allocation"]
+        A1["TenantCluster created"]
+        A2["Allocate initialPoolSize IPs<br/>(default: 2)"]
+        A3["Install MetalLB with initial range"]
+    end
+
+    subgraph Monitor["Reconcile Loop (Ready clusters)"]
+        B1["reconcileElasticIPAM()"]
+        B2["Count used LB Services<br/>on tenant cluster"]
+        B3{"availableIPs < 1?"}
+        B4{"Under quota?"}
+        B5["Create growth allocation<br/>{ns}-{name}-lb-{N}<br/>size: growthIncrement"]
+        B6{"len(allocs) > 1 AND<br/>availableIPs > growthIncrement AND<br/>newest alloc age > 10min?"}
+        B7["Delete newest unused allocation"]
+        B8["updateMetalLBPool()<br/>Collect all allocated ranges<br/>Update MetalLB spec.addresses[]"]
+    end
+
+    A1 --> A2
+    A2 --> A3
+    A3 --> B1
+    B1 --> B2
+    B2 --> B3
+    B3 -->|Yes| B4
+    B3 -->|No| B6
+    B4 -->|Yes| B5
+    B4 -->|No, blocked| B6
+    B5 --> B8
+    B6 -->|Yes| B7
+    B6 -->|No| B8
+    B7 --> B8
+```
+
+**Configuration**:
+
+```yaml
+spec:
+  network:
+    mode: ipam
+    loadBalancer:
+      allocationMode: elastic
+      initialPoolSize: 2       # Start with 2 IPs
+      growthIncrement: 2       # Add 2 IPs each growth event
+    quotaPerTenant:
+      maxLoadBalancerIPs: 32   # Hard cap
+```
+
+**Growth logic** (runs on every Ready cluster reconcile):
+
+1. `reconcileElasticIPAM()` lists all LB IPAllocations for the tenant cluster.
+2. It connects to the tenant cluster and counts LoadBalancer Services with assigned IPs.
+3. `availableIPs = totalAllocated - usedIPs`.
+4. If `availableIPs < 1`:
+   - Check quota: `totalAllocated + growthIncrement <= maxLoadBalancerIPs`.
+   - Find a pool with `availableIPs >= growthIncrement`.
+   - Create a new IPAllocation named `{namespace}-{name}-lb-{N}` (where N is the allocation index).
+5. The NetworkPool controller fulfills the new allocation. On the next reconcile, `updateMetalLBPool()` collects all allocated ranges and updates the MetalLB `IPAddressPool.spec.addresses[]` with multiple ranges.
+
+**Shrink logic** (runs in the same reconcile):
+
+1. If `len(allocs) > 1` (at least one growth allocation exists) AND `availableIPs > growthIncrement`:
+   - Find the newest allocation (by index, skipping index 0, the initial allocation).
+   - Check that it is `Allocated` and older than 10 minutes (cooldown to prevent thrashing).
+   - Delete it.
+2. `updateMetalLBPool()` updates MetalLB to reflect the reduced address set.
+
+**MetalLB multi-range support**: When elastic IPAM produces multiple allocations, the tenant cluster's MetalLB `IPAddressPool` contains multiple entries:
+
+```yaml
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: butler-lb-pool
+  namespace: metallb-system
+spec:
+  addresses:
+    - "10.40.1.0-10.40.1.1"    # Initial allocation
+    - "10.40.1.8-10.40.1.9"    # Growth allocation 1
+    - "10.40.2.4-10.40.2.5"    # Growth allocation 2
+```
+
+### Cloud Provider Bypass
+
+When a ProviderConfig uses `mode: cloud` (the default), the entire IPAM subsystem is bypassed:
+
+- `reconcileIPAllocation()` returns `(true, nil)` immediately.
+- `isElasticIPAM()` returns `false`.
+- No NetworkPool, IPAllocation, or MetalLB resources are created.
+- The cloud provider's native LoadBalancer implementation handles IP assignment.
+
+This means cloud-hosted Butler deployments (AWS, Azure, GCP) use the cloud's existing LoadBalancer controllers with no additional configuration.
+
+---
+
+## Best-Fit Bitmap Allocator
+
+The allocator lives in `internal/ipam/allocator.go` and is a pure-function library with no Kubernetes dependencies. The NetworkPool controller is the sole caller.
+
+### How It Works
+
+1. **BuildBitmap**: Creates a boolean array representing the allocatable IP range. Each element corresponds to one IP address. `true` = used (reserved or allocated), `false` = free.
+
+2. **findFreeBlocks**: Scans the bitmap linearly to find all contiguous runs of `false` values. Returns a list of `FreeBlock{StartOffset, EndOffset, Size}`.
+
+3. **AllocateRange** (best-fit): Iterates through free blocks and selects the smallest block that can satisfy the requested count. Allocates from the start of the selected block.
+
+4. **AllocatePinnedRange**: Validates that the requested start-end range falls within the allocatable range, then checks every bit in the bitmap to confirm no overlap with reserved or existing allocations.
+
+5. **ComputeFragmentation**: Calculates `1 - (largestFreeBlock / totalFreeIPs)` as a percentage. A single contiguous free block yields 0% fragmentation. Many small scattered blocks approach 100%.
+
+### Why Best-Fit
+
+Best-fit allocation minimizes fragmentation over time compared to first-fit or next-fit strategies. By selecting the tightest-fitting free block, it preserves larger contiguous blocks for future allocations that may need them. This is important for long-lived pools where clusters are created and deleted repeatedly.
+
+### Constraints
+
+- **IPv4 only**: The allocator uses `uint32` arithmetic for IP addresses.
+- **Maximum pool size**: 1,048,576 IPs (~1M, a /12 CIDR). Pools larger than this are rejected to prevent excessive memory usage.
+- **Maximum enumeration**: `EnumerateIPs()` caps at 65,536 IPs per range to avoid generating oversized `status.addresses[]` arrays.
+
+### Data Structures
+
+```go
+// PoolState decouples the allocator from Kubernetes types.
+type PoolState struct {
+    AllocatableStart string          // First IP available for allocation
+    AllocatableEnd   string          // Last IP available for allocation
+    ReservedCIDRs    []string        // CIDRs excluded from allocation
+    ExistingAllocs   []AllocatedRange // Currently allocated ranges
+}
+
+// AllocationResult contains the result of a successful allocation.
+type AllocationResult struct {
+    Start     string   // First IP in allocated range
+    End       string   // Last IP in allocated range
+    CIDR      string   // CIDR notation if power-of-2 aligned, otherwise "start-end"
+    Addresses []string // All individual IPs
+    Count     int32    // Number of IPs allocated
+}
+```
+
+### CIDR Formatting
+
+The allocator formats the result as CIDR notation when the allocated range is power-of-2 aligned (e.g., `10.40.1.0/29` for 8 IPs starting at a /29 boundary). Otherwise, it uses `start-end` format (e.g., `10.40.1.3-10.40.1.10`). This affects `status.cidr` on the IPAllocation but does not change the allocated addresses.
+
+---
+
+## Cleanup and Garbage Collection
+
+Butler uses a three-layer cleanup strategy to ensure IP addresses are always returned to the pool, even under failure conditions.
+
+```mermaid
+flowchart TB
+    subgraph L1["Layer 1: TenantCluster Deletion"]
+        L1A["handleDeletion()"]
+        L1B["cleanupIPAllocations()"]
+        L1C["Delete by status refs<br/>(LBAllocationRef, IPAllocationRef)"]
+        L1D["Delete by labels<br/>(team + tenant)"]
+    end
+
+    subgraph L2["Layer 2: IPAllocation Finalizer"]
+        L2A["DeletionTimestamp set"]
+        L2B["Set phase: Released"]
+        L2C["Record releasedAt timestamp"]
+        L2D["Remove finalizer"]
+        L2E["IPAllocation deleted from etcd"]
+    end
+
+    subgraph L3["Layer 3: NetworkPool Orphan GC"]
+        L3A["Every 60 seconds"]
+        L3B["For each Allocated IPAllocation"]
+        L3C["GET tenantClusterRef"]
+        L3D{"TenantCluster exists?"}
+        L3E["Delete orphaned IPAllocation"]
+        L3F["Keep allocation"]
+    end
+
+    L1A --> L1B
+    L1B --> L1C
+    L1C --> L1D
+    L1D -->|"triggers"| L2A
+
+    L2A --> L2B
+    L2B --> L2C
+    L2C --> L2D
+    L2D --> L2E
+
+    L3A --> L3B
+    L3B --> L3C
+    L3C --> L3D
+    L3D -->|"404 Not Found"| L3E
+    L3D -->|"exists"| L3F
+```
+
+### Layer 1: TenantCluster Deletion
+
+When a TenantCluster is deleted, `handleDeletion()` calls `cleanupIPAllocations()`. This uses two strategies to find all associated allocations:
+
+1. **Status references**: Deletes the IPAllocations pointed to by `tc.Status.LBAllocationRef` and `tc.Status.IPAllocationRef`. This catches the primary allocation.
+
+2. **Label-based discovery**: Lists all IPAllocations in `butler-system` matching `butler.butlerlabs.dev/team={namespace}` and `butler.butlerlabs.dev/tenant={name}`. This catches elastic growth allocations that are not tracked in the TenantCluster status.
+
+A deduplication map prevents double-deletion of allocations found by both methods.
+
+### Layer 2: IPAllocation Finalizer
+
+Every IPAllocation has a finalizer (`butler.butlerlabs.dev/ipallocation`). When deletion is initiated:
+
+1. The IPAllocation controller detects `DeletionTimestamp` is set.
+2. It records the current time as `status.releasedAt` for audit purposes.
+3. It sets the phase to `Released`.
+4. It removes the finalizer, allowing Kubernetes to complete the deletion.
+
+The `releasedAt` timestamp creates an audit trail: you can see when an IP range was released even after the allocation object is gone (if you capture the Released status update in logs or events).
+
+### Layer 3: NetworkPool Orphan GC
+
+The NetworkPool controller runs orphan garbage collection on every reconcile cycle (every 60 seconds). For each `Allocated` IPAllocation referencing this pool:
+
+1. It reads `spec.tenantClusterRef.{name, namespace}`.
+2. It attempts to GET the referenced TenantCluster.
+3. If the TenantCluster returns 404 (Not Found), the allocation is orphaned and is deleted.
+
+This is a safety net for edge cases where:
+- The TenantCluster was force-deleted (finalizer removed manually).
+- The TenantCluster's namespace was deleted before cleanup could run.
+- A bug in the TenantCluster controller skipped `cleanupIPAllocations()`.
+
+:::tip
+Orphan GC only processes `Allocated` IPAllocations. Pending and Failed allocations are transient states handled by the normal allocation flow.
+:::
+
+---
+
+## Labels and Discovery
+
+All IPAllocations are labeled for efficient querying and cleanup:
+
+| Label | Value | Purpose |
+|-------|-------|---------|
+| `butler.butlerlabs.dev/team` | Team namespace (e.g., `team-platform`) | Filter allocations by team |
+| `butler.butlerlabs.dev/tenant` | TenantCluster name (e.g., `prod-cluster`) | Filter allocations by cluster |
+| `butler.butlerlabs.dev/network-pool` | NetworkPool name (e.g., `lab-pool`) | Track which pool an allocation came from |
+| `butler.butlerlabs.dev/allocation-type` | `loadbalancer` or `nodes` | Distinguish allocation purpose |
+
+The NetworkPool controller uses a field indexer on `spec.poolRef.name` for efficient listing of all IPAllocations referencing a given pool. This avoids full-list scans on every reconciliation.
+
+---
+
+## Quotas and Capacity Planning
+
+### Per-Tenant Quotas
+
+ProviderConfig enforces per-tenant IP limits:
+
+```yaml
+spec:
+  network:
+    quotaPerTenant:
+      maxNodeIPs: 20
+      maxLoadBalancerIPs: 32
+```
+
+Quota enforcement points:
+
+1. **Initial allocation**: `reconcileIPAllocation()` clamps the requested count to `maxLoadBalancerIPs`.
+2. **Elastic growth**: `reconcileElasticIPAM()` checks `totalAllocated + growthIncrement <= maxLoadBalancerIPs` before creating a growth allocation.
+
+If the quota is reached, the controller logs a message and skips the growth. The cluster continues to operate with its current allocation.
+
+### Pool Capacity Estimation
+
+The ProviderConfig controller estimates how many tenant clusters a provider can support:
+
+```
+estimatedTenants = availableIPs / (nodesPerTenant + lbPerTenant)
+```
+
+This is exposed as the `butler_provider_config_estimated_tenants` Prometheus metric and in the ProviderConfig status, enabling capacity planning dashboards.
+
+### Pool Capacity Events
+
+The NetworkPool controller emits Kubernetes events at utilization thresholds:
+
+| Utilization | Event Type | Event Reason |
+|-------------|------------|--------------|
+| >= 80% | Warning | `PoolCapacityWarning` |
+| >= 90% | Warning | `PoolCapacityDanger` |
+| 100% | Warning | `PoolExhausted` |
+
+Monitor these events to trigger capacity expansion before pools are fully consumed:
+
+```bash
+kubectl get events -n butler-system --field-selector reason=PoolCapacityWarning
+```
+
+---
+
+## Observability
+
+### Prometheus Metrics
+
+The NetworkPool controller exports the following metrics:
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `butler_network_pool_total_ips` | Gauge | `pool`, `namespace` | Total usable IPs (excludes reserved) |
+| `butler_network_pool_allocated_ips` | Gauge | `pool`, `namespace` | Currently allocated IPs |
+| `butler_network_pool_available_ips` | Gauge | `pool`, `namespace` | Available IPs |
+| `butler_network_pool_allocation_count` | Gauge | `pool`, `namespace` | Number of active IPAllocations |
+| `butler_network_pool_fragmentation_percent` | Gauge | `pool`, `namespace` | Free space fragmentation (0-100) |
+| `butler_network_pool_largest_free_block` | Gauge | `pool`, `namespace` | Largest contiguous free block |
+| `butler_ip_allocation_processed_total` | Counter | `pool`, `namespace`, `result` | Total allocations processed (`success` or `failed`) |
+
+### Example Alerting Rules
+
+```yaml
+groups:
+  - name: butler-ipam
+    rules:
+      - alert: NetworkPoolNearExhaustion
+        expr: |
+          butler_network_pool_available_ips / butler_network_pool_total_ips < 0.1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "NetworkPool {{ $labels.pool }} is over 90% utilized"
+          description: >
+            Pool {{ $labels.pool }} in namespace {{ $labels.namespace }} has
+            {{ $value | humanizePercentage }} capacity remaining.
+
+      - alert: NetworkPoolExhausted
+        expr: butler_network_pool_available_ips == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "NetworkPool {{ $labels.pool }} is fully exhausted"
+          description: >
+            No IPs available in pool {{ $labels.pool }}. New tenant clusters
+            cannot receive LoadBalancer allocations until capacity is freed.
+
+      - alert: NetworkPoolHighFragmentation
+        expr: butler_network_pool_fragmentation_percent > 50
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "NetworkPool {{ $labels.pool }} has high fragmentation"
+          description: >
+            Pool fragmentation is {{ $value }}%. The largest contiguous free block
+            is {{ with printf "butler_network_pool_largest_free_block{pool='%s'}" $labels.pool | query }}{{ . | first | value }}{{ end }} IPs.
+```
+
+### Useful kubectl Commands
+
+```bash
+# View all pools and their capacity
+kubectl get networkpool -n butler-system
+
+# View allocations for a specific tenant cluster
+kubectl get ipallocation -n butler-system \
+  -l butler.butlerlabs.dev/tenant=my-cluster
+
+# View allocation details
+kubectl get ipallocation -n butler-system my-allocation -o yaml
+
+# Check which pools a provider uses
+kubectl get providerconfig harvester-prod -n butler-system \
+  -o jsonpath='{.spec.network.poolRefs[*].name}'
+
+# View pool events (capacity warnings, allocations, GC)
+kubectl get events -n butler-system \
+  --field-selector involvedObject.kind=NetworkPool
+```
+
+---
+
+## Examples
+
+### Single Pool, Static IPAM
+
+A simple setup with one pool and static allocation for an on-premises Harvester environment.
+
+```yaml
+---
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: NetworkPool
+metadata:
+  name: lab-pool
+  namespace: butler-system
+spec:
+  cidr: "10.40.0.0/22"
+  reserved:
+    - cidr: "10.40.0.0/28"
+      description: "Management cluster control plane and VIP"
+    - cidr: "10.40.0.16/28"
+      description: "Management cluster MetalLB pool"
+  tenantAllocation:
+    start: "10.40.1.0"
+    end: "10.40.3.254"
+    defaults:
+      nodesPerTenant: 5
+      lbPoolPerTenant: 8
+---
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: harvester-lab
+  namespace: butler-system
+spec:
+  provider: harvester
+  credentialsRef:
+    name: harvester-kubeconfig
+  network:
+    mode: ipam
+    poolRefs:
+      - name: lab-pool
+        priority: 0
+    subnet: "10.40.0.0/22"
+    gateway: "10.40.0.1"
+    dnsServers:
+      - "10.40.0.2"
+    loadBalancer:
+      defaultPoolSize: 8
+      allocationMode: static
+```
+
+With this configuration, each new TenantCluster receives 8 LoadBalancer IPs from the `lab-pool`. The pool has 766 usable IPs in the tenant allocation range (10.40.1.0 - 10.40.3.254), supporting approximately 58 tenants at 13 IPs each (5 nodes + 8 LB).
+
+### Multi-Pool with Priority Failover
+
+Two pools with priority-based failover. When the primary pool is exhausted, allocations automatically fall through to the secondary pool.
+
+```yaml
+---
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: NetworkPool
+metadata:
+  name: prod-pool-primary
+  namespace: butler-system
+spec:
+  cidr: "10.40.0.0/22"
+  reserved:
+    - cidr: "10.40.0.0/26"
+      description: "Infrastructure services"
+  tenantAllocation:
+    start: "10.40.0.64"
+    end: "10.40.3.254"
+---
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: NetworkPool
+metadata:
+  name: prod-pool-secondary
+  namespace: butler-system
+spec:
+  cidr: "10.40.4.0/22"
+  tenantAllocation:
+    start: "10.40.4.0"
+    end: "10.40.7.254"
+---
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: harvester-prod
+  namespace: butler-system
+spec:
+  provider: harvester
+  credentialsRef:
+    name: harvester-kubeconfig
+  network:
+    mode: ipam
+    poolRefs:
+      - name: prod-pool-primary
+        priority: 0      # Tried first
+      - name: prod-pool-secondary
+        priority: 10     # Fallback
+    loadBalancer:
+      defaultPoolSize: 8
+      allocationMode: static
+    quotaPerTenant:
+      maxNodeIPs: 20
+      maxLoadBalancerIPs: 32
+```
+
+### Elastic IPAM for Cost-Efficient Clusters
+
+Elastic mode for environments where most tenants need few LoadBalancer IPs but some may need many.
+
+```yaml
+---
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: harvester-elastic
+  namespace: butler-system
+spec:
+  provider: harvester
+  credentialsRef:
+    name: harvester-kubeconfig
+  network:
+    mode: ipam
+    poolRefs:
+      - name: lab-pool
+        priority: 0
+    loadBalancer:
+      allocationMode: elastic
+      initialPoolSize: 2       # Start small
+      growthIncrement: 2       # Grow by 2 when needed
+    quotaPerTenant:
+      maxLoadBalancerIPs: 16   # Hard cap prevents runaway growth
+```
+
+With this configuration, a new TenantCluster starts with 2 LB IPs. When both are consumed by LoadBalancer Services, the next reconcile allocates 2 more. If usage drops (a Service is deleted) and the newest allocation is unused for 10+ minutes, it is reclaimed.
+
+### Pinned Range for Stable Addresses
+
+When a tenant cluster requires specific IP addresses (for example, DNS records that cannot be changed):
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: IPAllocation
+metadata:
+  name: team-platform-api-lb
+  namespace: butler-system
+  labels:
+    butler.butlerlabs.dev/team: team-platform
+    butler.butlerlabs.dev/tenant: api-prod
+    butler.butlerlabs.dev/network-pool: lab-pool
+    butler.butlerlabs.dev/allocation-type: loadbalancer
+spec:
+  poolRef:
+    name: lab-pool
+  tenantClusterRef:
+    name: api-prod
+    namespace: team-platform
+  type: loadbalancer
+  pinnedRange:
+    startAddress: "10.40.2.0"
+    endAddress: "10.40.2.7"
+```
+
+The NetworkPool controller validates that the pinned range is within the pool, does not overlap reserved ranges, and does not conflict with existing allocations. If validation passes, the range is allocated exactly as requested.
+
+:::warning
+Pinned ranges bypass best-fit allocation. If the requested range is in the middle of a large free block, it splits the block into two smaller ones, increasing fragmentation.
+:::
+
+---
+
+## Troubleshooting
+
+### IPAllocation Stuck in Pending
+
+**Symptoms**: IPAllocation shows `phase: Pending` for more than 60 seconds.
+
+**Diagnosis**:
+
+```bash
+# Check the IPAllocation status
+kubectl get ipallocation -n butler-system <name> -o yaml
+
+# Check if the referenced pool exists and has capacity
+kubectl get networkpool -n butler-system <pool-name>
+
+# Check NetworkPool controller logs
+kubectl logs -n butler-system -l app=butler-controller | grep networkpool
+```
+
+**Common causes**:
+
+1. **Pool exhausted**: `availableIPs` on the pool is less than the requested count. Expand the pool or add a secondary pool to the ProviderConfig.
+2. **Fragmentation**: Available IPs exist but no contiguous block is large enough. Check `fragmentationPercent` and `largestFreeBlock` in pool status.
+3. **NetworkPool controller not running**: Verify the butler-controller pod is healthy.
+
+### IPAllocation in Failed State
+
+**Symptoms**: IPAllocation shows `phase: Failed` with a condition message.
+
+**Diagnosis**:
+
+```bash
+kubectl get ipallocation -n butler-system <name> \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}'
+```
+
+**Common causes**:
+
+1. **Pool exhausted**: The condition message will contain "no contiguous block available". Add capacity.
+2. **Pinned range conflict**: A pinned range overlaps with a reserved CIDR or existing allocation. Check `kubectl get ipallocation -n butler-system -o wide` for overlapping ranges.
+3. **Invalid CIDR**: The pool's CIDR is malformed. Check pool validation conditions.
+
+Failed allocations are retried by both the NetworkPool controller (event-driven, treats Failed as Pending) and the IPAllocation controller (backstop, every 30 seconds).
+
+### Orphaned Allocations
+
+**Symptoms**: IPAllocations exist for TenantClusters that no longer exist.
+
+**Resolution**: The NetworkPool controller's orphan GC runs every 60 seconds and automatically detects and deletes orphaned allocations. If you need to force cleanup:
+
+```bash
+# List allocations for a deleted cluster
+kubectl get ipallocation -n butler-system \
+  -l butler.butlerlabs.dev/tenant=deleted-cluster
+
+# Manual deletion (if GC is not running)
+kubectl delete ipallocation -n butler-system \
+  -l butler.butlerlabs.dev/tenant=deleted-cluster
+```
+
+### NetworkPool Cannot Be Deleted
+
+**Symptoms**: NetworkPool stuck in terminating state.
+
+**Cause**: The pool has active IPAllocations. The finalizer blocks deletion until all allocations are Released.
+
+```bash
+# Check active allocations
+kubectl get ipallocation -n butler-system \
+  -l butler.butlerlabs.dev/network-pool=<pool-name> \
+  --field-selector status.phase!=Released
+
+# Delete the TenantClusters using this pool, or wait for their cleanup
+```
+
+### MetalLB Not Receiving Updated Ranges (Elastic IPAM)
+
+**Symptoms**: New LoadBalancer Services on the tenant cluster are stuck in Pending despite available allocations.
+
+**Diagnosis**:
+
+```bash
+# Check the MetalLB IPAddressPool on the tenant cluster
+kubectl --kubeconfig <tenant-kubeconfig> get ipaddresspool -n metallb-system -o yaml
+
+# Compare with the allocated ranges
+kubectl get ipallocation -n butler-system \
+  -l butler.butlerlabs.dev/tenant=<cluster-name>,butler.butlerlabs.dev/allocation-type=loadbalancer
+```
+
+**Common causes**:
+
+1. **updateMetalLBPool() failed**: Check butler-controller logs for "failed to update MetalLB pool" errors.
+2. **Tenant cluster unreachable**: The controller could not connect to the tenant cluster API. Verify the tenant control plane is healthy.
+3. **Growth allocation still Pending**: The NetworkPool controller has not yet fulfilled the growth allocation. Check the allocation phase.
+
+---
+
+## See Also
+
+- [Tenant Lifecycle](tenant-lifecycle.md) -- How tenant clusters are provisioned and managed
+- [Addon System](addon-system.md) -- MetalLB is installed as a platform addon
+- [Multi-Tenancy](multi-tenancy.md) -- How teams and namespaces interact with IPAM
+- [Bootstrap Flow](bootstrap-flow.md) -- Management cluster MetalLB setup

--- a/docs/overview/concepts.md
+++ b/docs/overview/concepts.md
@@ -67,6 +67,7 @@ Traditional control plane with dedicated VMs for control plane nodes. Each tenan
 An infrastructure adapter that provisions VMs for Butler clusters. Providers implement the interface between Butler and specific infrastructure platforms.
 
 **Current Providers:**
+
 | Provider | Platform | CAPI Provider |
 |----------|----------|---------------|
 | butler-provider-harvester | Harvester HCI | KubeVirt (capk) |

--- a/docs/reference/crds/README.md
+++ b/docs/reference/crds/README.md
@@ -45,6 +45,13 @@ Butler extends the Kubernetes API with Custom Resource Definitions (CRDs) under 
 | TenantAddon | Namespaced | `ta` | Addon on tenant cluster |
 | ManagementAddon | Cluster | `ma` | Addon on management cluster |
 
+### Networking
+
+| CRD | Scope | Short Name | Description |
+|-----|-------|------------|-------------|
+| [NetworkPool](./networkpool.md) | Namespaced | `np` | IP address pool for on-prem IPAM |
+| [IPAllocation](./ipallocation.md) | Namespaced | `ipa` | Individual IP allocation from a pool |
+
 ## Steward Resources
 
 Steward provides hosted control plane management.
@@ -63,6 +70,8 @@ Steward provides hosted control plane management.
 | `app.kubernetes.io/managed-by: butler` | Resource managed by Butler |
 | `butler.butlerlabs.dev/team: <name>` | Team ownership |
 | `butler.butlerlabs.dev/cluster: <name>` | Associated tenant cluster |
+| `butler.butlerlabs.dev/network-pool` | Associated network pool |
+| `butler.butlerlabs.dev/allocation-type` | IP allocation type (loadbalancer, nodes) |
 
 ### Annotations
 
@@ -77,9 +86,12 @@ Butler uses finalizers to ensure proper cleanup:
 
 | Finalizer | Applied To | Purpose |
 |-----------|------------|---------|
-| `butler.butlerlabs.dev/tenant-cluster` | TenantCluster | Cleanup child resources |
+| `butler.butlerlabs.dev/tenantcluster` | TenantCluster | Cleanup child resources |
 | `butler.butlerlabs.dev/team` | Team | Cleanup namespace and RBAC |
-| `butler.butlerlabs.dev/addon` | TenantAddon | Uninstall Helm release |
+| `butler.butlerlabs.dev/tenantaddon` | TenantAddon | Uninstall Helm release |
+| `butler.butlerlabs.dev/networkpool` | NetworkPool | Block deletion with active allocations |
+| `butler.butlerlabs.dev/ipallocation` | IPAllocation | Ensure Released phase for audit trail |
+| `butler.butlerlabs.dev/providerconfig` | ProviderConfig | Block deletion if TenantClusters reference it |
 
 ## See Also
 

--- a/docs/reference/crds/ipallocation.md
+++ b/docs/reference/crds/ipallocation.md
@@ -158,24 +158,13 @@ my-cluster-lb       vlan40-pool   my-cluster    loadbalancer   Allocated   10.40
 
 An IPAllocation progresses through the following phases:
 
-```
-                  ┌──────────┐
-                  │ Pending  │  Created by TenantCluster controller
-                  └────┬─────┘
-                       │
-            NetworkPool controller fulfills
-                       │
-              ┌────────┴────────┐
-              │                 │
-        ┌─────▼─────┐   ┌──────▼─────┐
-        │ Allocated  │   │  Failed    │  Pool exhausted or invalid request
-        └─────┬──────┘   └────────────┘
-              │
-     TenantCluster deleted
-              │
-        ┌─────▼─────┐
-        │ Released   │  IPs returned to pool
-        └────────────┘
+```mermaid
+stateDiagram-v2
+    [*] --> Pending: Created by TenantCluster controller
+    Pending --> Allocated: NetworkPool controller fulfills
+    Pending --> Failed: Pool exhausted or invalid request
+    Allocated --> Released: TenantCluster deleted
+    Released --> [*]: IPs returned to pool
 ```
 
 1. **Pending** -- The TenantCluster controller creates the IPAllocation. It sits in `Pending` phase until the NetworkPool controller processes it.

--- a/docs/reference/crds/ipallocation.md
+++ b/docs/reference/crds/ipallocation.md
@@ -1,0 +1,306 @@
+---
+title: IPAllocation
+sidebar_position: 6
+---
+
+An IPAllocation represents an individual IP address allocation from a NetworkPool for a tenant cluster.
+
+## API Version
+
+`butler.butlerlabs.dev/v1alpha1`
+
+## Scope
+
+Namespaced
+
+## Short Name
+
+`ipa`
+
+## Description
+
+IPAllocation is the request and record of IP addresses assigned to a specific TenantCluster from a NetworkPool. Each TenantCluster typically has two IPAllocations: one for worker node IPs (`nodes` type) and one for load balancer IPs (`loadbalancer` type).
+
+IPAllocations are created by the TenantCluster controller when a cluster is provisioned. The NetworkPool controller watches for pending IPAllocations and fulfills them by assigning contiguous IP blocks from the referenced pool. IPAllocations are released when the owning TenantCluster is deleted.
+
+## Types
+
+### IPAllocationType
+
+| Value | Description |
+|-------|-------------|
+| `nodes` | Worker node IPs. Each worker VM receives one IP from this allocation. |
+| `loadbalancer` | Load balancer IPs. Used by MetalLB or similar for Kubernetes Services of type LoadBalancer. |
+
+### IPAllocationPhase
+
+| Phase | Description |
+|-------|-------------|
+| `Pending` | Allocation created, waiting for the NetworkPool controller to assign IPs. |
+| `Allocated` | IPs have been assigned. The status contains the allocated addresses. |
+| `Released` | IPs have been released back to the pool. Terminal state during deletion. |
+| `Failed` | Allocation could not be fulfilled (e.g., pool exhausted, invalid request). Check conditions for details. |
+
+## Specification
+
+### Full Example
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: IPAllocation
+metadata:
+  name: my-cluster-nodes
+  namespace: butler-system
+  labels:
+    butler.butlerlabs.dev/team: backend-team
+    butler.butlerlabs.dev/tenant: my-cluster
+    butler.butlerlabs.dev/network-pool: vlan40-pool
+    butler.butlerlabs.dev/allocation-type: nodes
+spec:
+  poolRef:
+    name: vlan40-pool
+  tenantClusterRef:
+    name: my-cluster
+    namespace: team-backend
+  type: nodes
+  count: 5
+```
+
+### Spec Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `poolRef` | LocalObjectReference | Yes | Reference to the NetworkPool to allocate from. Must be in the same namespace. |
+| `tenantClusterRef` | NamespacedObjectReference | Yes | Reference to the TenantCluster this allocation is for. |
+| `type` | IPAllocationType | Yes | Purpose of the allocation: `nodes` or `loadbalancer`. |
+| `count` | *int32 | No | Number of IPs to allocate. Minimum: 1. If not specified, defaults from the NetworkPool's `tenantAllocation.defaults` are used (`nodesPerTenant` for nodes, `lbPoolPerTenant` for loadbalancer). Ignored when `pinnedRange` is set. |
+| `pinnedRange` | PinnedIPRange | No | Requests a specific IP range instead of automatic allocation. Used for migrating existing clusters to IPAM or reserving well-known addresses. |
+
+### poolRef
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Name of the NetworkPool in the same namespace. |
+
+### tenantClusterRef
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Name of the TenantCluster. |
+| `namespace` | string | Yes | Namespace of the TenantCluster. |
+
+### pinnedRange
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `startAddress` | string | Yes | First IP of the pinned range. Must match the pattern `^(\d{1,3}\.){3}\d{1,3}$`. |
+| `endAddress` | string | Yes | Last IP of the pinned range. Must match the pattern `^(\d{1,3}\.){3}\d{1,3}$`. |
+
+## Status
+
+The status subresource is populated by the NetworkPool controller when the allocation is fulfilled.
+
+```yaml
+status:
+  phase: Allocated
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Allocated
+      message: "5 IPs allocated from vlan40-pool"
+      lastTransitionTime: "2026-02-15T10:00:30Z"
+  cidr: "10.40.0.64/29"
+  startAddress: "10.40.0.64"
+  endAddress: "10.40.0.68"
+  addresses:
+    - "10.40.0.64"
+    - "10.40.0.65"
+    - "10.40.0.66"
+    - "10.40.0.67"
+    - "10.40.0.68"
+  allocatedCount: 5
+  observedGeneration: 1
+  allocatedAt: "2026-02-15T10:00:30Z"
+  allocatedBy: "networkpool-controller"
+```
+
+### Status Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `phase` | IPAllocationPhase | Current lifecycle phase: `Pending`, `Allocated`, `Released`, or `Failed`. |
+| `conditions` | []Condition | Standard Kubernetes conditions (listType=map, key=type). |
+| `cidr` | string | Allocated range in CIDR notation. Only populated when the range is power-of-2 aligned (e.g., 8 IPs starting at a /29 boundary). |
+| `startAddress` | string | First IP in the allocated range. |
+| `endAddress` | string | Last IP in the allocated range. |
+| `addresses` | []string | All individual IP addresses in the allocated range. |
+| `allocatedCount` | int32 | Number of IPs allocated. |
+| `observedGeneration` | int64 | Last observed `.metadata.generation`. |
+| `allocatedAt` | *Time | Timestamp when IPs were assigned by the allocator. |
+| `allocatedBy` | string | Identifier of the controller that fulfilled the allocation (e.g., "networkpool-controller"). |
+| `releasedAt` | *Time | Timestamp when IPs were released back to the pool. Set during deletion. |
+
+### Conditions
+
+| Condition | Description |
+|-----------|-------------|
+| `Ready` | Allocation is fulfilled and IPs are available for use. |
+
+### Print Columns
+
+```
+NAME                POOL          CLUSTER       TYPE           PHASE       START         END           AGE
+my-cluster-nodes    vlan40-pool   my-cluster    nodes          Allocated   10.40.0.64    10.40.0.68    7d
+my-cluster-lb       vlan40-pool   my-cluster    loadbalancer   Allocated   10.40.0.80    10.40.0.87    7d
+```
+
+## Phase Lifecycle
+
+An IPAllocation progresses through the following phases:
+
+```
+                  ┌──────────┐
+                  │ Pending  │  Created by TenantCluster controller
+                  └────┬─────┘
+                       │
+            NetworkPool controller fulfills
+                       │
+              ┌────────┴────────┐
+              │                 │
+        ┌─────▼─────┐   ┌──────▼─────┐
+        │ Allocated  │   │  Failed    │  Pool exhausted or invalid request
+        └─────┬──────┘   └────────────┘
+              │
+     TenantCluster deleted
+              │
+        ┌─────▼─────┐
+        │ Released   │  IPs returned to pool
+        └────────────┘
+```
+
+1. **Pending** -- The TenantCluster controller creates the IPAllocation. It sits in `Pending` phase until the NetworkPool controller processes it.
+
+2. **Allocated** -- The NetworkPool controller finds a suitable contiguous block, marks the IPs as allocated in the pool's bitmap, and populates the status with the assigned addresses. The TenantCluster controller reads the addresses and uses them for VM provisioning or MetalLB configuration.
+
+3. **Released** -- When the TenantCluster is deleted, its IPAllocations are cleaned up. The IPAllocation controller sets the phase to `Released` and the NetworkPool controller reclaims the IPs. The finalizer is removed and the resource is deleted.
+
+4. **Failed** -- The allocation could not be fulfilled. Common reasons include: the pool does not have enough contiguous free space, the pinned range overlaps an existing allocation, or the referenced pool does not exist. Check the conditions for details.
+
+## Controller Responsibilities
+
+IPAllocation involves two controllers with distinct responsibilities:
+
+**IPAllocation controller** (thin lifecycle manager):
+- Adds the `butler.butlerlabs.dev/ipallocation` finalizer on creation
+- Sets initial phase to `Pending` if not set
+- On deletion, transitions phase to `Released` and waits for the NetworkPool controller to reclaim IPs before removing the finalizer
+
+**NetworkPool controller** (actual allocator):
+- Watches IPAllocations that reference its pool
+- Fulfills `Pending` allocations by running the best-fit bitmap algorithm
+- Populates status fields: `startAddress`, `endAddress`, `addresses`, `cidr`, `allocatedCount`, `allocatedAt`, `allocatedBy`
+- Updates pool status counters (`allocatedIPs`, `availableIPs`, `allocationCount`, `fragmentationPercent`, `largestFreeBlock`)
+- Reclaims IPs from `Released` allocations
+
+This separation ensures that the NetworkPool controller is the single source of truth for IP assignments, avoiding race conditions across multiple pools.
+
+## Labels
+
+Butler applies the following labels to IPAllocation resources:
+
+| Label | Value | Description |
+|-------|-------|-------------|
+| `butler.butlerlabs.dev/network-pool` | Pool name | Identifies the source NetworkPool. |
+| `butler.butlerlabs.dev/team` | Team name | Team that owns the TenantCluster. |
+| `butler.butlerlabs.dev/tenant` | Cluster name | TenantCluster this allocation belongs to. |
+| `butler.butlerlabs.dev/allocation-type` | `nodes` or `loadbalancer` | The type of IP allocation. |
+
+## Finalizers
+
+| Finalizer | Description |
+|-----------|-------------|
+| `butler.butlerlabs.dev/ipallocation` | Ensures IPs are released back to the NetworkPool before the resource is deleted. The IPAllocation controller removes the finalizer only after the NetworkPool controller has reclaimed the IPs. |
+
+## Examples
+
+### Load Balancer Allocation
+
+Allocate 8 IPs for MetalLB address pools on a tenant cluster.
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: IPAllocation
+metadata:
+  name: my-cluster-lb
+  namespace: butler-system
+  labels:
+    butler.butlerlabs.dev/team: backend-team
+    butler.butlerlabs.dev/tenant: my-cluster
+    butler.butlerlabs.dev/network-pool: vlan40-pool
+    butler.butlerlabs.dev/allocation-type: loadbalancer
+spec:
+  poolRef:
+    name: vlan40-pool
+  tenantClusterRef:
+    name: my-cluster
+    namespace: team-backend
+  type: loadbalancer
+  count: 8
+```
+
+### Node Allocation
+
+Allocate IPs for worker node VMs. If `count` is omitted, the pool's `tenantAllocation.defaults.nodesPerTenant` is used.
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: IPAllocation
+metadata:
+  name: my-cluster-nodes
+  namespace: butler-system
+  labels:
+    butler.butlerlabs.dev/team: backend-team
+    butler.butlerlabs.dev/tenant: my-cluster
+    butler.butlerlabs.dev/network-pool: vlan40-pool
+    butler.butlerlabs.dev/allocation-type: nodes
+spec:
+  poolRef:
+    name: vlan40-pool
+  tenantClusterRef:
+    name: my-cluster
+    namespace: team-backend
+  type: nodes
+```
+
+### Pinned Range Allocation
+
+Reserve a specific IP range for an existing cluster being migrated to Butler IPAM. The allocator validates that the range is within the pool and not already allocated.
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: IPAllocation
+metadata:
+  name: legacy-cluster-nodes
+  namespace: butler-system
+  labels:
+    butler.butlerlabs.dev/team: platform-team
+    butler.butlerlabs.dev/tenant: legacy-cluster
+    butler.butlerlabs.dev/network-pool: vlan40-pool
+    butler.butlerlabs.dev/allocation-type: nodes
+spec:
+  poolRef:
+    name: vlan40-pool
+  tenantClusterRef:
+    name: legacy-cluster
+    namespace: team-platform
+  type: nodes
+  pinnedRange:
+    startAddress: "10.40.0.100"
+    endAddress: "10.40.0.109"
+```
+
+## See Also
+
+- [NetworkPool](./networkpool.md) - The IP address pool that IPAllocations draw from
+- [TenantCluster](./tenantcluster.md) - Creates IPAllocations during cluster provisioning
+- [Networking Architecture](../../architecture/networking.md) - How Butler manages on-premises networking

--- a/docs/reference/crds/networkpool.md
+++ b/docs/reference/crds/networkpool.md
@@ -1,0 +1,259 @@
+---
+title: NetworkPool
+sidebar_position: 5
+---
+
+A NetworkPool defines a platform-level IP address pool for on-premises IPAM.
+
+## API Version
+
+`butler.butlerlabs.dev/v1alpha1`
+
+## Scope
+
+Namespaced
+
+## Short Name
+
+`np`
+
+## Description
+
+NetworkPool is the foundation of Butler's on-premises IP address management (IPAM) system. Each NetworkPool defines a network CIDR and manages IP allocation to tenant clusters within that range. When a TenantCluster is created, the TenantCluster controller creates IPAllocation resources that reference a NetworkPool. The NetworkPool controller is the sole allocator -- it fulfills pending IPAllocations using a best-fit bitmap algorithm that minimizes fragmentation.
+
+NetworkPool supports:
+
+1. Reserving ranges for infrastructure (gateways, DNS servers, management nodes)
+2. Constraining the allocatable sub-range for tenant workloads
+3. Configuring default allocation sizes per tenant (node IPs and load balancer IPs)
+
+## Specification
+
+### Full Example
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: NetworkPool
+metadata:
+  name: vlan40-pool
+  namespace: butler-system
+spec:
+  cidr: "10.40.0.0/24"
+  reserved:
+    - cidr: "10.40.0.0/28"
+      description: "Gateway, DNS, and management cluster nodes"
+    - cidr: "10.40.0.240/28"
+      description: "Out-of-band management interfaces"
+  tenantAllocation:
+    start: "10.40.0.16"
+    end: "10.40.0.239"
+    defaults:
+      nodesPerTenant: 5
+      lbPoolPerTenant: 8
+```
+
+### Spec Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `cidr` | string | Yes | Network range in CIDR notation (e.g., "10.40.0.0/24"). Must match the pattern `^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$`. |
+| `reserved` | []ReservedRange | No | Ranges within the CIDR excluded from allocation. |
+| `tenantAllocation` | TenantAllocationConfig | No | Configures the allocatable sub-range and default sizes. If not specified, the entire CIDR (minus reserved ranges) is allocatable. |
+
+### reserved[]
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `cidr` | string | Yes | Reserved range in CIDR notation. Must match the pattern `^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$`. Must fall within the pool's CIDR. |
+| `description` | string | No | Human-readable explanation of why this range is reserved. |
+
+### tenantAllocation
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `start` | string | Yes | First allocatable IP address for tenants. |
+| `end` | string | Yes | Last allocatable IP address for tenants. |
+| `defaults` | TenantAllocationDefaults | No | Default allocation sizes per tenant. |
+
+### tenantAllocation.defaults
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `nodesPerTenant` | int32 | No | 5 | Default number of node IPs allocated per tenant cluster. Minimum: 1. |
+| `lbPoolPerTenant` | int32 | No | 8 | Default number of load balancer IPs allocated per tenant cluster. Minimum: 1. |
+
+## Status
+
+The status subresource tracks pool utilization and health.
+
+```yaml
+status:
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: PoolAvailable
+      message: "Pool is available for allocations"
+      lastTransitionTime: "2026-02-15T10:00:00Z"
+  totalIPs: 224
+  allocatedIPs: 65
+  availableIPs: 159
+  allocationCount: 5
+  fragmentationPercent: 12
+  largestFreeBlock: 128
+  observedGeneration: 1
+```
+
+### Status Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `conditions` | []Condition | Standard Kubernetes conditions (listType=map, key=type). |
+| `totalIPs` | int32 | Total number of usable IPs in the pool (CIDR size minus reserved ranges). |
+| `allocatedIPs` | int32 | Number of IPs currently allocated to tenants. |
+| `availableIPs` | int32 | Number of IPs available for new allocations. |
+| `allocationCount` | int32 | Total number of IPAllocation resources referencing this pool. |
+| `fragmentationPercent` | *int32 | Percentage (0-100) indicating how fragmented the free space is. Nil if no allocations exist. |
+| `largestFreeBlock` | int32 | Size of the largest contiguous block of free IPs. Useful for determining if a requested allocation can be satisfied. |
+| `observedGeneration` | int64 | Last observed `.metadata.generation`. Indicates whether the controller has processed the latest spec changes. |
+
+### Conditions
+
+| Condition | Description |
+|-----------|-------------|
+| `Ready` | Pool is valid and available for allocations. |
+| `Degraded` | Pool has issues (e.g., high fragmentation, near capacity). |
+
+### Print Columns
+
+```
+NAME          CIDR            AVAILABLE   ALLOCATED   TOTAL   AGE
+vlan40-pool   10.40.0.0/24    159         65          224     7d
+```
+
+## How It Works
+
+NetworkPool is the authoritative source of IP address space for on-premises deployments. The allocation flow works as follows:
+
+1. **Pool defines the IP space.** An administrator creates a NetworkPool with a CIDR, optional reserved ranges, and optional tenant allocation configuration.
+
+2. **IPAllocations consume from the pool.** When a TenantCluster is created, the TenantCluster controller creates IPAllocation resources (one for node IPs, one for load balancer IPs) that reference the NetworkPool.
+
+3. **NetworkPool controller is the sole allocator.** The NetworkPool controller watches for IPAllocations in `Pending` phase that reference its pool. It selects the best-fit contiguous block using a bitmap-based algorithm, marks the IPs as allocated in its internal state, and updates the IPAllocation status with the assigned addresses.
+
+4. **Best-fit bitmap algorithm.** The controller maintains a bitmap of the entire CIDR range. Reserved ranges are permanently marked. When fulfilling an allocation, the controller finds the smallest free block that satisfies the request, minimizing fragmentation. This approach provides O(n) allocation with deterministic behavior.
+
+5. **Release on deletion.** When a TenantCluster is deleted, its IPAllocations transition to `Released` phase. The NetworkPool controller reclaims the IPs and updates pool utilization counters.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    NetworkPool (10.40.0.0/24)                │
+│                                                              │
+│  ┌──────────┐  ┌──────────────────────┐  ┌──────────┐      │
+│  │ Reserved  │  │   Allocatable Range  │  │ Reserved │      │
+│  │ .0 - .15  │  │   .16 - .239         │  │.240-.255 │      │
+│  └──────────┘  │  ┌─────┐ ┌────┐ Free │  └──────────┘      │
+│                │  │TC-A  │ │TC-B│      │                     │
+│                │  │nodes │ │ lb │      │                     │
+│                │  └─────┘ └────┘      │                     │
+│                └──────────────────────┘                      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Webhook Validation
+
+NetworkPool uses admission webhooks to enforce the following rules:
+
+**On create:**
+- CIDR must be valid (parseable, correct network address)
+- Reserved CIDRs must fall entirely within the pool's CIDR
+- If `tenantAllocation` is set, `start` and `end` must fall within the CIDR and `start` must precede `end`
+- Reserved ranges must not overlap each other
+
+**On update:**
+- CIDR cannot be shrunk (the new CIDR must be a superset of or equal to the old CIDR)
+- Reserved ranges cannot be expanded into space that has active allocations
+- `tenantAllocation.start` and `tenantAllocation.end` changes must not exclude currently allocated IPs
+
+**On delete:**
+- Deletion is blocked if any IPAllocations in `Allocated` phase reference this pool
+- The finalizer `butler.butlerlabs.dev/networkpool` enforces this
+
+## Labels
+
+Butler applies the following label to resources associated with a NetworkPool:
+
+| Label | Value | Description |
+|-------|-------|-------------|
+| `butler.butlerlabs.dev/network-pool` | Pool name | Identifies the NetworkPool. Applied to IPAllocations that reference this pool. |
+
+## Finalizers
+
+| Finalizer | Description |
+|-----------|-------------|
+| `butler.butlerlabs.dev/networkpool` | Prevents deletion while active IPAllocations exist. The controller removes the finalizer only after all allocations are released. |
+
+## Examples
+
+### Minimal Pool
+
+A simple pool with no reserved ranges and no tenant allocation configuration. The entire CIDR is allocatable.
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: NetworkPool
+metadata:
+  name: simple-pool
+  namespace: butler-system
+spec:
+  cidr: "10.50.0.0/24"
+```
+
+### Pool with Reserved Ranges
+
+Reserve specific ranges for infrastructure components while leaving the rest available for tenant allocation.
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: NetworkPool
+metadata:
+  name: infra-pool
+  namespace: butler-system
+spec:
+  cidr: "10.40.0.0/23"
+  reserved:
+    - cidr: "10.40.0.0/28"
+      description: "Management cluster control plane and gateway"
+    - cidr: "10.40.0.16/28"
+      description: "Management cluster worker nodes"
+    - cidr: "10.40.1.240/28"
+      description: "IPMI and out-of-band management"
+```
+
+### Pool with Tenant Allocation Configuration
+
+Constrain the allocatable range and set default allocation sizes for tenant clusters.
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: NetworkPool
+metadata:
+  name: tenant-pool
+  namespace: butler-system
+spec:
+  cidr: "10.40.0.0/22"
+  reserved:
+    - cidr: "10.40.0.0/26"
+      description: "Management infrastructure"
+  tenantAllocation:
+    start: "10.40.0.64"
+    end: "10.40.3.254"
+    defaults:
+      nodesPerTenant: 10
+      lbPoolPerTenant: 16
+```
+
+## See Also
+
+- [IPAllocation](./ipallocation.md) - Individual IP allocations from a NetworkPool
+- [ProviderConfig](./providerconfig.md) - Provider configuration that references NetworkPools via `spec.network.poolRefs`
+- [Networking Architecture](../../architecture/networking.md) - How Butler manages on-premises networking

--- a/docs/reference/crds/networkpool.md
+++ b/docs/reference/crds/networkpool.md
@@ -144,20 +144,29 @@ NetworkPool is the authoritative source of IP address space for on-premises depl
 
 5. **Release on deletion.** When a TenantCluster is deleted, its IPAllocations transition to `Released` phase. The NetworkPool controller reclaims the IPs and updates pool utilization counters.
 
+```mermaid
+flowchart LR
+    subgraph pool["NetworkPool 10.40.0.0/24"]
+        R1["Reserved\n.0-.15"]
+        TCA["TC-A\nnodes"]
+        TCB["TC-B\nlb"]
+        Free["Free\n.16-.239"]
+        R2["Reserved\n.240-.255"]
+    end
+
+    R1 ~~~ TCA
+    TCA ~~~ TCB
+    TCB ~~~ Free
+    Free ~~~ R2
+
+    style R1 fill:#ff9999,color:#333
+    style R2 fill:#ff9999,color:#333
+    style TCA fill:#99ccff,color:#333
+    style TCB fill:#99ccff,color:#333
+    style Free fill:#99ff99,color:#333
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                    NetworkPool (10.40.0.0/24)                │
-│                                                              │
-│  ┌──────────┐  ┌──────────────────────┐  ┌──────────┐      │
-│  │ Reserved  │  │   Allocatable Range  │  │ Reserved │      │
-│  │ .0 - .15  │  │   .16 - .239         │  │.240-.255 │      │
-│  └──────────┘  │  ┌─────┐ ┌────┐ Free │  └──────────┘      │
-│                │  │TC-A  │ │TC-B│      │                     │
-│                │  │nodes │ │ lb │      │                     │
-│                │  └─────┘ └────┘      │                     │
-│                └──────────────────────┘                      │
-└─────────────────────────────────────────────────────────────┘
-```
+
+The diagram shows a NetworkPool with reserved ranges at the start and end, two tenant allocations in the middle, and free space available for future allocations.
 
 ## Webhook Validation
 

--- a/docs/reference/crds/providerconfig.md
+++ b/docs/reference/crds/providerconfig.md
@@ -3,7 +3,9 @@ title: ProviderConfig
 sidebar_position: 3
 ---
 
-A ProviderConfig defines connection credentials and settings for an infrastructure provider.
+# ProviderConfig
+
+A ProviderConfig defines connection credentials, infrastructure settings, network configuration, and resource limits for an infrastructure provider.
 
 ## API Version
 
@@ -17,40 +19,413 @@ Namespaced
 
 `pc`
 
+## Finalizer
+
+`butler.butlerlabs.dev/providerconfig`
+
+## Print Columns
+
+| Column | Field |
+|--------|-------|
+| Provider | `spec.provider` |
+| Scope | `spec.scope.type` |
+| Ready | `status.ready` |
+| Validated | `status.validated` |
+| Age | `metadata.creationTimestamp` |
+
 ## Description
 
-ProviderConfig stores the credentials and configuration needed to connect to an infrastructure provider (Harvester, Nutanix, or Proxmox). Each provider type has its own configuration section with provider-specific fields.
+ProviderConfig stores the credentials, provider-specific settings, network configuration, and resource limits needed to provision tenant cluster infrastructure. Butler supports six provider types: three on-premises providers (Harvester, Nutanix, Proxmox) and three cloud providers (Azure, AWS, GCP). Each provider type has its own configuration section with provider-specific fields.
+
+A ProviderConfig can be scoped to the entire platform or to a specific team, controlling which teams can use it for cluster provisioning. Network configuration supports both cloud-native networking and IPAM-managed address pools with static or elastic allocation modes.
 
 ## Spec
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `provider` | string | Yes | Provider type: `harvester`, `nutanix`, or `proxmox` |
-| `credentialsRef` | SecretReference | Yes | Reference to Secret containing provider credentials |
-| `harvester` | HarvesterConfig | No | Harvester-specific configuration |
-| `nutanix` | NutanixConfig | No | Nutanix-specific configuration |
-| `proxmox` | ProxmoxConfig | No | Proxmox-specific configuration |
+| `provider` | `ProviderType` | Yes | Provider type. One of: `harvester`, `nutanix`, `proxmox`, `azure`, `aws`, `gcp` |
+| `credentialsRef` | [`SecretReference`](#secretreference) | Yes | Reference to a Secret containing provider credentials |
+| `harvester` | [`HarvesterConfig`](#harvesterconfig) | No | Harvester-specific configuration |
+| `nutanix` | [`NutanixConfig`](#nutanixconfig) | No | Nutanix-specific configuration |
+| `proxmox` | [`ProxmoxConfig`](#proxmoxconfig) | No | Proxmox-specific configuration |
+| `azure` | [`AzureConfig`](#azureconfig) | No | Azure-specific configuration |
+| `aws` | [`AWSConfig`](#awsconfig) | No | AWS-specific configuration |
+| `gcp` | [`GCPConfig`](#gcpconfig) | No | GCP-specific configuration |
+| `scope` | [`Scope`](#scope) | No | Controls which teams can use this provider |
+| `network` | [`NetworkConfig`](#network-configuration) | No | Network and IPAM configuration |
+| `limits` | [`Limits`](#limits) | No | Resource limits for teams using this provider |
+
+### SecretReference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Name of the Secret |
+| `namespace` | string | No | Namespace of the Secret. Defaults to the ProviderConfig namespace |
+| `key` | string | No | Specific key within the Secret data |
+
+---
+
+## Provider Configuration
+
+Each provider type requires its own configuration section matching the `spec.provider` value. Only the section corresponding to the chosen provider type is used; the others are ignored.
 
 ### HarvesterConfig
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `namespace` | string | Yes | Harvester namespace for VMs |
-| `networkName` | string | Yes | Network name for VM NICs |
-| `imageName` | string | Yes | VM image name |
+Configuration for [Harvester](https://harvesterhci.io/) HCI clusters.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `endpoint` | string | No | | Harvester API endpoint URL |
+| `namespace` | string | No | `"default"` | Harvester namespace for VM resources |
+| `networkName` | string | Yes | | VM network in `namespace/name` format (e.g., `default/vlan40-workloads`) |
+| `imageName` | string | No | | VM image name |
+| `storageClassName` | string | No | | StorageClass to use for VM volumes |
 
 ### NutanixConfig
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `endpoint` | string | Yes | Prism Central endpoint URL |
-| `port` | int32 | No | API port (default: 9440) |
-| `insecure` | bool | No | Skip TLS verification |
-| `clusterUUID` | string | Yes | Target AHV cluster UUID |
-| `subnetUUID` | string | Yes | Network subnet UUID |
-| `imageUUID` | string | No | VM image UUID |
+Configuration for [Nutanix](https://www.nutanix.com/) AHV clusters via Prism Central.
 
-## Example
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `endpoint` | string | Yes | | Prism Central endpoint URL. Must use `https://` scheme |
+| `port` | int32 | No | `9440` | Prism Central API port |
+| `insecure` | bool | No | `false` | Skip TLS certificate verification |
+| `clusterUUID` | string | Yes | | Target AHV cluster UUID |
+| `subnetUUID` | string | Yes | | Network subnet UUID for VM NICs |
+| `imageUUID` | string | No | | VM image UUID |
+| `storageContainerUUID` | string | No | | Storage container UUID for VM disks |
+
+### ProxmoxConfig
+
+Configuration for [Proxmox VE](https://www.proxmox.com/en/proxmox-virtual-environment) clusters.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `endpoint` | string | Yes | | Proxmox API endpoint URL. Must use `https://` scheme |
+| `insecure` | bool | No | `false` | Skip TLS certificate verification |
+| `nodes` | []string | Yes | | Target Proxmox node names. Minimum 1 entry |
+| `storage` | string | Yes | | Storage identifier for VM disks |
+| `templateID` | int32 | No | | VM template ID to clone from |
+| `vmidRange` | [`VMIDRange`](#vmidrange) | No | | Range of VM IDs to allocate |
+
+#### VMIDRange
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `start` | int32 | No | | Start of VM ID range. Minimum value: `100` |
+| `end` | int32 | No | | End of VM ID range. Minimum value: `100` |
+
+### AzureConfig
+
+Configuration for [Microsoft Azure](https://azure.microsoft.com/).
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `subscriptionID` | string | Yes | | Azure subscription ID |
+| `resourceGroup` | string | Yes | | Azure resource group name |
+| `location` | string | No | | Azure region (e.g., `eastus`, `westeurope`) |
+| `vnetName` | string | No | | Virtual network name |
+| `subnetName` | string | No | | Subnet name within the VNet |
+
+### AWSConfig
+
+Configuration for [Amazon Web Services](https://aws.amazon.com/).
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `region` | string | Yes | | AWS region (e.g., `us-east-1`, `eu-west-1`) |
+| `vpcID` | string | No | | VPC ID. If omitted, the default VPC is used |
+| `subnetIDs` | []string | No | | Subnet IDs for VM placement |
+| `securityGroupIDs` | []string | No | | Security group IDs to attach to VMs |
+
+### GCPConfig
+
+Configuration for [Google Cloud Platform](https://cloud.google.com/).
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `projectID` | string | Yes | | GCP project ID |
+| `region` | string | Yes | | GCP region (e.g., `us-central1`, `europe-west1`) |
+| `network` | string | No | | VPC network name |
+| `subnetwork` | string | No | | Subnetwork name within the VPC |
+
+---
+
+## Scope
+
+The `spec.scope` field controls which teams can use the ProviderConfig for cluster provisioning.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `type` | string | No | `"platform"` | Scope type. One of: `platform`, `team` |
+| `teamRef` | LocalObjectReference | Conditional | | Reference to the Team. Required when `type` is `team` |
+
+### Platform Scope
+
+When `scope.type` is `platform` (or `scope` is omitted entirely), any team in the Butler platform can reference this ProviderConfig for cluster provisioning. Platform-scoped ProviderConfigs are typically created by platform administrators.
+
+### Team Scope
+
+When `scope.type` is `team`, only the team referenced by `scope.teamRef.name` can use this ProviderConfig. Team-scoped ProviderConfigs allow teams to bring their own infrastructure credentials and isolate their provider access from other teams.
+
+---
+
+## Network Configuration
+
+The `spec.network` section controls IP address management and load balancer allocation for tenant clusters provisioned with this provider.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `mode` | string | No | `"cloud"` | Network mode. One of: `ipam`, `cloud` |
+| `poolRefs` | [`[]PoolRef`](#poolref) | No | | References to IP address pools. Required when `mode` is `ipam` |
+| `subnet` | string | No | | Subnet CIDR for node addressing |
+| `gateway` | string | No | | Default gateway IP address |
+| `dnsServers` | []string | No | | DNS server addresses |
+| `loadBalancer` | [`LoadBalancerConfig`](#loadbalancerconfig) | No | | Load balancer IP allocation settings |
+| `quotaPerTenant` | [`QuotaPerTenant`](#quotapertenant) | No | | Per-tenant IP address quotas |
+
+### Network Modes
+
+**`cloud` mode** (default): Relies on the cloud provider's native networking. IP addresses are assigned by the cloud provider's DHCP or instance metadata service. This is the default mode and is appropriate for AWS, Azure, and GCP providers.
+
+**`ipam` mode**: Butler manages IP address allocation from configured address pools. Required for on-premises providers (Harvester, Nutanix, Proxmox) where no cloud DHCP service is available. When `ipam` mode is selected, `poolRefs` must reference at least one IP address pool.
+
+:::warning
+IPAM mode (`ipam`) is required for on-premises providers and is forbidden for cloud providers (`azure`, `aws`, `gcp`). The webhook validates this constraint on create and update.
+:::
+
+### PoolRef
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | Yes | | Name of the IP address pool resource |
+| `priority` | int32 | No | `0` | Pool selection priority. Higher values indicate higher priority |
+
+### LoadBalancerConfig
+
+Controls how load balancer IP addresses are allocated to tenant clusters.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `defaultPoolSize` | *int32 | No | `8` | Default number of LB IPs allocated per tenant. Minimum: `1` |
+| `allocationMode` | string | No | `"static"` | Allocation strategy. One of: `static`, `elastic` |
+| `initialPoolSize` | *int32 | No | `2` | Initial pool size when using `elastic` mode. Minimum: `1` |
+| `growthIncrement` | *int32 | No | `2` | Number of IPs to add when the elastic pool grows. Minimum: `1` |
+
+#### Static Allocation
+
+In `static` mode, each tenant cluster receives a fixed block of `defaultPoolSize` load balancer IPs at provisioning time. The block size does not change during the cluster lifecycle.
+
+#### Elastic Allocation
+
+In `elastic` mode, each tenant cluster starts with `initialPoolSize` load balancer IPs. As demand increases, Butler allocates additional IPs in increments of `growthIncrement`, up to `defaultPoolSize`. This conserves IP address space when tenants have variable load balancer requirements.
+
+### QuotaPerTenant
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `maxNodeIPs` | *int32 | No | | Maximum node IP addresses per tenant. Minimum: `1` |
+| `maxLoadBalancerIPs` | *int32 | No | | Maximum load balancer IP addresses per tenant. Minimum: `1` |
+
+---
+
+## Limits
+
+The `spec.limits` section constrains resource consumption by teams using this ProviderConfig.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `maxClustersPerTeam` | *int32 | No | | Maximum number of clusters a team can provision. Minimum: `1` |
+| `maxNodesPerTeam` | *int32 | No | | Maximum total nodes across all clusters for a team. Minimum: `1` |
+
+When limits are set, the Butler controller checks them before allowing a TenantCluster to be created or scaled. If a limit is not set, no restriction is enforced for that dimension.
+
+---
+
+## Status
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `conditions` | []Condition | Standard Kubernetes conditions. Includes `Ready`, `Validated` |
+| `validated` | bool | Whether the provider credentials and configuration have been validated |
+| `lastValidationTime` | *Time | Timestamp of the last successful validation |
+| `providerVersion` | string | Detected version of the provider (e.g., Harvester version, Nutanix AOS version) |
+| `ready` | bool | Whether the provider is reachable and ready to accept MachineRequests |
+| `lastProbeTime` | *Time | Timestamp of the last health probe |
+| `capacity` | [`Capacity`](#capacity) | Estimated available capacity |
+
+### Capacity
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `availableIPs` | int32 | Number of IP addresses available in the configured pools |
+| `estimatedTenants` | int32 | Estimated number of additional tenant clusters that can be provisioned |
+
+---
+
+## Credential Secret Format
+
+Each provider type expects specific keys in the referenced Secret. Create the Secret before creating the ProviderConfig.
+
+### Harvester
+
+| Key | Description |
+|-----|-------------|
+| `kubeconfig` | Harvester cluster kubeconfig with permissions to manage VMs |
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: harvester-credentials
+  namespace: butler-system
+type: Opaque
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - cluster:
+        server: https://harvester.example.com:6443
+        certificate-authority-data: <base64>
+      name: harvester
+    # ...
+```
+
+### Nutanix
+
+| Key | Description |
+|-----|-------------|
+| `username` | Prism Central username |
+| `password` | Prism Central password |
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nutanix-credentials
+  namespace: butler-system
+type: Opaque
+stringData:
+  username: admin
+  password: <prism-central-password>
+```
+
+### Proxmox
+
+Proxmox supports either username/password or API token authentication.
+
+| Key | Description |
+|-----|-------------|
+| `username` | Proxmox username (e.g., `root@pam`) |
+| `password` | Proxmox password |
+| `token` | Proxmox API token (alternative to username/password) |
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: proxmox-credentials
+  namespace: butler-system
+type: Opaque
+stringData:
+  username: root@pam
+  password: <proxmox-password>
+```
+
+### Azure
+
+| Key | Description |
+|-----|-------------|
+| `tenantId` | Azure Active Directory tenant ID |
+| `clientId` | Service principal application (client) ID |
+| `clientSecret` | Service principal client secret |
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-credentials
+  namespace: butler-system
+type: Opaque
+stringData:
+  tenantId: <azure-tenant-id>
+  clientId: <service-principal-client-id>
+  clientSecret: <service-principal-secret>
+```
+
+### AWS
+
+| Key | Description |
+|-----|-------------|
+| `accessKeyId` | IAM access key ID |
+| `secretAccessKey` | IAM secret access key |
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-credentials
+  namespace: butler-system
+type: Opaque
+stringData:
+  accessKeyId: <aws-access-key-id>
+  secretAccessKey: <aws-secret-access-key>
+```
+
+### GCP
+
+| Key | Description |
+|-----|-------------|
+| `serviceAccount` | GCP service account key in JSON format |
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gcp-credentials
+  namespace: butler-system
+type: Opaque
+stringData:
+  serviceAccount: |
+    {
+      "type": "service_account",
+      "project_id": "my-project",
+      "private_key_id": "...",
+      "private_key": "-----BEGIN PRIVATE KEY-----\n...",
+      "client_email": "butler@my-project.iam.gserviceaccount.com",
+      ...
+    }
+```
+
+---
+
+## Webhook Validation
+
+The ProviderConfig admission webhook enforces the following rules.
+
+### Create and Update
+
+- The provider-specific configuration section must be present and valid for the chosen `spec.provider` type.
+- Provider-specific required fields are validated:
+  - **Azure**: `subscriptionID` and `resourceGroup` must be set.
+  - **AWS**: `region` must be set.
+  - **GCP**: `projectID` and `region` must be set.
+- If `spec.scope.type` is `team`, `spec.scope.teamRef.name` must be set.
+- If `spec.network.mode` is `ipam`, `spec.network.poolRefs` must contain at least one entry.
+- IPAM mode is forbidden for cloud providers (`azure`, `aws`, `gcp`).
+
+### Delete
+
+- Deletion is blocked if any TenantCluster references the ProviderConfig via `providerConfigRef`. Remove or migrate all dependent clusters before deleting.
+
+---
+
+## Examples
+
+### On-Premises Harvester with IPAM
+
+A platform-scoped Harvester provider using IPAM for IP address management with static load balancer allocation.
 
 ```yaml
 apiVersion: butler.butlerlabs.dev/v1alpha1
@@ -61,23 +436,186 @@ metadata:
 spec:
   provider: harvester
   credentialsRef:
-    name: harvester-kubeconfig
+    name: harvester-credentials
     namespace: butler-system
   harvester:
+    endpoint: https://harvester.example.com:6443
     namespace: default
     networkName: default/vlan40-workloads
-    imageName: default/talos-1.8.0
+    imageName: default/talos-1.9.0
+    storageClassName: longhorn
+  network:
+    mode: ipam
+    poolRefs:
+      - name: prod-ip-pool
+        priority: 10
+      - name: overflow-ip-pool
+        priority: 5
+    subnet: "10.40.0.0/24"
+    gateway: "10.40.0.1"
+    dnsServers:
+      - "10.40.0.2"
+      - "10.40.0.3"
+    loadBalancer:
+      defaultPoolSize: 8
+      allocationMode: static
+    quotaPerTenant:
+      maxNodeIPs: 20
+      maxLoadBalancerIPs: 8
+  limits:
+    maxClustersPerTeam: 5
+    maxNodesPerTeam: 50
 ```
 
-## Status
+### Nutanix with Static IPAM
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `ready` | bool | Whether the provider is reachable |
-| `lastValidated` | Time | Last successful connection test |
-| `message` | string | Status message or error |
+A platform-scoped Nutanix provider with IPAM and resource limits.
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: nutanix-datacenter
+  namespace: butler-system
+spec:
+  provider: nutanix
+  credentialsRef:
+    name: nutanix-credentials
+  nutanix:
+    endpoint: https://prism.example.com
+    port: 9440
+    insecure: false
+    clusterUUID: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    subnetUUID: "f0e1d2c3-b4a5-6789-0fed-cba987654321"
+    imageUUID: "11223344-5566-7788-99aa-bbccddeeff00"
+    storageContainerUUID: "aabbccdd-eeff-0011-2233-445566778899"
+  network:
+    mode: ipam
+    poolRefs:
+      - name: nutanix-node-pool
+        priority: 10
+    subnet: "10.50.0.0/24"
+    gateway: "10.50.0.1"
+    dnsServers:
+      - "10.50.0.10"
+    loadBalancer:
+      defaultPoolSize: 4
+      allocationMode: static
+  limits:
+    maxClustersPerTeam: 3
+    maxNodesPerTeam: 30
+```
+
+### Cloud AWS Provider
+
+An AWS provider using cloud-native networking. No IPAM configuration is needed.
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: aws-us-east
+  namespace: butler-system
+spec:
+  provider: aws
+  credentialsRef:
+    name: aws-credentials
+  aws:
+    region: us-east-1
+    vpcID: vpc-0abc123def456789
+    subnetIDs:
+      - subnet-0aaa111bbb222ccc
+      - subnet-0ddd333eee444fff
+    securityGroupIDs:
+      - sg-0123456789abcdef0
+  limits:
+    maxClustersPerTeam: 10
+    maxNodesPerTeam: 100
+```
+
+### Team-Scoped Azure Provider
+
+An Azure provider scoped to a specific team. Only the `platform-team` can use this ProviderConfig.
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: azure-platform-team
+  namespace: team-platform-team
+spec:
+  provider: azure
+  credentialsRef:
+    name: azure-credentials
+    namespace: team-platform-team
+  azure:
+    subscriptionID: "12345678-abcd-efgh-ijkl-1234567890ab"
+    resourceGroup: platform-team-rg
+    location: eastus
+    vnetName: platform-vnet
+    subnetName: tenant-subnet
+  scope:
+    type: team
+    teamRef:
+      name: platform-team
+  limits:
+    maxClustersPerTeam: 5
+    maxNodesPerTeam: 40
+```
+
+### Elastic IPAM Configuration
+
+A Proxmox provider with elastic load balancer IP allocation. Tenant clusters start with a small pool that grows on demand.
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: proxmox-elastic
+  namespace: butler-system
+spec:
+  provider: proxmox
+  credentialsRef:
+    name: proxmox-credentials
+  proxmox:
+    endpoint: https://proxmox.example.com:8006
+    insecure: false
+    nodes:
+      - pve-node-01
+      - pve-node-02
+      - pve-node-03
+    storage: local-lvm
+    templateID: 9000
+    vmidRange:
+      start: 200
+      end: 999
+  network:
+    mode: ipam
+    poolRefs:
+      - name: proxmox-main-pool
+        priority: 10
+    subnet: "192.168.10.0/24"
+    gateway: "192.168.10.1"
+    dnsServers:
+      - "192.168.10.2"
+    loadBalancer:
+      defaultPoolSize: 16
+      allocationMode: elastic
+      initialPoolSize: 2
+      growthIncrement: 4
+    quotaPerTenant:
+      maxNodeIPs: 10
+      maxLoadBalancerIPs: 16
+  limits:
+    maxClustersPerTeam: 8
+    maxNodesPerTeam: 40
+```
+
+---
 
 ## See Also
 
-- [Provider Guides](../../providers/) - Provider-specific documentation
-- [TenantCluster](./tenantcluster.md) - Uses ProviderConfig for infrastructure
+- [TenantCluster](./tenantcluster.md) -- Uses ProviderConfig for infrastructure provisioning
+- [MachineRequest](./machinerequest.md) -- VM lifecycle requests dispatched to provider controllers
+- [Team](./team.md) -- Multi-tenancy unit; team-scoped ProviderConfigs restrict access
+- [Provider Guides](../../guides/providers.md) -- Provider-specific setup and configuration guides

--- a/docs/reference/crds/providerconfig.md
+++ b/docs/reference/crds/providerconfig.md
@@ -3,8 +3,6 @@ title: ProviderConfig
 sidebar_position: 3
 ---
 
-# ProviderConfig
-
 A ProviderConfig defines connection credentials, infrastructure settings, network configuration, and resource limits for an infrastructure provider.
 
 ## API Version
@@ -151,7 +149,7 @@ Configuration for [Google Cloud Platform](https://cloud.google.com/).
 
 ---
 
-## Scope
+## Provider Scope
 
 The `spec.scope` field controls which teams can use the ProviderConfig for cluster provisioning.
 
@@ -616,6 +614,5 @@ spec:
 ## See Also
 
 - [TenantCluster](./tenantcluster.md) -- Uses ProviderConfig for infrastructure provisioning
-- [MachineRequest](./machinerequest.md) -- VM lifecycle requests dispatched to provider controllers
 - [Team](./team.md) -- Multi-tenancy unit; team-scoped ProviderConfigs restrict access
-- [Provider Guides](../../guides/providers.md) -- Provider-specific setup and configuration guides
+- [Networking Architecture](../../architecture/networking.md) -- IPAM, pools, and allocation flows

--- a/docs/reference/crds/team.md
+++ b/docs/reference/crds/team.md
@@ -3,7 +3,9 @@ title: Team
 sidebar_position: 4
 ---
 
-A Team represents a multi-tenancy boundary in Butler, grouping users and clusters.
+# Team
+
+A Team represents a multi-tenancy boundary in Butler, grouping users, clusters, and resource quotas under a single organizational unit.
 
 ## API Version
 
@@ -19,48 +21,246 @@ Cluster
 
 ## Description
 
-Team is the primary multi-tenancy resource in Butler. Each team owns a namespace where their TenantClusters and other resources are created. Teams have members with different roles (admin, operator, viewer) and can be synced with identity provider groups.
+Team is the primary multi-tenancy resource in Butler. Each Team owns a dedicated namespace (`team-{name}`) where its TenantClusters, ProviderConfigs, and other namespaced resources are created. Teams control access through user and group memberships with role-based permissions, enforce resource quotas across all clusters, and define default cluster configurations.
+
+The Team controller reconciles the following:
+
+- Creates and manages the team namespace
+- Sets up RBAC (Roles and RoleBindings) for team members
+- Tracks resource usage across all TenantClusters in the team
+- Evaluates quota limits and sets conditions when limits are breached
 
 ## Spec
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `displayName` | string | No | Human-readable team name |
-| `description` | string | No | Team description |
-| `access` | TeamAccess | Yes | Team membership configuration |
-| `providerConfigRef` | ObjectReference | No | Default provider for team clusters |
-| `resourceQuota` | ResourceQuota | No | Limits on team resources |
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `displayName` | string | No | — | Human-readable team name |
+| `description` | string | No | — | Team description |
+| `access` | TeamAccess | Yes | — | Team membership configuration |
+| `resourceLimits` | TeamResourceLimits | No | — | Limits on team resource consumption |
+| `providerConfigRef` | LocalObjectReference | No | — | Default provider for team clusters |
+| `clusterDefaults` | ClusterDefaults | No | — | Default values for new TenantClusters |
 
 ### TeamAccess
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `users` | []TeamUser | Direct user memberships |
-| `groups` | []TeamGroup | Group-based memberships (synced from IdP) |
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `users` | []TeamUser | No | Direct user memberships |
+| `groups` | []TeamGroup | No | Group-based memberships (synced from IdP) |
 
 ### TeamUser
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `name` | string | User email address |
-| `role` | string | Role: `admin`, `operator`, or `viewer` |
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | Yes | — | User email address |
+| `role` | TeamRole | No | `viewer` | Role assigned to this user |
 
 ### TeamGroup
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `name` | string | Group name (from identity provider) |
-| `role` | string | Role assigned to group members |
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | Yes | — | Group name (from identity provider) |
+| `role` | TeamRole | No | `viewer` | Role assigned to all group members |
+| `identityProvider` | string | No | — | Name of the IdentityProvider CRD to match against. If omitted, matches groups from any configured provider. |
 
 ### Roles
 
-| Role | Permissions |
-|------|-------------|
-| `admin` | Full access to team resources, can manage members |
-| `operator` | Create, update, delete clusters and addons |
-| `viewer` | Read-only access to team resources |
+| Role | Description | Permissions |
+|------|-------------|-------------|
+| `admin` | Team administrator | Full access to team resources. Can manage members, create/delete clusters, configure addons, and modify team settings. |
+| `operator` | Cluster operator | Create, update, and delete clusters and addons. Cannot manage team membership. |
+| `viewer` | Read-only member | Read-only access to team resources. Can view clusters, addons, and team configuration. |
 
-## Example
+### TeamResourceLimits
+
+All fields are optional. When a limit is not set, no enforcement is applied for that dimension.
+
+#### Cluster Limits
+
+| Field | Type | Validation | Description |
+|-------|------|------------|-------------|
+| `maxClusters` | *int32 | min: 0 | Maximum number of TenantClusters the team can create |
+| `maxNodesPerCluster` | *int32 | min: 0 | Maximum worker nodes per individual cluster |
+| `maxTotalNodes` | *int32 | min: 0 | Maximum total worker nodes across all clusters |
+
+#### Compute Limits
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `maxCPUCores` | *resource.Quantity | Maximum total CPU cores across all clusters |
+| `maxMemory` | *resource.Quantity | Maximum total memory across all clusters |
+| `maxStorage` | *resource.Quantity | Maximum total storage across all clusters |
+
+#### Per-Cluster Defaults
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `defaultNodeCount` | *int32 | 3 | Default number of worker nodes when not specified |
+| `defaultCPUPerNode` | *resource.Quantity | — | Default CPU per worker node |
+| `defaultMemoryPerNode` | *resource.Quantity | — | Default memory per worker node |
+
+#### Feature Restrictions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `allowedKubernetesVersions` | []string | Kubernetes versions permitted for this team (e.g., `["1.29.x", "1.30.x"]`). Empty means all versions allowed. |
+| `allowedProviders` | []string | Infrastructure providers this team can use (e.g., `["harvester", "nutanix"]`). Empty means all providers allowed. |
+| `allowedAddons` | []string | Addons this team can install. Empty means all addons allowed. |
+| `deniedAddons` | []string | Addons this team cannot install. Takes precedence over `allowedAddons`. |
+
+### ClusterDefaults
+
+Default values applied to new TenantClusters created in this team when the corresponding field is not explicitly set.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `kubernetesVersion` | string | Default Kubernetes version |
+| `workerCount` | int32 | Default number of worker nodes |
+| `workerCPU` | resource.Quantity | Default CPU per worker |
+| `workerMemoryGi` | int32 | Default memory per worker (GiB) |
+| `workerDiskGi` | int32 | Default disk size per worker (GiB) |
+| `defaultAddons` | []string | Addons installed by default on new clusters |
+
+### ProviderConfigRef
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Name of the ProviderConfig in the team namespace |
+
+## Status
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `conditions` | []Condition | Standard Kubernetes conditions (see below) |
+| `phase` | string | Current team phase |
+| `namespace` | string | Team's namespace (`team-{name}`) |
+| `observedGeneration` | int64 | Last generation reconciled by the controller |
+| `clusterCount` | int32 | Number of TenantClusters in the team |
+| `memberCount` | int32 | Total number of team members (users + resolved group members) |
+| `resourceUsage` | TeamResourceUsage | Current resource consumption |
+| `quotaStatus` | string | Overall quota status |
+| `quotaMessage` | string | Human-readable quota status message |
+
+### Conditions
+
+| Type | Description |
+|------|-------------|
+| `NamespaceReady` | The team namespace has been created and is available |
+| `RBACReady` | Roles and RoleBindings have been created for all team members |
+| `Ready` | The team is fully reconciled and operational |
+| `QuotaExceeded` | One or more resource limits have been breached |
+
+### Phases
+
+| Phase | Description |
+|-------|-------------|
+| `Pending` | Team created, waiting for namespace and RBAC setup |
+| `Ready` | Team is fully provisioned and operational |
+| `Terminating` | Team is being deleted, cleanup in progress |
+| `Failed` | An error occurred during reconciliation |
+
+### TeamResourceUsage
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `clusters` | int32 | Number of active TenantClusters |
+| `totalNodes` | int32 | Total worker nodes across all clusters |
+| `totalCPU` | *resource.Quantity | Total CPU allocated across all clusters |
+| `totalMemory` | *resource.Quantity | Total memory allocated across all clusters |
+| `totalStorage` | *resource.Quantity | Total storage allocated across all clusters |
+| `clusterUtilization` | int32 | Percentage of maxClusters used (0-100) |
+| `nodeUtilization` | int32 | Percentage of maxTotalNodes used (0-100) |
+| `cpuUtilization` | int32 | Percentage of maxCPUCores used (0-100) |
+| `memoryUtilization` | int32 | Percentage of maxMemory used (0-100) |
+
+### Quota Status Values
+
+| Value | Description |
+|-------|-------------|
+| `OK` | All resource usage is within limits |
+| `Warning` | Resource usage is approaching a limit (>80%) |
+| `Exceeded` | One or more limits have been breached |
+
+### Print Columns
+
+| Column | Field | Description |
+|--------|-------|-------------|
+| Display Name | `spec.displayName` | Human-readable name |
+| Phase | `status.phase` | Current lifecycle phase |
+| Namespace | `status.namespace` | Team namespace |
+| Clusters | `status.clusterCount` | Number of clusters |
+| Quota | `status.quotaStatus` | Quota status (OK/Warning/Exceeded) |
+| Age | `metadata.creationTimestamp` | Resource age |
+
+## Resource Usage Calculation
+
+The Team controller computes resource usage by aggregating data from all TenantClusters in the team namespace:
+
+- **CPU**: Sum of `machineTemplate.CPU * workers.replicas` across all TenantClusters
+- **Memory**: Sum of `machineTemplate.Memory * workers.replicas` across all TenantClusters
+- **Storage**: Sum of `machineTemplate.DiskSize * workers.replicas` across all TenantClusters
+- **Utilization percentages**: Computed as `(current usage / limit) * 100`, only when the corresponding limit is set
+
+When any utilization exceeds 100%, the controller sets the `QuotaExceeded` condition to `True` and updates `quotaStatus` to `Exceeded`.
+
+## Quota Enforcement
+
+Resource limits are enforced at two levels:
+
+### Webhook Enforcement (TenantCluster Admission)
+
+A validating webhook intercepts TenantCluster create and update requests and checks them against the owning Team's resource limits:
+
+- **CPU quota**: Sums `machineTemplate.CPU * replicas` across all existing TenantClusters in the team (excluding self on update), adds the proposed cluster's CPU, and compares against `maxCPUCores`.
+- **Memory quota**: Same calculation using `machineTemplate.Memory` against `maxMemory`.
+- **Storage quota**: Same calculation using `machineTemplate.DiskSize` against `maxStorage`.
+- **Cluster count**: Checks current cluster count against `maxClusters`.
+- **Nodes per cluster**: Checks proposed worker replicas against `maxNodesPerCluster`.
+- **Total nodes**: Sums worker replicas across all clusters against `maxTotalNodes`.
+
+The webhook also enforces ProviderConfig-level limits (`maxClustersPerTeam`, `maxNodesPerTeam`) when present.
+
+If any limit would be exceeded, the webhook rejects the request with a descriptive error message.
+
+### Controller Enforcement (Continuous Monitoring)
+
+The Team controller continuously monitors resource usage and updates status conditions. This catches drift caused by external changes and provides visibility into quota health via the `QuotaExceeded` condition and `quotaStatus` field.
+
+## Group Sync
+
+Teams can reference identity provider groups to automatically grant access to group members. When a user authenticates via SSO, Butler resolves their group memberships and matches them against team group entries.
+
+### How Group Matching Works
+
+1. The user authenticates via an IdentityProvider (OIDC/SSO).
+2. Butler retrieves the user's group memberships from the identity provider:
+   - **Google Workspace**: Groups fetched via Admin SDK (not included in OIDC token).
+   - **Microsoft Entra ID / Okta**: Groups come from the `groups` claim in the OIDC token.
+3. Group names are normalized before matching:
+   - Email-style groups: `engineers@company.com` is normalized to `engineers`.
+   - LDAP DN format: `CN=Engineers,OU=Groups,DC=company` is normalized to `engineers`.
+4. The normalized group name is compared against `spec.access.groups[].name`.
+5. If the group entry specifies `identityProvider`, it only matches groups from that specific IdentityProvider CRD. Otherwise, it matches groups from any configured provider.
+6. Matched users receive the role specified on the group entry.
+
+### Group Priority
+
+If a user is matched by both a direct `users` entry and one or more `groups` entries, the highest-privilege role wins. Role precedence: `admin` > `operator` > `viewer`.
+
+## Finalizer
+
+`butler.butlerlabs.dev/team`
+
+The Team finalizer ensures proper cleanup when a Team is deleted:
+
+1. All TenantClusters in the team namespace are deleted (and their finalizers run).
+2. RBAC resources (Roles, RoleBindings) are removed.
+3. The team namespace (`team-{name}`) is deleted.
+4. The finalizer is removed and the Team resource is deleted.
+
+## Examples
+
+### Basic Team
 
 ```yaml
 apiVersion: butler.butlerlabs.dev/v1alpha1
@@ -83,22 +283,95 @@ spec:
         role: viewer
   providerConfigRef:
     name: harvester-prod
-    namespace: butler-system
-  resourceQuota:
-    maxClusters: 10
-    maxNodesPerCluster: 20
 ```
 
-## Status
+### Team with Full Resource Quotas
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `namespace` | string | Team's namespace (team-{name}) |
-| `ready` | bool | Whether team is fully provisioned |
-| `clusterCount` | int32 | Number of clusters in team |
-| `memberCount` | int32 | Number of team members |
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: Team
+metadata:
+  name: development
+spec:
+  displayName: Development Team
+  description: Shared development environment with resource limits
+  access:
+    users:
+      - name: lead@example.com
+        role: admin
+    groups:
+      - name: developers
+        role: operator
+        identityProvider: google-workspace
+  resourceLimits:
+    # Cluster limits
+    maxClusters: 5
+    maxNodesPerCluster: 10
+    maxTotalNodes: 30
+    # Compute limits
+    maxCPUCores: "120"
+    maxMemory: "480Gi"
+    maxStorage: "2Ti"
+    # Per-cluster defaults
+    defaultNodeCount: 3
+    defaultCPUPerNode: "4"
+    defaultMemoryPerNode: "16Gi"
+  providerConfigRef:
+    name: harvester-dev
+  clusterDefaults:
+    kubernetesVersion: "1.30.4"
+    workerCount: 3
+    workerCPU: "4"
+    workerMemoryGi: 16
+    workerDiskGi: 100
+    defaultAddons:
+      - cilium
+      - metallb
+      - cert-manager
+```
+
+### Team with Feature Restrictions
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: Team
+metadata:
+  name: sandbox
+spec:
+  displayName: Sandbox Team
+  description: Restricted sandbox for experimentation
+  access:
+    users:
+      - name: intern@example.com
+        role: operator
+    groups:
+      - name: interns
+        role: viewer
+  resourceLimits:
+    maxClusters: 2
+    maxNodesPerCluster: 3
+    maxTotalNodes: 6
+    maxCPUCores: "24"
+    maxMemory: "96Gi"
+    maxStorage: "500Gi"
+    # Feature restrictions
+    allowedKubernetesVersions:
+      - "1.30.4"
+    allowedProviders:
+      - harvester
+    allowedAddons:
+      - cilium
+      - metallb
+    deniedAddons:
+      - longhorn
+      - gpu-operator
+  providerConfigRef:
+    name: harvester-sandbox
+```
 
 ## See Also
 
 - [Multi-Tenancy Architecture](../../architecture/multi-tenancy.md)
 - [TenantCluster](./tenantcluster.md) - Clusters owned by teams
+- [ProviderConfig](./providerconfig.md) - Infrastructure provider configuration
+- [IdentityProvider](../../architecture/security-model.md) - SSO and group sync

--- a/docs/reference/crds/team.md
+++ b/docs/reference/crds/team.md
@@ -3,8 +3,6 @@ title: Team
 sidebar_position: 4
 ---
 
-# Team
-
 A Team represents a multi-tenancy boundary in Butler, grouping users, clusters, and resource quotas under a single organizational unit.
 
 ## API Version


### PR DESCRIPTION
## Summary

- Add comprehensive networking architecture doc covering the full IPAM subsystem (static and elastic allocation modes, best-fit bitmap allocator, three-layer cleanup/GC, MetalLB integration, Prometheus metrics, troubleshooting)
- Add NetworkPool and IPAllocation CRD reference docs
- Rewrite ProviderConfig CRD reference to cover all 6 provider types (Harvester, Nutanix, Proxmox, AWS, Azure, GCP), IPAM modes, elastic allocation, scope, limits, credential formats
- Rewrite Team CRD reference with TeamResourceLimits, TeamResourceUsage, quota enforcement, group sync, feature restrictions
- Update CRD index with Networking section, new labels, corrected finalizer names
- Update architecture README with IPAM flow

## Files Changed

| File | Lines | Action |
|---|---|---|
| `docs/architecture/networking.md` | 1,151 | New |
| `docs/reference/crds/networkpool.md` | 259 | New |
| `docs/reference/crds/ipallocation.md` | 306 | New |
| `docs/reference/crds/providerconfig.md` | 621 | Rewritten |
| `docs/reference/crds/team.md` | 377 | Rewritten |
| `docs/reference/crds/README.md` | 99 | Updated |
| `docs/architecture/README.md` | 187 | Updated |

## Test plan

- [ ] Verify all internal markdown links resolve
- [ ] Verify YAML examples are valid
- [ ] Review field tables against CRD source types in butler-api