### PR TITLE
docs: add cloud bootstrap and provider documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ Built by [Butler Labs](https://butlerlabs.dev) to solve the problem we kept seei
 | **Harvester HCI** | On-Premises | Stable | 1.28 - 1.31 |
 | **Nutanix AHV** | On-Premises | Stable | 1.28 - 1.31 |
 | **Proxmox VE** | On-Premises | In Progress | - |
+| **GCP** | Cloud | Beta | 1.28 - 1.31 |
 | **AWS** | Cloud | In Progress | - |
 | **Azure** | Cloud | In Progress | - |
-| **GCP** | Cloud | In Progress | - |
 
 See [Provider Guides](docs/providers/) for detailed setup instructions.
 

--- a/docs/architecture/bootstrap-flow.md
+++ b/docs/architecture/bootstrap-flow.md
@@ -1,19 +1,40 @@
 # Bootstrap Flow
 
-This document describes how Butler bootstraps a management cluster from scratch.
+This document describes how Butler bootstraps a management cluster from scratch, covering both on-prem and cloud provider paths.
 
 ## Overview
 
 Bootstrapping creates a new Butler management cluster on your infrastructure. The process uses a temporary [KIND](https://kind.sigs.k8s.io/) cluster to orchestrate the bootstrap, then cleans up after completion.
 
+Butler supports two deployment models:
+
+- **On-prem** (Harvester, Nutanix, Proxmox): Uses kube-vip for control plane HA with a floating virtual IP. MetalLB provides LoadBalancer services.
+- **Cloud** (GCP, AWS, Azure): Uses a cloud-native L4 load balancer for control plane HA. Cloud load balancers handle services natively.
+
 ## Prerequisites
 
-- Docker installed on the bootstrap machine
-- Infrastructure credentials (Harvester kubeconfig, Nutanix credentials, etc.)
-- Network connectivity to the infrastructure
-- IP addresses allocated for the management cluster
+### Common
 
-## Bootstrap Sequence
+- Docker installed on the bootstrap machine
+- `butleradm` CLI installed
+- Network connectivity from the bootstrap machine to the infrastructure
+- A Talos factory schematic ID for the boot image
+
+### On-Prem
+
+- Infrastructure credentials (Harvester kubeconfig, Nutanix Prism credentials, Proxmox API token)
+- A static VIP address for the control plane endpoint (not in use by any other service)
+- An IP range for MetalLB LoadBalancer services (must not overlap with the VIP)
+- A VM image (Talos Linux) uploaded to the infrastructure
+
+### Cloud
+
+- Cloud credentials with compute and networking permissions
+- A VPC/VNet with a subnet for cluster nodes
+- Firewall rules allowing TCP 6443, 50000, and 50001 between nodes
+- A VM image (Talos Linux) available in the target region
+
+## On-Prem Bootstrap Sequence
 
 ```mermaid
 sequenceDiagram
@@ -24,9 +45,9 @@ sequenceDiagram
     participant Provider as butler-provider-*
     participant Infra as Infrastructure
     participant MC as Management Cluster
-    
+
     User->>CLI: butleradm bootstrap harvester --config bootstrap.yaml
-    
+
     rect rgb(240, 240, 240)
         Note over CLI,KIND: Phase 1: Local Setup
         CLI->>KIND: Create KIND cluster
@@ -35,48 +56,138 @@ sequenceDiagram
         CLI->>KIND: Create ProviderConfig CR
         CLI->>KIND: Create ClusterBootstrap CR
     end
-    
+
     rect rgb(230, 245, 255)
         Note over Bootstrap,Infra: Phase 2: VM Provisioning
         Bootstrap->>Bootstrap: Watch ClusterBootstrap
         Bootstrap->>Provider: Create MachineRequest CRs
         Provider->>Infra: Create VMs
-        Infra-->>Provider: VMs running
+        Infra-->>Provider: VMs running with IPs
         Provider->>Provider: Update MachineRequest status
-        Bootstrap->>Bootstrap: Wait for all machines ready
+        Bootstrap->>Bootstrap: Wait for all machines Running
     end
-    
+
     rect rgb(255, 245, 230)
-        Note over Bootstrap,MC: Phase 3: Cluster Bootstrap
-        Bootstrap->>MC: Generate Talos machine configs
-        Bootstrap->>MC: Apply configs to nodes
-        Bootstrap->>MC: Run talosctl bootstrap
+        Note over Bootstrap,MC: Phase 3: Talos Configuration
+        Bootstrap->>MC: Generate Talos machine configs (VIP as endpoint)
+        Bootstrap->>MC: Apply configs to all nodes via Talos API
+        Bootstrap->>MC: Bootstrap first control plane node
         MC-->>Bootstrap: Kubernetes API available
         Bootstrap->>Bootstrap: Retrieve kubeconfig
     end
-    
+
     rect rgb(230, 255, 230)
         Note over Bootstrap,MC: Phase 4: Addon Installation
-        Bootstrap->>MC: Install kube-vip (control plane HA)
+        Bootstrap->>MC: Install kube-vip (floating VIP for CP HA)
         Bootstrap->>MC: Install Cilium (CNI)
         Bootstrap->>MC: Install cert-manager
         Bootstrap->>MC: Install Longhorn (storage)
-        Bootstrap->>MC: Install MetalLB (LoadBalancer)
+        Bootstrap->>MC: Install MetalLB (LoadBalancer services)
         Bootstrap->>MC: Install Traefik (ingress)
-        Bootstrap->>MC: Install Steward
-        Bootstrap->>MC: Install CAPI + providers
+        Bootstrap->>MC: Install Steward (hosted control planes)
+        Bootstrap->>MC: Install CAPI + infrastructure providers
         Bootstrap->>MC: Install Butler controller
         Bootstrap->>MC: Install Flux (optional)
     end
-    
+
     rect rgb(245, 230, 255)
         Note over CLI,KIND: Phase 5: Completion
-        Bootstrap->>KIND: Update ClusterBootstrap status: Complete
+        Bootstrap->>KIND: Update ClusterBootstrap status: Ready
         CLI->>CLI: Save kubeconfig to ~/.butler/
         CLI->>KIND: Delete KIND cluster
-        CLI-->>User: Bootstrap complete!
+        CLI-->>User: Bootstrap complete
     end
 ```
+
+## Cloud Bootstrap Sequence
+
+Cloud bootstrap differs from on-prem in how the control plane endpoint is established. Instead of a floating VIP, a cloud-native L4 load balancer fronts the control plane nodes.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as butleradm
+    participant KIND as KIND Cluster
+    participant Bootstrap as butler-bootstrap
+    participant Provider as butler-provider-*
+    participant Cloud as Cloud Provider
+    participant MC as Management Cluster
+
+    User->>CLI: butleradm bootstrap gcp --config bootstrap.yaml
+
+    rect rgb(240, 240, 240)
+        Note over CLI,KIND: Phase 1: Local Setup
+        CLI->>KIND: Create KIND cluster
+        CLI->>KIND: Deploy butler-bootstrap controller
+        CLI->>KIND: Deploy butler-provider-gcp
+        CLI->>KIND: Create ProviderConfig CR
+        CLI->>KIND: Create ClusterBootstrap CR
+    end
+
+    rect rgb(230, 245, 255)
+        Note over Bootstrap,Cloud: Phase 2: VM Provisioning
+        Bootstrap->>Provider: Create MachineRequest CRs
+        Provider->>Cloud: Create VMs in VPC subnet
+        Cloud-->>Provider: VMs running with IPs
+        Provider->>Provider: Update MachineRequest status
+    end
+
+    rect rgb(255, 230, 230)
+        Note over Bootstrap,Cloud: Phase 2b: Load Balancer Provisioning
+        Bootstrap->>KIND: Create LoadBalancerRequest CR
+        Provider->>Cloud: Create static IP, health check, target pool, forwarding rule
+        Cloud-->>Provider: LB ready with endpoint IP
+        Provider->>KIND: Update LoadBalancerRequest status (endpoint)
+        Bootstrap->>Bootstrap: Use LB endpoint as control plane address
+    end
+
+    rect rgb(255, 245, 230)
+        Note over Bootstrap,MC: Phase 3: Talos Configuration
+        Bootstrap->>MC: Generate Talos configs (LB endpoint as CP address)
+        Bootstrap->>MC: Add loopback interface patch (LB IP on lo)
+        Bootstrap->>MC: Apply configs to all nodes
+        Bootstrap->>MC: Bootstrap first control plane node
+        MC-->>Bootstrap: Kubernetes API available via LB
+        Bootstrap->>Bootstrap: Retrieve kubeconfig
+    end
+
+    rect rgb(230, 255, 230)
+        Note over Bootstrap,MC: Phase 4: Addon Installation
+        Note over Bootstrap,MC: kube-vip and MetalLB are SKIPPED for cloud
+        Bootstrap->>MC: Install Cilium (CNI)
+        Bootstrap->>MC: Install cert-manager
+        Bootstrap->>MC: Install Longhorn (storage)
+        Bootstrap->>MC: Install Steward (hosted control planes)
+        Bootstrap->>MC: Install CAPI + cloud infrastructure providers
+        Bootstrap->>MC: Install Butler controller
+        Bootstrap->>MC: Install Flux (optional)
+    end
+
+    rect rgb(245, 230, 255)
+        Note over CLI,KIND: Phase 5: Completion
+        Bootstrap->>KIND: Update ClusterBootstrap status: Ready
+        CLI->>CLI: Save kubeconfig to ~/.butler/
+        CLI->>KIND: Delete KIND cluster
+        CLI-->>User: Bootstrap complete
+    end
+```
+
+### Loopback Interface Patch
+
+Cloud passthrough load balancers (GCP forwarding rules, AWS NLBs, Azure Standard LBs) deliver packets with the original destination IP unchanged. The kube-apiserver binds to `0.0.0.0:6443` but the kernel drops packets destined for an IP that is not assigned to any local interface.
+
+To solve this, the bootstrap controller adds a Talos config patch that assigns the LB IP to the loopback interface on each control plane node:
+
+```yaml
+machine:
+  network:
+    interfaces:
+      - interface: lo
+        addresses:
+          - 35.194.52.218/32  # The LB's external IP
+```
+
+This allows the kernel to accept packets routed through the load balancer and deliver them to kube-apiserver.
 
 ## Phases in Detail
 
@@ -85,199 +196,163 @@ sequenceDiagram
 The CLI creates a temporary KIND cluster and deploys controllers:
 
 ```bash
-# What happens internally
-kind create cluster --name butler-bootstrap
-
-# Deploy controllers
-kubectl apply -f embedded-manifests/butler-bootstrap.yaml
-kubectl apply -f embedded-manifests/butler-provider-harvester.yaml
-
-# Create configuration CRs
-kubectl apply -f provider-config.yaml
-kubectl apply -f cluster-bootstrap.yaml
+butleradm bootstrap harvester --config bootstrap.yaml
 ```
 
+Internally:
+1. Creates a KIND cluster named `butler-bootstrap`
+2. Deploys the butler-bootstrap controller
+3. Deploys the appropriate provider controller (butler-provider-harvester, butler-provider-gcp, etc.)
+4. Creates the ProviderConfig CR with infrastructure credentials
+5. Creates the ClusterBootstrap CR that triggers reconciliation
+
 **Why KIND?**
-- Provides a standard Kubernetes API for controllers
+- Provides a standard Kubernetes API for controller-runtime
 - Watch-based reconciliation instead of polling scripts
 - Clean separation between orchestration and infrastructure
-- Can pause/resume by preserving KIND cluster
+- Can preserve for debugging with `--skip-cleanup`
 
 ### Phase 2: VM Provisioning
 
-The bootstrap controller creates MachineRequest CRs, and the provider controller provisions VMs:
+The bootstrap controller creates MachineRequest CRs for each node defined in the ClusterBootstrap spec. The provider controller watches these resources, creates VMs, and reports IP addresses.
 
 ```yaml
 apiVersion: butler.butlerlabs.dev/v1alpha1
 kind: MachineRequest
 metadata:
   name: butler-mgmt-cp-0
+  namespace: butler-system
 spec:
-  role: controlplane
-  providerConfigRef:
-    name: harvester-config
-  resources:
-    cpu: 4
-    memory: 16Gi
-    disk: 100Gi
+  providerRef:
+    name: harvester-prod
+    namespace: butler-system
+  machineName: butler-mgmt-cp-0
+  role: control-plane
+  cpu: 4
+  memoryMB: 16384
+  diskGB: 100
 ```
 
-**Machine Roles:**
-- `controlplane`: Control plane nodes (3 for HA, 1 for single-node)
-- `worker`: Worker nodes (optional for management cluster)
+For cloud providers, the controller also creates a LoadBalancerRequest after all VMs have IPs. The provider controller provisions the cloud load balancer and reports its endpoint.
 
-### Phase 3: Cluster Bootstrap
+### Phase 3: Talos Configuration
 
-Once VMs are running, Talos Linux is configured:
+Once all VMs are running (and for cloud, the LB endpoint is ready):
 
-1. **Generate configs**: Create machine configs for each node
-2. **Apply configs**: Push configs to nodes via Talos API
-3. **Bootstrap**: Initialize etcd and Kubernetes
-4. **Retrieve kubeconfig**: Get admin credentials
-
-```mermaid
-stateDiagram-v2
-    [*] --> ConfiguringTalos
-    ConfiguringTalos --> BootstrappingKubernetes: Configs applied
-    BootstrappingKubernetes --> WaitingForAPI: Bootstrap complete
-    WaitingForAPI --> RetrievingKubeconfig: API available
-    RetrievingKubeconfig --> [*]: Kubeconfig saved
-```
+1. **Generate configs**: Create Talos machine configs with the control plane endpoint
+   - On-prem: endpoint is the VIP address from `network.vip`
+   - Cloud: endpoint is the LB IP from `LoadBalancerRequest.status.endpoint`
+2. **Apply configs**: Push configs to all nodes via Talos API (insecure mode, pre-bootstrap)
+3. **Bootstrap**: Initialize etcd and Kubernetes on the first control plane node
+4. **Retrieve kubeconfig**: Get admin credentials for the new cluster
 
 ### Phase 4: Addon Installation
 
-Platform addons are installed in dependency order:
+Platform addons are installed in dependency order. The set of addons differs between on-prem and cloud:
 
-| Order | Addon | Purpose | Depends On |
-|-------|-------|---------|------------|
-| 1 | kube-vip | Control plane VIP | None |
-| 2 | Cilium | CNI with kube-proxy replacement | kube-vip |
-| 3 | cert-manager | TLS certificates | Cilium |
-| 4 | Longhorn | Distributed storage | cert-manager |
-| 5 | MetalLB | LoadBalancer services | Cilium |
-| 6 | Traefik | Ingress controller | MetalLB |
-| 7 | Steward | Hosted control planes | cert-manager |
-| 8 | CAPI | Cluster lifecycle | Steward |
-| 9 | Butler Controller | Platform controller | CAPI |
-| 10 | Flux | GitOps (optional) | Butler Controller |
+| Order | Addon | On-Prem | Cloud | Purpose |
+|-------|-------|---------|-------|---------|
+| 1 | kube-vip | Yes | No | Floating VIP for control plane HA |
+| 2 | Cilium | Yes | Yes | CNI with kube-proxy replacement |
+| 3 | cert-manager | Yes | Yes | TLS certificate automation |
+| 4 | Longhorn | Yes | Yes | Distributed persistent storage |
+| 5 | MetalLB | Yes | No | LoadBalancer service implementation |
+| 6 | Traefik | Yes | No | Ingress controller |
+| 7 | Steward | Yes | Yes | Hosted tenant control planes |
+| 8 | CAPI + providers | Yes | Yes | Cluster API for tenant worker lifecycle |
+| 9 | Butler controller | Yes | Yes | Platform reconciliation controller |
+| 10 | Flux | Optional | Optional | GitOps controller |
+| 11 | Butler Console | Optional | Optional | Web UI |
 
 ### Phase 5: Completion
 
-1. ClusterBootstrap status updated to `Complete`
+1. ClusterBootstrap status updated to `Ready`
 2. Kubeconfig saved to `~/.butler/<cluster-name>-kubeconfig`
-3. KIND cluster deleted
-4. Summary printed to user
+3. Talosconfig saved to `~/.butler/<cluster-name>-talosconfig`
+4. KIND cluster deleted (unless `--skip-cleanup` was passed)
+5. Summary printed to the terminal
 
-## Configuration
+## Cloud Resources by Provider
 
-### ClusterBootstrap Spec
+Each cloud provider controller creates different resources to implement the L4 passthrough load balancer:
 
-```yaml
-apiVersion: butler.butlerlabs.dev/v1alpha1
-kind: ClusterBootstrap
-metadata:
-  name: butler-mgmt
-  namespace: butler-system
-spec:
-  provider: harvester  # or nutanix
-  
-  cluster:
-    name: butler-mgmt
-    controlPlaneEndpoint: 10.40.0.200
-    kubernetesVersion: "v1.31.0"
-    topology: ha  # ha (3 CP nodes) or single-node
-    
-    controlPlane:
-      replicas: 3
-      machineTemplate:
-        cpu: 4
-        memory: 16Gi
-        diskSize: 100Gi
+| Provider | Resources Created |
+|----------|-------------------|
+| GCP | Regional static IP, legacy HTTP health check, target pool, forwarding rule |
+| AWS | Network Load Balancer (NLB), target group (TCP), listener on port 6443 |
+| Azure | Public IP, Standard Load Balancer, health probe, load balancing rule, backend pool |
 
-    workers:
-      replicas: 3
-      machineTemplate:
-        cpu: 8
-        memory: 32Gi
-        diskSize: 200Gi
+All providers use TCP passthrough. The kube-apiserver handles TLS directly.
 
-  networking:
-    podCIDR: 10.244.0.0/16
-    serviceCIDR: 10.96.0.0/12
-    
-  platform:
-    cni: cilium
-    storage: longhorn
-    loadBalancer: metallb
-    metalLBPool: 10.40.0.200-10.40.0.250
-    
-  gitops:
-    enabled: true
-    provider: flux
-    repository: https://github.com/myorg/butler-mgmt-live
-    branch: main
-    path: clusters/butler-mgmt
-    
-  providerConfig:
-    harvester:
-      credentialsRef:
-        name: harvester-kubeconfig
-      namespace: default
-      networkName: default/workloads
-      imageName: default/talos-1.9
-```
+## Topology Options
 
-### Topology Options
+| Topology | Control Planes | Workers | kube-vip | Storage Replicas | Use Case |
+|----------|---------------|---------|----------|-----------------|----------|
+| `ha` | 3 (recommended) | 1+ | Yes (on-prem) | 3 | Production |
+| `single-node` | 1 (schedulable) | 0 | Skipped | 1 | Dev, testing, edge |
 
-| Topology | Control Planes | Workers | Use Case |
-|----------|---------------|---------|----------|
-| `ha` | 3 | 0-N | Production |
-| `single-node` | 1 (schedulable) | 0 | Edge, dev, testing |
+Single-node topology skips kube-vip (no HA needed with one node), forces Longhorn replica count to 1, and skips the pivoting phase.
 
 ## Troubleshooting
 
 ### Common Issues
 
 **VMs not provisioning:**
-- Check provider credentials
-- Verify network connectivity
-- Check MachineRequest status: `kubectl get machinerequest -A`
+- Check provider credentials in the ProviderConfig Secret
+- Verify network connectivity from KIND to the infrastructure API
+- Check MachineRequest status: `kubectl get mr -n butler-system`
+- Review provider controller logs: `kubectl logs -n butler-system deploy/butler-provider-*`
 
 **Talos bootstrap failing:**
-- Verify control plane endpoint IP is correct
-- Check Talos API connectivity
-- Review Talos logs: `talosctl logs -n <node-ip>`
+- Verify control plane endpoint is reachable from nodes
+- Check Talos API connectivity: `talosctl --nodes <ip> version --insecure`
+- Review Talos logs: `talosctl --nodes <ip> logs -f`
 
 **Addon installation failing:**
-- Check Helm release status
-- Verify storage class availability (for stateful addons)
-- Check pod logs in addon namespace
+- Check Helm release status on the management cluster
+- Verify CNI is healthy before checking later addons (everything depends on Cilium)
+- Check pod logs in the addon's namespace
 
-### Debug Mode
+**Cloud LB not provisioning:**
+- Check LoadBalancerRequest status: `kubectl get lbr -n butler-system`
+- Verify cloud API permissions (compute admin or equivalent)
+- Check quota limits (static IPs, forwarding rules, NLBs)
+- Review provider controller logs for API errors
 
-Use `--verbose` for detailed output:
-
-```bash
-butleradm bootstrap harvester --config bootstrap.yaml --verbose
-```
+**Cloud LB health check failures:**
+- Verify firewall rules allow TCP 6443 from health check source ranges
+- GCP health checks come from `130.211.0.0/22` and `35.191.0.0/16`
+- AWS NLB health checks come from within the VPC
+- Confirm kube-apiserver is listening on port 6443
 
 ### Preserving KIND Cluster
 
-Use `--keep-kind` to preserve the bootstrap cluster for debugging:
+Use `--skip-cleanup` to preserve the bootstrap cluster for debugging:
 
 ```bash
-butleradm bootstrap harvester --config bootstrap.yaml --keep-kind
+butleradm bootstrap harvester --config bootstrap.yaml --skip-cleanup
 ```
 
 Then inspect:
 
 ```bash
-kubectl --context kind-butler-bootstrap get clusterbootstrap -A
-kubectl --context kind-butler-bootstrap get machinerequest -A
+kubectl --context kind-butler-bootstrap get cb -n butler-system
+kubectl --context kind-butler-bootstrap get mr -n butler-system
+kubectl --context kind-butler-bootstrap get lbr -n butler-system  # cloud only
+```
+
+### Dry Run
+
+Use `--dry-run` to validate the config and see what resources would be created without executing:
+
+```bash
+butleradm bootstrap gcp --config bootstrap.yaml --dry-run
 ```
 
 ## See Also
 
-- [Getting Started](../getting-started/) - Quick start guide
-- [Tenant Lifecycle](tenant-lifecycle.md) - How tenant clusters are created
-- [Provider Guides](../providers/) - Infrastructure-specific setup
+- [ClusterBootstrap CRD](../reference/crds/clusterbootstrap.md) -- full spec reference
+- [LoadBalancerRequest CRD](../reference/crds/loadbalancerrequest.md) -- cloud LB provisioning
+- [MachineRequest CRD](../reference/crds/machinerequest.md) -- VM provisioning interface
+- [Provider Guides](../providers/) -- per-provider setup and configuration
+- [Getting Started](../getting-started/) -- quick start guide

--- a/docs/architecture/bootstrap-flow.md
+++ b/docs/architecture/bootstrap-flow.md
@@ -347,8 +347,8 @@ butleradm bootstrap gcp --config bootstrap.yaml --dry-run
 
 ## See Also
 
-- [ClusterBootstrap CRD](../reference/crds/clusterbootstrap.md) -- full spec reference
-- [LoadBalancerRequest CRD](../reference/crds/loadbalancerrequest.md) -- cloud LB provisioning
-- [MachineRequest CRD](../reference/crds/machinerequest.md) -- VM provisioning interface
-- [Provider Guides](../providers/) -- per-provider setup and configuration
-- [Getting Started](../getting-started/) -- quick start guide
+- [ClusterBootstrap CRD](../reference/crds/clusterbootstrap.md) - full spec reference
+- [LoadBalancerRequest CRD](../reference/crds/loadbalancerrequest.md) - cloud LB provisioning
+- [MachineRequest CRD](../reference/crds/machinerequest.md) - VM provisioning interface
+- [Provider Guides](../providers/) - per-provider setup and configuration
+- [Getting Started](../getting-started/) - quick start guide

--- a/docs/architecture/bootstrap-flow.md
+++ b/docs/architecture/bootstrap-flow.md
@@ -125,19 +125,15 @@ sequenceDiagram
     end
 
     rect rgb(230, 245, 255)
-        Note over Bootstrap,Cloud: Phase 2: VM Provisioning
-        Bootstrap->>Provider: Create MachineRequest CRs
-        Provider->>Cloud: Create VMs in VPC subnet
-        Cloud-->>Provider: VMs running with IPs
-        Provider->>Provider: Update MachineRequest status
-    end
-
-    rect rgb(255, 230, 230)
-        Note over Bootstrap,Cloud: Phase 2b: Load Balancer Provisioning
+        Note over Bootstrap,Cloud: Phase 2: Infrastructure Provisioning
         Bootstrap->>KIND: Create LoadBalancerRequest CR
-        Provider->>Cloud: Create static IP, health check, target pool, forwarding rule
+        Bootstrap->>Provider: Create MachineRequest CRs
+        Provider->>Cloud: Provision cloud load balancer resources
+        Provider->>Cloud: Create VMs in VPC subnet
         Cloud-->>Provider: LB ready with endpoint IP
+        Cloud-->>Provider: VMs running with IPs
         Provider->>KIND: Update LoadBalancerRequest status (endpoint)
+        Provider->>Provider: Update MachineRequest status
         Bootstrap->>Bootstrap: Use LB endpoint as control plane address
     end
 

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -17,8 +17,8 @@ Butler supports multiple infrastructure providers for provisioning management an
 | Provider | Platform | Status | Documentation |
 |----------|----------|--------|---------------|
 | GCP | Google Cloud Platform | Beta | [gcp.md](gcp.md) |
-| AWS | Amazon Web Services | Beta | [aws.md](aws.md) |
-| Azure | Microsoft Azure | Beta | [azure.md](azure.md) |
+| AWS | Amazon Web Services | In Progress | [aws.md](aws.md) |
+| Azure | Microsoft Azure | In Progress | [azure.md](azure.md) |
 
 ## Provider Architecture
 

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -1,51 +1,86 @@
 # Infrastructure Providers
 
-Butler supports multiple infrastructure providers for provisioning cluster nodes.
+Butler supports multiple infrastructure providers for provisioning management and tenant cluster nodes.
 
 ## Supported Providers
+
+### On-Prem
 
 | Provider | Platform | Status | Documentation |
 |----------|----------|--------|---------------|
 | Harvester | Harvester HCI | Stable | [harvester.md](harvester.md) |
 | Nutanix | Nutanix AHV | Stable | [nutanix.md](nutanix.md) |
 | Proxmox | Proxmox VE | Planned | Coming soon |
-| AWS | Amazon Web Services | Roadmap | - |
-| Azure | Microsoft Azure | Roadmap | - |
-| GCP | Google Cloud Platform | Roadmap | - |
+
+### Cloud
+
+| Provider | Platform | Status | Documentation |
+|----------|----------|--------|---------------|
+| GCP | Google Cloud Platform | Beta | [gcp.md](gcp.md) |
+| AWS | Amazon Web Services | Beta | [aws.md](aws.md) |
+| Azure | Microsoft Azure | Beta | [azure.md](azure.md) |
 
 ## Provider Architecture
+
+Butler uses a two-layer provider model:
+
+- **Bootstrap layer**: Thin provider controllers (`butler-provider-*`) handle MachineRequest CRDs during management cluster bootstrap. Each controller calls the provider SDK to launch VMs, polls for IPs, and reports back. The same pattern applies across all six providers.
+- **Steady-state layer**: Official CAPI infrastructure providers (CAPK, CAPA, CAPZ, CAPG) manage tenant cluster worker VM lifecycle after the management cluster is running.
 
 ```mermaid
 flowchart TB
     subgraph Butler["Butler Platform"]
         Controller["butler-controller"]
+        Bootstrap["butler-bootstrap"]
         TC[TenantCluster CR]
+        CB[ClusterBootstrap CR]
         CAPI[Cluster API]
     end
-    
-    subgraph Providers["Provider Controllers"]
+
+    subgraph OnPrem["On-Prem Providers"]
         PH["butler-provider-harvester"]
         PN["butler-provider-nutanix"]
         PP["butler-provider-proxmox"]
     end
-    
+
+    subgraph Cloud["Cloud Providers"]
+        PG["butler-provider-gcp"]
+        PA["butler-provider-aws"]
+        PZ["butler-provider-azure"]
+    end
+
     subgraph Infrastructure["Infrastructure"]
         Harvester["Harvester HCI"]
         Nutanix["Nutanix AHV"]
         Proxmox["Proxmox VE"]
+        GCP["Google Cloud"]
+        AWS["Amazon Web Services"]
+        Azure["Microsoft Azure"]
     end
-    
+
+    CB --> Bootstrap
     TC --> Controller
     Controller --> CAPI
-    
-    CAPI --> PH
-    CAPI --> PN
-    CAPI --> PP
-    
+    Bootstrap --> PH & PN & PP & PG & PA & PZ
+
+    CAPI --> PH & PN & PP & PG & PA & PZ
+
     PH --> Harvester
     PN --> Nutanix
     PP --> Proxmox
+    PG --> GCP
+    PA --> AWS
+    PZ --> Azure
 ```
+
+## On-Prem vs Cloud Differences
+
+| Aspect | On-Prem | Cloud |
+|--------|---------|-------|
+| Control plane HA | kube-vip (floating VIP) | Cloud L4 load balancer (via [LoadBalancerRequest](../reference/crds/loadbalancerrequest.md)) |
+| MetalLB | Installed for LoadBalancer services | Not needed (cloud LBs) |
+| Network mode | `ipam` (Butler manages IP allocation) | `cloud` (cloud networking, no IPAM) |
+| VM images | Uploaded to infrastructure (Harvester image, Nutanix disk image) | Imported as cloud image (GCE image, AMI, managed image) |
 
 ## Provider Selection
 
@@ -71,11 +106,14 @@ kind: ProviderConfig
 metadata:
   name: harvester-prod
 spec:
-  type: harvester
+  provider: harvester
+  credentialsRef:
+    name: harvester-kubeconfig
+    namespace: butler-system
+  network:
+    mode: ipam
   harvester:
-    credentialsRef:
-      name: harvester-kubeconfig
-      namespace: butler-system
+    endpoint: "https://harvester.example.com"
     namespace: default
     networkName: default/workloads
     imageName: default/talos-1.9
@@ -86,8 +124,8 @@ spec:
 See the [Contributing Guide](../contributing/) for information on adding new providers.
 
 Requirements for new providers:
-1. Implement the provider controller interface
-2. Create ProviderConfig schema
-3. Integration with Cluster API
-4. Documentation
-5. CI/CD pipeline
+1. Implement the provider controller interface (watch MachineRequest, create VMs, report IPs)
+2. Add provider-specific config types to `butler-api/api/v1alpha1/providerconfig_types.go`
+3. Integration with Cluster API (InfrastructureMachineTemplate generation in `butler-controller/internal/capi/builder.go`)
+4. Documentation (provider guide following the existing pattern)
+5. CI/CD pipeline (GitHub Actions for build, test, release)

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -1,0 +1,354 @@
+# AWS Provider Guide
+
+This guide covers setting up Butler with Amazon Web Services as the infrastructure provider for management cluster bootstrap.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [AWS Setup](#aws-setup)
+- [Butler Configuration](#butler-configuration)
+- [Network Architecture](#network-architecture)
+- [Load Balancer Resources](#load-balancer-resources)
+- [Resource Recommendations](#resource-recommendations)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+Butler uses a thin provider controller (`butler-provider-aws`) to provision EC2 instances running Talos Linux. The controller creates instances in the specified VPC/subnet and reports their IPs back to the bootstrap controller.
+
+For control plane HA, the bootstrap controller creates a LoadBalancerRequest, and the AWS provider provisions a Network Load Balancer (NLB) with a TCP target group and listener on port 6443.
+
+```mermaid
+flowchart LR
+    CLI["butleradm"] --> KIND["KIND Cluster"]
+    KIND --> Bootstrap["butler-bootstrap"]
+    KIND --> AWSProvider["butler-provider-aws"]
+    Bootstrap --> MR["MachineRequest CRs"]
+    Bootstrap --> LBR["LoadBalancerRequest CR"]
+    AWSProvider --> EC2["EC2 Instances"]
+    AWSProvider --> NLB["Network Load Balancer"]
+```
+
+### Key Components
+
+| Component | Purpose |
+|-----------|---------|
+| butler-provider-aws | Provisions EC2 instances and NLB resources |
+| CAPI AWS Provider (CAPA) | Manages tenant cluster worker instances after bootstrap |
+
+---
+
+## Prerequisites
+
+### AWS Account
+
+- An AWS account with access to the target region
+- EC2 and Elastic Load Balancing APIs enabled
+
+### IAM User or Role
+
+An IAM user (or role) with permissions for:
+- EC2: instances, security groups, key pairs, AMIs, EBS volumes
+- Elastic Load Balancing v2: NLBs, target groups, listeners
+- VPC: subnets, route tables (read-only)
+
+A suitable managed policy combination:
+- `AmazonEC2FullAccess`
+- `ElasticLoadBalancingFullAccess`
+
+Or use a custom IAM policy scoped to the required resources.
+
+### Networking
+
+- A VPC with at least one public subnet (instances need reachability from the bootstrap machine)
+- A security group allowing required ports (see [Network Architecture](#network-architecture))
+- Sufficient Elastic IP quota if using static public IPs
+
+### Talos AMI
+
+A Talos Linux AMI must be available in the target region. Import from the official Talos releases or use the Talos Image Factory to produce a custom AMI.
+
+---
+
+## AWS Setup
+
+### 1. Create IAM User
+
+```bash
+# Create IAM user
+aws iam create-user --user-name butler-bootstrap
+
+# Attach required policies
+aws iam attach-user-policy --user-name butler-bootstrap \
+  --policy-arn arn:aws:iam::aws:policy/AmazonEC2FullAccess
+aws iam attach-user-policy --user-name butler-bootstrap \
+  --policy-arn arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess
+
+# Create access key
+aws iam create-access-key --user-name butler-bootstrap
+```
+
+Save the `AccessKeyId` and `SecretAccessKey` from the output.
+
+### 2. Create Security Group
+
+```bash
+# Create security group
+SG_ID=$(aws ec2 create-security-group \
+  --group-name butler-bootstrap \
+  --description "Butler bootstrap cluster" \
+  --vpc-id vpc-XXXXX \
+  --query 'GroupId' --output text)
+
+# Allow inter-node traffic (self-referencing)
+aws ec2 authorize-security-group-ingress --group-id $SG_ID \
+  --protocol tcp --port 6443 --source-group $SG_ID
+aws ec2 authorize-security-group-ingress --group-id $SG_ID \
+  --protocol tcp --port 50000-50001 --source-group $SG_ID
+aws ec2 authorize-security-group-ingress --group-id $SG_ID \
+  --protocol tcp --port 2379-2380 --source-group $SG_ID
+aws ec2 authorize-security-group-ingress --group-id $SG_ID \
+  --protocol tcp --port 10250 --source-group $SG_ID
+
+# Allow kube-apiserver access from anywhere (for LB and external access)
+aws ec2 authorize-security-group-ingress --group-id $SG_ID \
+  --protocol tcp --port 6443 --cidr 0.0.0.0/0
+
+# Allow SSH (optional, for debugging)
+aws ec2 authorize-security-group-ingress --group-id $SG_ID \
+  --protocol tcp --port 22 --cidr YOUR_IP/32
+```
+
+### 3. Import Talos AMI (if needed)
+
+```bash
+# Download Talos AWS image
+wget https://factory.talos.dev/image/SCHEMATIC_ID/vX.Y.Z/aws-amd64.raw.xz
+
+# Upload to S3 and import as AMI
+aws s3 cp talos-vX.Y.Z.raw.xz s3://BUCKET/talos-vX.Y.Z.raw.xz
+
+aws ec2 import-image \
+  --disk-containers "Description=Talos vX.Y.Z,Format=raw,Url=s3://BUCKET/talos-vX.Y.Z.raw.xz"
+```
+
+---
+
+## Butler Configuration
+
+### ProviderConfig
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-credentials
+  namespace: butler-system
+type: Opaque
+stringData:
+  access-key-id: "AKIAIOSFODNN7EXAMPLE"
+  secret-access-key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+---
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: aws-prod
+  namespace: butler-system
+spec:
+  provider: aws
+  credentialsRef:
+    name: aws-credentials
+    namespace: butler-system
+  network:
+    mode: cloud
+  aws:
+    region: us-east-1
+    vpcID: vpc-0abcdef1234567890
+    subnetIDs:
+      - subnet-0abcdef1234567890
+    securityGroupIDs:
+      - sg-0abcdef1234567890
+```
+
+### Bootstrap Config
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ClusterBootstrap
+metadata:
+  name: butler-mgmt
+  namespace: butler-system
+spec:
+  provider: aws
+  providerRef:
+    name: aws-prod
+    namespace: butler-system
+
+  cluster:
+    name: butler-mgmt
+    topology: ha
+    controlPlane:
+      replicas: 3
+      cpu: 4
+      memoryMB: 16384
+      diskGB: 100
+    workers:
+      replicas: 3
+      cpu: 8
+      memoryMB: 32768
+      diskGB: 200
+
+  network:
+    podCIDR: 10.244.0.0/16
+    serviceCIDR: 10.96.0.0/12
+
+  talos:
+    version: v1.9.2
+    schematic: ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515
+
+  addons:
+    cni:
+      type: cilium
+    storage:
+      type: longhorn
+    controlPlaneProvider:
+      type: steward
+    capi:
+      enabled: true
+      infrastructureProviders:
+        - name: aws
+
+  controlPlaneExposure:
+    mode: LoadBalancer
+```
+
+### Run Bootstrap
+
+```bash
+butleradm bootstrap aws --config bootstrap.yaml
+```
+
+---
+
+## Network Architecture
+
+```mermaid
+flowchart TB
+    subgraph AWS["AWS Account"]
+        subgraph VPC["VPC"]
+            subgraph Subnet["Public Subnet (us-east-1a)"]
+                CP0["CP-0<br/>10.0.1.10"]
+                CP1["CP-1<br/>10.0.1.11"]
+                CP2["CP-2<br/>10.0.1.12"]
+                W0["Worker-0<br/>10.0.1.20"]
+                W1["Worker-1<br/>10.0.1.21"]
+                W2["Worker-2<br/>10.0.1.22"]
+            end
+            SG["Security Group"]
+        end
+        NLB["Network Load Balancer<br/>butler-mgmt-nlb-xxx.elb.amazonaws.com:6443"]
+    end
+
+    Internet["External Access"] --> NLB
+    NLB --> CP0
+    NLB --> CP1
+    NLB --> CP2
+    SG -.-> Subnet
+```
+
+### Security Group Rules
+
+| Direction | Protocol/Port | Source/Destination | Purpose |
+|-----------|--------------|-------------------|---------|
+| Inbound | TCP 6443 | 0.0.0.0/0 | Kubernetes API (external + NLB health checks) |
+| Inbound | TCP 50000-50001 | Self | Talos API (apid + trustd) |
+| Inbound | TCP 2379-2380 | Self | etcd client and peer |
+| Inbound | TCP 10250 | Self | kubelet API |
+
+NLB health checks originate from within the VPC, so the `0.0.0.0/0` rule on port 6443 covers both external access and health check traffic.
+
+---
+
+## Load Balancer Resources
+
+When the bootstrap controller creates a LoadBalancerRequest with `provider: aws`, the AWS provider controller creates:
+
+| AWS Resource | Purpose |
+|--------------|---------|
+| Network Load Balancer | Regional L4 load balancer in the VPC |
+| Target group (TCP 6443) | Groups the control plane EC2 instances |
+| Listener (TCP 6443) | Routes traffic from NLB to the target group |
+
+The NLB uses TCP passthrough. The NLB DNS name (e.g., `butler-mgmt-nlb-xxx.elb.us-east-1.amazonaws.com`) is reported as the LoadBalancerRequest endpoint and used as the control plane address.
+
+Target registration uses instance IDs (`LoadBalancerTarget.instanceID`).
+
+---
+
+## Resource Recommendations
+
+| Profile | CP Nodes | CP Instance Type | Worker Nodes | Worker Instance Type | Estimated Monthly Cost |
+|---------|----------|-----------------|-------------|---------------------|----------------------|
+| Development | 1 (single-node) | m6i.xlarge (4 vCPU, 16 GB) | 0 | -- | ~$150 |
+| Staging | 3 | m6i.xlarge (4 vCPU, 16 GB) | 2 | m6i.2xlarge (8 vCPU, 32 GB) | ~$950 |
+| Production | 3 | m6i.xlarge (4 vCPU, 16 GB) | 3+ | m6i.2xlarge (8 vCPU, 32 GB) | ~$1,300+ |
+
+NLB pricing: NLB charges per hour plus per LCU (Load Balancer Capacity Unit). For a management cluster with low traffic, expect approximately $20/month.
+
+---
+
+## Troubleshooting
+
+### Security Group Rules Missing
+
+**Symptom**: Talos bootstrap times out. Nodes cannot communicate on required ports.
+
+**Verify**:
+```bash
+aws ec2 describe-security-groups --group-ids sg-XXXXX \
+  --query "SecurityGroups[0].IpPermissions"
+```
+
+### IAM Permissions Insufficient
+
+**Symptom**: Provider controller logs show `UnauthorizedOperation` errors.
+
+**Verify**:
+```bash
+aws iam simulate-principal-policy \
+  --policy-source-arn arn:aws:iam::ACCOUNT:user/butler-bootstrap \
+  --action-names ec2:RunInstances elasticloadbalancing:CreateLoadBalancer
+```
+
+### NLB Target Health Failures
+
+**Symptom**: LoadBalancerRequest stuck in `Creating` phase. Target group shows unhealthy targets.
+
+**Verify**:
+```bash
+aws elbv2 describe-target-health \
+  --target-group-arn arn:aws:elasticloadbalancing:REGION:ACCOUNT:targetgroup/butler-mgmt/XXXXX
+```
+
+**Common causes:**
+- Security group does not allow TCP 6443 from VPC CIDR
+- kube-apiserver not yet listening (bootstrap still in progress)
+- Instance not registered in the correct target group
+
+### Subnet Not Public
+
+**Symptom**: Instances created but not reachable from the bootstrap machine.
+
+Instances need a route to the internet (via IGW) for the KIND cluster to reach the Talos API during bootstrap. Use a public subnet with auto-assign public IP, or set up a bastion/VPN.
+
+---
+
+## See Also
+
+- [Bootstrap Flow](../architecture/bootstrap-flow.md) -- end-to-end bootstrap sequence
+- [ClusterBootstrap CRD](../reference/crds/clusterbootstrap.md) -- full spec reference
+- [LoadBalancerRequest CRD](../reference/crds/loadbalancerrequest.md) -- cloud LB provisioning
+- [ProviderConfig CRD](../reference/crds/providerconfig.md) -- provider credentials

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -1,5 +1,7 @@
 # AWS Provider Guide
 
+> **Status: In Progress.** Cloud provider support is in active development. The CRD types, bootstrap controller integration, and CLI commands are implemented. The provider controller (`butler-provider-aws`) is not yet released. This guide describes the target architecture.
+
 This guide covers setting up Butler with Amazon Web Services as the infrastructure provider for management cluster bootstrap.
 
 ## Table of Contents
@@ -348,7 +350,7 @@ Instances need a route to the internet (via IGW) for the KIND cluster to reach t
 
 ## See Also
 
-- [Bootstrap Flow](../architecture/bootstrap-flow.md) -- end-to-end bootstrap sequence
-- [ClusterBootstrap CRD](../reference/crds/clusterbootstrap.md) -- full spec reference
-- [LoadBalancerRequest CRD](../reference/crds/loadbalancerrequest.md) -- cloud LB provisioning
-- [ProviderConfig CRD](../reference/crds/providerconfig.md) -- provider credentials
+- [Bootstrap Flow](../architecture/bootstrap-flow.md) - end-to-end bootstrap sequence
+- [ClusterBootstrap CRD](../reference/crds/clusterbootstrap.md) - full spec reference
+- [LoadBalancerRequest CRD](../reference/crds/loadbalancerrequest.md) - cloud LB provisioning
+- [ProviderConfig CRD](../reference/crds/providerconfig.md) - provider credentials

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -1,5 +1,7 @@
 # Azure Provider Guide
 
+> **Status: In Progress.** Cloud provider support is in active development. The CRD types, bootstrap controller integration, and CLI commands are implemented. The provider controller (`butler-provider-azure`) is not yet released. This guide describes the target architecture.
+
 This guide covers setting up Butler with Microsoft Azure as the infrastructure provider for management cluster bootstrap.
 
 ## Table of Contents
@@ -397,7 +399,7 @@ az ad sp credential reset --id APP_ID
 
 ## See Also
 
-- [Bootstrap Flow](../architecture/bootstrap-flow.md) -- end-to-end bootstrap sequence
-- [ClusterBootstrap CRD](../reference/crds/clusterbootstrap.md) -- full spec reference
-- [LoadBalancerRequest CRD](../reference/crds/loadbalancerrequest.md) -- cloud LB provisioning
-- [ProviderConfig CRD](../reference/crds/providerconfig.md) -- provider credentials
+- [Bootstrap Flow](../architecture/bootstrap-flow.md) - end-to-end bootstrap sequence
+- [ClusterBootstrap CRD](../reference/crds/clusterbootstrap.md) - full spec reference
+- [LoadBalancerRequest CRD](../reference/crds/loadbalancerrequest.md) - cloud LB provisioning
+- [ProviderConfig CRD](../reference/crds/providerconfig.md) - provider credentials

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -1,0 +1,403 @@
+# Azure Provider Guide
+
+This guide covers setting up Butler with Microsoft Azure as the infrastructure provider for management cluster bootstrap.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Azure Setup](#azure-setup)
+- [Butler Configuration](#butler-configuration)
+- [Network Architecture](#network-architecture)
+- [Load Balancer Resources](#load-balancer-resources)
+- [Resource Recommendations](#resource-recommendations)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+Butler uses a thin provider controller (`butler-provider-azure`) to provision VMs on Azure Compute. The controller creates VM instances with Talos Linux images and reports their IPs back to the bootstrap controller.
+
+For control plane HA, the bootstrap controller creates a LoadBalancerRequest, and the Azure provider provisions a Standard Load Balancer with a public IP, health probe, and load balancing rule on port 6443.
+
+```mermaid
+flowchart LR
+    CLI["butleradm"] --> KIND["KIND Cluster"]
+    KIND --> Bootstrap["butler-bootstrap"]
+    KIND --> AzureProvider["butler-provider-azure"]
+    Bootstrap --> MR["MachineRequest CRs"]
+    Bootstrap --> LBR["LoadBalancerRequest CR"]
+    AzureProvider --> AzureVM["Azure VMs"]
+    AzureProvider --> LB["Standard Load Balancer"]
+```
+
+### Key Components
+
+| Component | Purpose |
+|-----------|---------|
+| butler-provider-azure | Provisions Azure VMs and Standard Load Balancer resources |
+| CAPI Azure Provider (CAPZ) | Manages tenant cluster worker VMs after bootstrap |
+
+---
+
+## Prerequisites
+
+### Azure Subscription
+
+- An Azure subscription with sufficient quota
+- Microsoft.Compute and Microsoft.Network resource providers registered
+
+### Service Principal
+
+A service principal with `Contributor` role on the resource group (or subscription).
+
+### Networking
+
+- A resource group in the target region
+- A VNet with at least one subnet
+- A Network Security Group (NSG) allowing required ports (see [Network Architecture](#network-architecture))
+
+### Talos Image
+
+A Talos Linux image must be available as a managed image or in a Shared Image Gallery in the target subscription. Use the Talos Image Factory or import from official releases.
+
+---
+
+## Azure Setup
+
+### 1. Create Service Principal
+
+```bash
+# Create service principal with Contributor role scoped to a resource group
+az ad sp create-for-rbac \
+  --name butler-bootstrap \
+  --role Contributor \
+  --scopes /subscriptions/SUBSCRIPTION_ID/resourceGroups/butler-rg
+```
+
+Save the output (`appId`, `password`, `tenant`).
+
+### 2. Create Resource Group and VNet
+
+```bash
+# Create resource group
+az group create --name butler-rg --location eastus
+
+# Create VNet and subnet
+az network vnet create \
+  --resource-group butler-rg \
+  --name butler-vnet \
+  --address-prefix 10.0.0.0/16 \
+  --subnet-name butler-subnet \
+  --subnet-prefix 10.0.0.0/24
+```
+
+### 3. Create Network Security Group
+
+```bash
+# Create NSG
+az network nsg create \
+  --resource-group butler-rg \
+  --name butler-nsg
+
+# Allow kube-apiserver (external + LB health probes)
+az network nsg rule create \
+  --resource-group butler-rg \
+  --nsg-name butler-nsg \
+  --name allow-apiserver \
+  --priority 100 \
+  --access Allow \
+  --protocol Tcp \
+  --destination-port-ranges 6443 \
+  --source-address-prefixes '*'
+
+# Allow inter-node Talos API
+az network nsg rule create \
+  --resource-group butler-rg \
+  --nsg-name butler-nsg \
+  --name allow-talos \
+  --priority 200 \
+  --access Allow \
+  --protocol Tcp \
+  --destination-port-ranges 50000-50001 \
+  --source-address-prefixes 10.0.0.0/24
+
+# Allow etcd peer and client
+az network nsg rule create \
+  --resource-group butler-rg \
+  --nsg-name butler-nsg \
+  --name allow-etcd \
+  --priority 300 \
+  --access Allow \
+  --protocol Tcp \
+  --destination-port-ranges 2379-2380 \
+  --source-address-prefixes 10.0.0.0/24
+
+# Allow kubelet API
+az network nsg rule create \
+  --resource-group butler-rg \
+  --nsg-name butler-nsg \
+  --name allow-kubelet \
+  --priority 400 \
+  --access Allow \
+  --protocol Tcp \
+  --destination-port-ranges 10250 \
+  --source-address-prefixes 10.0.0.0/24
+
+# Associate NSG with subnet
+az network vnet subnet update \
+  --resource-group butler-rg \
+  --vnet-name butler-vnet \
+  --name butler-subnet \
+  --network-security-group butler-nsg
+```
+
+### 4. Upload Talos Image (if needed)
+
+```bash
+# Download Talos Azure image
+wget https://factory.talos.dev/image/SCHEMATIC_ID/vX.Y.Z/azure-amd64.vhd.xz
+
+# Create managed image
+az image create \
+  --resource-group butler-rg \
+  --name talos-vX-Y-Z \
+  --os-type Linux \
+  --source PATH_TO_VHD
+```
+
+---
+
+## Butler Configuration
+
+### ProviderConfig
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-credentials
+  namespace: butler-system
+type: Opaque
+stringData:
+  client-id: "APP_ID"
+  client-secret: "PASSWORD"
+  tenant-id: "TENANT_ID"
+  subscription-id: "SUBSCRIPTION_ID"
+---
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: azure-prod
+  namespace: butler-system
+spec:
+  provider: azure
+  credentialsRef:
+    name: azure-credentials
+    namespace: butler-system
+  network:
+    mode: cloud
+  azure:
+    subscriptionID: "SUBSCRIPTION_ID"
+    resourceGroup: butler-rg
+    location: eastus
+    vnetName: butler-vnet
+    subnetName: butler-subnet
+```
+
+### Bootstrap Config
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ClusterBootstrap
+metadata:
+  name: butler-mgmt
+  namespace: butler-system
+spec:
+  provider: azure
+  providerRef:
+    name: azure-prod
+    namespace: butler-system
+
+  cluster:
+    name: butler-mgmt
+    topology: ha
+    controlPlane:
+      replicas: 3
+      cpu: 4
+      memoryMB: 16384
+      diskGB: 100
+    workers:
+      replicas: 3
+      cpu: 8
+      memoryMB: 32768
+      diskGB: 200
+
+  network:
+    podCIDR: 10.244.0.0/16
+    serviceCIDR: 10.96.0.0/12
+
+  talos:
+    version: v1.9.2
+    schematic: ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515
+
+  addons:
+    cni:
+      type: cilium
+    storage:
+      type: longhorn
+    controlPlaneProvider:
+      type: steward
+    capi:
+      enabled: true
+      infrastructureProviders:
+        - name: azure
+
+  controlPlaneExposure:
+    mode: LoadBalancer
+```
+
+### Run Bootstrap
+
+```bash
+butleradm bootstrap azure --config bootstrap.yaml
+```
+
+---
+
+## Network Architecture
+
+```mermaid
+flowchart TB
+    subgraph Azure["Azure Subscription"]
+        subgraph RG["Resource Group (butler-rg)"]
+            subgraph VNet["VNet (butler-vnet)"]
+                subgraph Subnet["Subnet (butler-subnet)"]
+                    CP0["CP-0<br/>10.0.0.4"]
+                    CP1["CP-1<br/>10.0.0.5"]
+                    CP2["CP-2<br/>10.0.0.6"]
+                    W0["Worker-0<br/>10.0.0.10"]
+                    W1["Worker-1<br/>10.0.0.11"]
+                    W2["Worker-2<br/>10.0.0.12"]
+                end
+            end
+            NSG["Network Security Group"]
+            LB["Standard Load Balancer<br/>20.185.XXX.XXX:6443"]
+        end
+    end
+
+    Internet["External Access"] --> LB
+    LB --> CP0
+    LB --> CP1
+    LB --> CP2
+    NSG -.-> Subnet
+```
+
+### NSG Rules
+
+| Priority | Direction | Protocol/Port | Source | Purpose |
+|----------|-----------|--------------|--------|---------|
+| 100 | Inbound | TCP 6443 | * | Kubernetes API (external + LB probes) |
+| 200 | Inbound | TCP 50000-50001 | 10.0.0.0/24 | Talos API (apid + trustd) |
+| 300 | Inbound | TCP 2379-2380 | 10.0.0.0/24 | etcd client and peer |
+| 400 | Inbound | TCP 10250 | 10.0.0.0/24 | kubelet API |
+
+Azure Standard Load Balancer health probes originate from the IP `168.63.129.16`. The wildcard source on the TCP 6443 rule covers both external access and health probe traffic.
+
+---
+
+## Load Balancer Resources
+
+When the bootstrap controller creates a LoadBalancerRequest with `provider: azure`, the Azure provider controller creates:
+
+| Azure Resource | Purpose |
+|----------------|---------|
+| Public IP address | Stable external IP for the control plane endpoint |
+| Standard Load Balancer | Regional L4 load balancer |
+| Health probe (TCP 6443) | Checks kube-apiserver availability on each CP node |
+| Load balancing rule (TCP 6443) | Routes traffic to the backend pool |
+| Backend address pool | Groups the control plane VM NICs |
+
+The Standard Load Balancer uses TCP passthrough (no TLS termination). Backend VMs are added directly by their NIC (using IP addresses from `LoadBalancerTarget.ip`).
+
+The public IP is reported as the LoadBalancerRequest endpoint and used as the control plane address.
+
+---
+
+## Resource Recommendations
+
+| Profile | CP Nodes | CP VM Size | Worker Nodes | Worker VM Size | Estimated Monthly Cost |
+|---------|----------|-----------|-------------|---------------|----------------------|
+| Development | 1 (single-node) | Standard_D4s_v5 (4 vCPU, 16 GB) | 0 | -- | ~$150 |
+| Staging | 3 | Standard_D4s_v5 (4 vCPU, 16 GB) | 2 | Standard_D8s_v5 (8 vCPU, 32 GB) | ~$1,000 |
+| Production | 3 | Standard_D4s_v5 (4 vCPU, 16 GB) | 3+ | Standard_D8s_v5 (8 vCPU, 32 GB) | ~$1,400+ |
+
+Standard Load Balancer pricing: fixed hourly charge plus per-rule charge. For a management cluster with a single rule, expect approximately $25/month.
+
+---
+
+## Troubleshooting
+
+### NSG Rules Blocking Traffic
+
+**Symptom**: Talos bootstrap times out. Nodes cannot communicate.
+
+**Verify**:
+```bash
+az network nsg rule list \
+  --resource-group butler-rg \
+  --nsg-name butler-nsg \
+  --output table
+```
+
+### Quota Limits
+
+**Symptom**: MachineRequest stuck in `Creating` with quota error.
+
+**Common quotas to check:**
+- `Total Regional vCPUs` (default varies by subscription type)
+- `Standard Dv5 Family vCPUs` (or whichever family is used)
+- `Public IP Addresses - Standard` (default: 10 per region)
+
+**Check**:
+```bash
+az vm list-usage --location eastus --output table
+```
+
+**Fix**: Request quota increase in the Azure Portal under Subscription > Usage + quotas.
+
+### LB Health Probe Failures
+
+**Symptom**: LoadBalancerRequest stuck in `Creating` phase.
+
+**Verify**:
+```bash
+az network lb probe show \
+  --resource-group butler-rg \
+  --lb-name butler-mgmt-lb \
+  --name butler-mgmt-probe
+```
+
+**Common causes:**
+- NSG blocks TCP 6443 from the health probe source IP (`168.63.129.16`)
+- kube-apiserver not yet listening (bootstrap still in progress)
+- Backend pool has no associated NICs
+
+### Service Principal Expired
+
+**Symptom**: Provider controller logs show `AADSTS7000215: Invalid client secret`.
+
+**Fix**: Create a new client secret and update the credentials Secret:
+```bash
+az ad sp credential reset --id APP_ID
+```
+
+---
+
+## See Also
+
+- [Bootstrap Flow](../architecture/bootstrap-flow.md) -- end-to-end bootstrap sequence
+- [ClusterBootstrap CRD](../reference/crds/clusterbootstrap.md) -- full spec reference
+- [LoadBalancerRequest CRD](../reference/crds/loadbalancerrequest.md) -- cloud LB provisioning
+- [ProviderConfig CRD](../reference/crds/providerconfig.md) -- provider credentials

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -1,0 +1,365 @@
+# GCP Provider Guide
+
+This guide covers setting up Butler with Google Cloud Platform as the infrastructure provider for management cluster bootstrap.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [GCP Setup](#gcp-setup)
+- [Butler Configuration](#butler-configuration)
+- [Network Architecture](#network-architecture)
+- [Load Balancer Resources](#load-balancer-resources)
+- [Resource Recommendations](#resource-recommendations)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+Butler uses a thin provider controller (`butler-provider-gcp`) to provision VMs on Google Compute Engine. The controller creates VM instances with Talos Linux boot images and reports their IPs back to the bootstrap controller.
+
+For control plane HA, the bootstrap controller creates a LoadBalancerRequest, and the GCP provider provisions a regional TCP passthrough load balancer using a forwarding rule, target pool, and health check.
+
+```mermaid
+flowchart LR
+    CLI["butleradm"] --> KIND["KIND Cluster"]
+    KIND --> Bootstrap["butler-bootstrap"]
+    KIND --> GCPProvider["butler-provider-gcp"]
+    Bootstrap --> MR["MachineRequest CRs"]
+    Bootstrap --> LBR["LoadBalancerRequest CR"]
+    GCPProvider --> GCE["GCE VM Instances"]
+    GCPProvider --> LB["TCP Load Balancer"]
+```
+
+### Key Components
+
+| Component | Purpose |
+|-----------|---------|
+| butler-provider-gcp | Provisions GCE VMs and GCP load balancer resources |
+| CAPI GCP Provider (CAPG) | Manages tenant cluster worker VMs after bootstrap |
+
+---
+
+## Prerequisites
+
+### GCP Project
+
+- A GCP project with billing enabled
+- Compute Engine API enabled (`compute.googleapis.com`)
+
+### Service Account
+
+A service account with the `roles/compute.admin` role (or equivalent custom role covering instances, disks, networks, forwarding rules, target pools, health checks, and static addresses).
+
+### Networking
+
+- A VPC with at least one subnet in the target region
+- Firewall rules (see [Network Architecture](#network-architecture) below)
+- Sufficient quota for static regional IPs, CPUs, and disks in the target region
+
+### Talos Image
+
+A Talos Linux image must be available in the project. Use the Talos Image Factory to produce a GCP-compatible image, or import one from the Talos GitHub releases.
+
+---
+
+## GCP Setup
+
+### 1. Create Service Account
+
+```bash
+# Create service account
+gcloud iam service-accounts create butler-bootstrap \
+  --display-name="Butler Bootstrap"
+
+# Grant compute admin role
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="serviceAccount:butler-bootstrap@PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/compute.admin"
+
+# Create and download key
+gcloud iam service-accounts keys create gcp-credentials.json \
+  --iam-account=butler-bootstrap@PROJECT_ID.iam.gserviceaccount.com
+```
+
+### 2. Create Firewall Rules
+
+```bash
+# Allow inter-node communication (Talos API, etcd, kubelet)
+gcloud compute firewall-rules create butler-internal \
+  --network=default \
+  --allow=tcp:6443,tcp:50000,tcp:50001,tcp:2379-2380,tcp:10250 \
+  --source-tags=butler-node \
+  --target-tags=butler-node
+
+# Allow health checks from GCP health check ranges
+gcloud compute firewall-rules create butler-health-check \
+  --network=default \
+  --allow=tcp:6443 \
+  --source-ranges=130.211.0.0/22,35.191.0.0/16 \
+  --target-tags=butler-node
+
+# Allow external access to kube-apiserver via LB
+gcloud compute firewall-rules create butler-apiserver \
+  --network=default \
+  --allow=tcp:6443 \
+  --source-ranges=0.0.0.0/0 \
+  --target-tags=butler-node
+```
+
+### 3. Upload Talos Image (if needed)
+
+```bash
+# Download Talos GCP image
+wget https://factory.talos.dev/image/SCHEMATIC_ID/vX.Y.Z/gcp-amd64.raw.tar.gz
+
+# Create GCE image
+gcloud compute images create talos-vX-Y-Z \
+  --source-uri=gs://BUCKET/talos-vX-Y-Z.raw.tar.gz
+```
+
+---
+
+## Butler Configuration
+
+### ProviderConfig
+
+Create a Kubernetes Secret with the service account key, then reference it from a ProviderConfig:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gcp-credentials
+  namespace: butler-system
+type: Opaque
+stringData:
+  credentials.json: |
+    {
+      "type": "service_account",
+      "project_id": "my-project",
+      ...
+    }
+---
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: gcp-prod
+  namespace: butler-system
+spec:
+  provider: gcp
+  credentialsRef:
+    name: gcp-credentials
+    namespace: butler-system
+    key: credentials.json
+  network:
+    mode: cloud
+  gcp:
+    projectID: my-project
+    region: us-central1
+    network: default
+    subnetwork: default
+```
+
+### Bootstrap Config
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ClusterBootstrap
+metadata:
+  name: butler-mgmt
+  namespace: butler-system
+spec:
+  provider: gcp
+  providerRef:
+    name: gcp-prod
+    namespace: butler-system
+
+  cluster:
+    name: butler-mgmt
+    topology: ha
+    controlPlane:
+      replicas: 3
+      cpu: 4
+      memoryMB: 16384
+      diskGB: 100
+    workers:
+      replicas: 3
+      cpu: 8
+      memoryMB: 32768
+      diskGB: 200
+
+  network:
+    podCIDR: 10.244.0.0/16
+    serviceCIDR: 10.96.0.0/12
+    # VIP is set automatically from LoadBalancerRequest endpoint
+
+  talos:
+    version: v1.9.2
+    schematic: ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515
+
+  addons:
+    cni:
+      type: cilium
+      hubbleEnabled: true
+    storage:
+      type: longhorn
+    controlPlaneProvider:
+      type: steward
+    capi:
+      enabled: true
+      infrastructureProviders:
+        - name: gcp
+
+  controlPlaneExposure:
+    mode: LoadBalancer
+```
+
+### Run Bootstrap
+
+```bash
+butleradm bootstrap gcp --config bootstrap.yaml
+```
+
+---
+
+## Network Architecture
+
+```mermaid
+flowchart TB
+    subgraph GCP["GCP Project"]
+        subgraph VPC["VPC Network"]
+            subgraph Subnet["Subnet (us-central1)"]
+                CP0["CP-0<br/>10.128.0.10"]
+                CP1["CP-1<br/>10.128.0.11"]
+                CP2["CP-2<br/>10.128.0.12"]
+                W0["Worker-0<br/>10.128.0.20"]
+                W1["Worker-1<br/>10.128.0.21"]
+                W2["Worker-2<br/>10.128.0.22"]
+            end
+        end
+        LB["TCP Load Balancer<br/>35.194.52.218:6443"]
+        FW["Firewall Rules"]
+    end
+
+    Internet["External Access"] --> LB
+    LB --> CP0
+    LB --> CP1
+    LB --> CP2
+    FW -.-> Subnet
+```
+
+### Firewall Rules
+
+| Rule | Protocol/Port | Source | Target | Purpose |
+|------|--------------|--------|--------|---------|
+| butler-internal | TCP 6443, 50000-50001, 2379-2380, 10250 | butler-node tag | butler-node tag | Inter-node communication |
+| butler-health-check | TCP 6443 | 130.211.0.0/22, 35.191.0.0/16 | butler-node tag | GCP health check probes |
+| butler-apiserver | TCP 6443 | 0.0.0.0/0 | butler-node tag | External kube-apiserver access |
+
+Ports explained:
+- **6443**: Kubernetes API server
+- **50000**: Talos API (apid)
+- **50001**: Talos trustd
+- **2379-2380**: etcd client and peer
+- **10250**: kubelet API
+
+---
+
+## Load Balancer Resources
+
+When the bootstrap controller creates a LoadBalancerRequest with `provider: gcp`, the GCP provider controller creates:
+
+| GCP Resource | Purpose |
+|--------------|---------|
+| Regional static IP address | Stable external IP for the control plane endpoint |
+| Legacy HTTP health check | Checks TCP 6443 on each control plane node |
+| Target pool | Groups the control plane VM instances |
+| Regional forwarding rule | Routes TCP 6443 traffic from the static IP to the target pool |
+
+These are regional resources created in the same region as the VMs. The forwarding rule uses TCP passthrough (no TLS termination). The kube-apiserver handles TLS.
+
+The static IP is reported back as `LoadBalancerRequest.status.endpoint` and used as the control plane address in Talos machine configs.
+
+---
+
+## Resource Recommendations
+
+| Profile | CP Nodes | CP Sizing | Worker Nodes | Worker Sizing | Estimated Monthly Cost |
+|---------|----------|-----------|-------------|---------------|----------------------|
+| Development | 1 (single-node) | n2-standard-4 (4 vCPU, 16 GB) | 0 | -- | ~$150 |
+| Staging | 3 | n2-standard-4 (4 vCPU, 16 GB) | 2 | n2-standard-8 (8 vCPU, 32 GB) | ~$900 |
+| Production | 3 | n2-standard-4 (4 vCPU, 16 GB) | 3+ | n2-standard-8 (8 vCPU, 32 GB) | ~$1,200+ |
+
+Storage: Longhorn uses attached persistent disks. Add `extraDisks` with adequate `sizeGB` for persistent volume capacity.
+
+---
+
+## Troubleshooting
+
+### Quota Exceeded
+
+**Symptom**: MachineRequest stuck in `Creating` phase with quota error in provider logs.
+
+**Common quotas to check:**
+- `CPUS_ALL_REGIONS` (default: 12 per region)
+- `IN_USE_ADDRESSES` (static IPs, default: 8 per region)
+- `DISKS_TOTAL_GB` (default: 2,048 GB per region)
+
+**Fix**: Request quota increase in the GCP Console under IAM & Admin > Quotas.
+
+### Firewall Rules Missing
+
+**Symptom**: Talos bootstrap times out. Nodes cannot reach each other on port 6443.
+
+**Verify**:
+```bash
+gcloud compute firewall-rules list --filter="network=default" --format="table(name, direction, allowed, sourceRanges)"
+```
+
+### LB Health Check Failures
+
+**Symptom**: LoadBalancerRequest stays in `Creating` phase. Health check shows 0 healthy instances.
+
+**Verify**:
+```bash
+gcloud compute health-checks describe butler-mgmt-hc --region=us-central1
+gcloud compute target-pools get-health butler-mgmt-tp --region=us-central1
+```
+
+**Common causes:**
+- Firewall rule for health check source ranges (130.211.0.0/22, 35.191.0.0/16) is missing
+- kube-apiserver not yet listening (bootstrap still in progress)
+- Health check port does not match the apiserver port
+
+### API Not Enabled
+
+**Symptom**: Provider controller logs show `googleapi: Error 403: Compute Engine API has not been used`.
+
+**Fix**:
+```bash
+gcloud services enable compute.googleapis.com --project=PROJECT_ID
+```
+
+### Insufficient IAM Permissions
+
+**Symptom**: Provider controller logs show permission denied errors for compute operations.
+
+**Verify**:
+```bash
+gcloud projects get-iam-policy PROJECT_ID \
+  --filter="bindings.members:butler-bootstrap@PROJECT_ID.iam.gserviceaccount.com" \
+  --format="table(bindings.role)"
+```
+
+The service account needs `roles/compute.admin` or a custom role with permissions for instances, disks, networks, addresses, forwarding rules, target pools, and health checks.
+
+---
+
+## See Also
+
+- [Bootstrap Flow](../architecture/bootstrap-flow.md) -- end-to-end bootstrap sequence
+- [ClusterBootstrap CRD](../reference/crds/clusterbootstrap.md) -- full spec reference
+- [LoadBalancerRequest CRD](../reference/crds/loadbalancerrequest.md) -- cloud LB provisioning
+- [ProviderConfig CRD](../reference/crds/providerconfig.md) -- provider credentials

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -1,5 +1,7 @@
 # GCP Provider Guide
 
+> **Status: Beta.** GCP bootstrap has been E2E validated with LoadBalancerRequest HA. The CRD types, bootstrap controller integration, CLI commands, and provider controller are implemented.
+
 This guide covers setting up Butler with Google Cloud Platform as the infrastructure provider for management cluster bootstrap.
 
 ## Table of Contents
@@ -359,7 +361,7 @@ The service account needs `roles/compute.admin` or a custom role with permission
 
 ## See Also
 
-- [Bootstrap Flow](../architecture/bootstrap-flow.md) -- end-to-end bootstrap sequence
-- [ClusterBootstrap CRD](../reference/crds/clusterbootstrap.md) -- full spec reference
-- [LoadBalancerRequest CRD](../reference/crds/loadbalancerrequest.md) -- cloud LB provisioning
-- [ProviderConfig CRD](../reference/crds/providerconfig.md) -- provider credentials
+- [Bootstrap Flow](../architecture/bootstrap-flow.md) - end-to-end bootstrap sequence
+- [ClusterBootstrap CRD](../reference/crds/clusterbootstrap.md) - full spec reference
+- [LoadBalancerRequest CRD](../reference/crds/loadbalancerrequest.md) - cloud LB provisioning
+- [ProviderConfig CRD](../reference/crds/providerconfig.md) - provider credentials

--- a/docs/reference/cli/butleradm.md
+++ b/docs/reference/cli/butleradm.md
@@ -28,7 +28,7 @@ Bootstrap a new Butler management cluster.
 
 ### Common Flags
 
-All `butleradm bootstrap <provider>` commands share the same flags. Provider-specific settings (credentials, regions, networks) are specified in the bootstrap config YAML file.
+All `butleradm bootstrap <provider>` commands share these flags. Each provider also has credential override flags documented in its section below.
 
 | Flag | Short | Description | Required |
 |------|-------|-------------|----------|
@@ -46,11 +46,21 @@ Bootstrap Butler on Harvester HCI.
 butleradm bootstrap harvester [flags]
 ```
 
+**Provider Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--harvester-kubeconfig` | Path to Harvester kubeconfig (overrides config file) |
+
 **Examples:**
 
 ```bash
 # Bootstrap with config file
 butleradm bootstrap harvester --config bootstrap.yaml
+
+# Override Harvester kubeconfig via flag
+butleradm bootstrap harvester --config bootstrap.yaml \
+  --harvester-kubeconfig /path/to/harvester-kubeconfig
 
 # Dry run to validate
 butleradm bootstrap harvester --config bootstrap.yaml --dry-run
@@ -113,10 +123,25 @@ Bootstrap Butler on Nutanix AHV.
 butleradm bootstrap nutanix [flags]
 ```
 
+**Provider Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--prism-endpoint` | Nutanix Prism Central endpoint (overrides config file) |
+| `--prism-username` | Nutanix Prism Central username (overrides config file) |
+| `--prism-password` | Nutanix Prism Central password (overrides config file) |
+
 **Examples:**
 
 ```bash
+# Bootstrap with config file
 butleradm bootstrap nutanix --config bootstrap.yaml
+
+# Override Prism credentials via flags
+butleradm bootstrap nutanix --config bootstrap.yaml \
+  --prism-endpoint https://prism.example.com:9440 \
+  --prism-username admin \
+  --prism-password "${PRISM_PASSWORD}"
 ```
 
 ### butleradm bootstrap proxmox
@@ -137,11 +162,21 @@ Bootstrap Butler on Google Cloud Platform.
 butleradm bootstrap gcp [flags]
 ```
 
+**Provider Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--credentials` | Path to GCP service account JSON key (overrides config file) |
+
 **Examples:**
 
 ```bash
 # Bootstrap on GCP
 butleradm bootstrap gcp --config bootstrap.yaml
+
+# Override service account key via flag
+butleradm bootstrap gcp --config bootstrap.yaml \
+  --credentials /path/to/sa-key.json
 
 # Dry run to validate
 butleradm bootstrap gcp --config bootstrap.yaml --dry-run
@@ -155,10 +190,23 @@ Bootstrap Butler on Amazon Web Services.
 butleradm bootstrap aws [flags]
 ```
 
+**Provider Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--access-key-id` | AWS access key ID (overrides config file) |
+| `--secret-access-key` | AWS secret access key (overrides config file) |
+
 **Examples:**
 
 ```bash
+# Bootstrap on AWS
 butleradm bootstrap aws --config bootstrap.yaml
+
+# Override AWS credentials via flags
+butleradm bootstrap aws --config bootstrap.yaml \
+  --access-key-id "${AWS_ACCESS_KEY_ID}" \
+  --secret-access-key "${AWS_SECRET_ACCESS_KEY}"
 ```
 
 ### butleradm bootstrap azure
@@ -169,10 +217,27 @@ Bootstrap Butler on Microsoft Azure.
 butleradm bootstrap azure [flags]
 ```
 
+**Provider Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--client-id` | Azure service principal app ID (overrides config file) |
+| `--client-secret` | Azure service principal password (overrides config file) |
+| `--tenant-id` | Azure tenant ID (overrides config file) |
+| `--subscription-id` | Azure subscription ID (overrides config file) |
+
 **Examples:**
 
 ```bash
+# Bootstrap on Azure
 butleradm bootstrap azure --config bootstrap.yaml
+
+# Override Azure credentials via flags
+butleradm bootstrap azure --config bootstrap.yaml \
+  --client-id "${AZURE_CLIENT_ID}" \
+  --client-secret "${AZURE_CLIENT_SECRET}" \
+  --tenant-id "${AZURE_TENANT_ID}" \
+  --subscription-id "${AZURE_SUBSCRIPTION_ID}"
 ```
 
 ### Bootstrap Config Reference

--- a/docs/reference/cli/butleradm.md
+++ b/docs/reference/cli/butleradm.md
@@ -26,6 +26,18 @@ butleradm [command] [flags]
 
 Bootstrap a new Butler management cluster.
 
+### Common Flags
+
+All `butleradm bootstrap <provider>` commands share the same flags. Provider-specific settings (credentials, regions, networks) are specified in the bootstrap config YAML file.
+
+| Flag | Short | Description | Required |
+|------|-------|-------------|----------|
+| `--config` | `-c` | Path to bootstrap config file | Yes |
+| `--dry-run` | | Show what would be created without executing | No |
+| `--skip-cleanup` | | Don't delete KIND cluster on failure (for debugging) | No |
+| `--local` | | Local development mode: build and load images from source | No |
+| `--repo-root` | | Path to butlerdotdev repos (default: `~/code/github.com/butlerdotdev`) | No |
+
 ### butleradm bootstrap harvester
 
 Bootstrap Butler on Harvester HCI.
@@ -34,28 +46,14 @@ Bootstrap Butler on Harvester HCI.
 butleradm bootstrap harvester [flags]
 ```
 
-**Flags:**
-
-| Flag | Description | Required |
-|------|-------------|----------|
-| `--config` | Path to bootstrap config file | Yes |
-| `--harvester-kubeconfig` | Path to Harvester kubeconfig | Yes |
-| `--dry-run` | Validate without executing | No |
-| `--skip-cleanup` | Don't cleanup KIND on success | No |
-
 **Examples:**
 
 ```bash
 # Bootstrap with config file
-butleradm bootstrap harvester \
-  --config bootstrap.yaml \
-  --harvester-kubeconfig harvester.yaml
+butleradm bootstrap harvester --config bootstrap.yaml
 
 # Dry run to validate
-butleradm bootstrap harvester \
-  --config bootstrap.yaml \
-  --harvester-kubeconfig harvester.yaml \
-  --dry-run
+butleradm bootstrap harvester --config bootstrap.yaml --dry-run
 ```
 
 **Bootstrap Config Example:**
@@ -115,14 +113,11 @@ Bootstrap Butler on Nutanix AHV.
 butleradm bootstrap nutanix [flags]
 ```
 
-**Flags:**
+**Examples:**
 
-| Flag | Description | Required |
-|------|-------------|----------|
-| `--config` | Path to bootstrap config file | Yes |
-| `--prism-endpoint` | Prism Central endpoint | Yes |
-| `--prism-username` | Prism Central username | Yes |
-| `--prism-password` | Prism Central password | Yes |
+```bash
+butleradm bootstrap nutanix --config bootstrap.yaml
+```
 
 ### butleradm bootstrap proxmox
 
@@ -134,14 +129,6 @@ Bootstrap Butler on Proxmox VE.
 butleradm bootstrap proxmox [flags]
 ```
 
-**Flags:**
-
-| Flag | Description | Required |
-|------|-------------|----------|
-| `--config` | Path to bootstrap config file | Yes |
-| `--proxmox-endpoint` | Proxmox API endpoint | Yes |
-| `--proxmox-token` | Proxmox API token | Yes |
-
 ### butleradm bootstrap gcp
 
 Bootstrap Butler on Google Cloud Platform.
@@ -150,28 +137,14 @@ Bootstrap Butler on Google Cloud Platform.
 butleradm bootstrap gcp [flags]
 ```
 
-**Flags:**
-
-| Flag | Description | Required |
-|------|-------------|----------|
-| `--config` | Path to bootstrap config file | Yes |
-| `--credentials` | Path to GCP service account JSON key | Yes |
-| `--dry-run` | Validate without executing | No |
-| `--skip-cleanup` | Don't cleanup KIND on success | No |
-
 **Examples:**
 
 ```bash
 # Bootstrap on GCP
-butleradm bootstrap gcp \
-  --config bootstrap.yaml \
-  --credentials gcp-credentials.json
+butleradm bootstrap gcp --config bootstrap.yaml
 
 # Dry run to validate
-butleradm bootstrap gcp \
-  --config bootstrap.yaml \
-  --credentials gcp-credentials.json \
-  --dry-run
+butleradm bootstrap gcp --config bootstrap.yaml --dry-run
 ```
 
 ### butleradm bootstrap aws
@@ -182,24 +155,10 @@ Bootstrap Butler on Amazon Web Services.
 butleradm bootstrap aws [flags]
 ```
 
-**Flags:**
-
-| Flag | Description | Required |
-|------|-------------|----------|
-| `--config` | Path to bootstrap config file | Yes |
-| `--access-key-id` | AWS access key ID | Yes |
-| `--secret-access-key` | AWS secret access key | Yes |
-| `--dry-run` | Validate without executing | No |
-| `--skip-cleanup` | Don't cleanup KIND on success | No |
-
 **Examples:**
 
 ```bash
-# Bootstrap on AWS
-butleradm bootstrap aws \
-  --config bootstrap.yaml \
-  --access-key-id AKIAIOSFODNN7EXAMPLE \
-  --secret-access-key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+butleradm bootstrap aws --config bootstrap.yaml
 ```
 
 ### butleradm bootstrap azure
@@ -210,28 +169,10 @@ Bootstrap Butler on Microsoft Azure.
 butleradm bootstrap azure [flags]
 ```
 
-**Flags:**
-
-| Flag | Description | Required |
-|------|-------------|----------|
-| `--config` | Path to bootstrap config file | Yes |
-| `--client-id` | Azure service principal app ID | Yes |
-| `--client-secret` | Azure service principal password | Yes |
-| `--tenant-id` | Azure tenant ID | Yes |
-| `--subscription-id` | Azure subscription ID | Yes |
-| `--dry-run` | Validate without executing | No |
-| `--skip-cleanup` | Don't cleanup KIND on success | No |
-
 **Examples:**
 
 ```bash
-# Bootstrap on Azure
-butleradm bootstrap azure \
-  --config bootstrap.yaml \
-  --client-id APP_ID \
-  --client-secret PASSWORD \
-  --tenant-id TENANT_ID \
-  --subscription-id SUBSCRIPTION_ID
+butleradm bootstrap azure --config bootstrap.yaml
 ```
 
 ### Bootstrap Config Reference
@@ -242,10 +183,10 @@ The bootstrap config file is a ClusterBootstrap resource. See the [ClusterBootst
 |---------|---------|---------|-------|
 | `spec.provider` | Infrastructure provider | `harvester`, `nutanix`, `proxmox` | `gcp`, `aws`, `azure` |
 | `spec.cluster` | Topology, node sizing | Required | Required |
-| `spec.network.vip` | Control plane VIP | Required | Not needed (LB endpoint used) |
-| `spec.network.loadBalancerPool` | MetalLB IP range | Required | Not needed |
+| `spec.network.vip` | Control plane VIP | Recommended (kube-vip requires it) | Not needed (LB endpoint used) |
+| `spec.network.loadBalancerPool` | MetalLB IP range | Recommended | Not needed |
 | `spec.talos` | Talos version, schematic, install disk | Required | Required |
-| `spec.addons` | Platform addons | All available | kube-vip and MetalLB skipped |
+| `spec.addons` | Platform addons | All available | kube-vip and MetalLB not installed |
 | `spec.controlPlaneExposure` | Tenant API server exposure | Optional | Optional |
 
 ---

--- a/docs/reference/cli/butleradm.md
+++ b/docs/reference/cli/butleradm.md
@@ -142,6 +142,112 @@ butleradm bootstrap proxmox [flags]
 | `--proxmox-endpoint` | Proxmox API endpoint | Yes |
 | `--proxmox-token` | Proxmox API token | Yes |
 
+### butleradm bootstrap gcp
+
+Bootstrap Butler on Google Cloud Platform.
+
+```bash
+butleradm bootstrap gcp [flags]
+```
+
+**Flags:**
+
+| Flag | Description | Required |
+|------|-------------|----------|
+| `--config` | Path to bootstrap config file | Yes |
+| `--credentials` | Path to GCP service account JSON key | Yes |
+| `--dry-run` | Validate without executing | No |
+| `--skip-cleanup` | Don't cleanup KIND on success | No |
+
+**Examples:**
+
+```bash
+# Bootstrap on GCP
+butleradm bootstrap gcp \
+  --config bootstrap.yaml \
+  --credentials gcp-credentials.json
+
+# Dry run to validate
+butleradm bootstrap gcp \
+  --config bootstrap.yaml \
+  --credentials gcp-credentials.json \
+  --dry-run
+```
+
+### butleradm bootstrap aws
+
+Bootstrap Butler on Amazon Web Services.
+
+```bash
+butleradm bootstrap aws [flags]
+```
+
+**Flags:**
+
+| Flag | Description | Required |
+|------|-------------|----------|
+| `--config` | Path to bootstrap config file | Yes |
+| `--access-key-id` | AWS access key ID | Yes |
+| `--secret-access-key` | AWS secret access key | Yes |
+| `--dry-run` | Validate without executing | No |
+| `--skip-cleanup` | Don't cleanup KIND on success | No |
+
+**Examples:**
+
+```bash
+# Bootstrap on AWS
+butleradm bootstrap aws \
+  --config bootstrap.yaml \
+  --access-key-id AKIAIOSFODNN7EXAMPLE \
+  --secret-access-key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+```
+
+### butleradm bootstrap azure
+
+Bootstrap Butler on Microsoft Azure.
+
+```bash
+butleradm bootstrap azure [flags]
+```
+
+**Flags:**
+
+| Flag | Description | Required |
+|------|-------------|----------|
+| `--config` | Path to bootstrap config file | Yes |
+| `--client-id` | Azure service principal app ID | Yes |
+| `--client-secret` | Azure service principal password | Yes |
+| `--tenant-id` | Azure tenant ID | Yes |
+| `--subscription-id` | Azure subscription ID | Yes |
+| `--dry-run` | Validate without executing | No |
+| `--skip-cleanup` | Don't cleanup KIND on success | No |
+
+**Examples:**
+
+```bash
+# Bootstrap on Azure
+butleradm bootstrap azure \
+  --config bootstrap.yaml \
+  --client-id APP_ID \
+  --client-secret PASSWORD \
+  --tenant-id TENANT_ID \
+  --subscription-id SUBSCRIPTION_ID
+```
+
+### Bootstrap Config Reference
+
+The bootstrap config file is a ClusterBootstrap resource. See the [ClusterBootstrap CRD reference](../crds/clusterbootstrap.md) for the full spec. Key sections:
+
+| Section | Purpose | On-Prem | Cloud |
+|---------|---------|---------|-------|
+| `spec.provider` | Infrastructure provider | `harvester`, `nutanix`, `proxmox` | `gcp`, `aws`, `azure` |
+| `spec.cluster` | Topology, node sizing | Required | Required |
+| `spec.network.vip` | Control plane VIP | Required | Not needed (LB endpoint used) |
+| `spec.network.loadBalancerPool` | MetalLB IP range | Required | Not needed |
+| `spec.talos` | Talos version, schematic, install disk | Required | Required |
+| `spec.addons` | Platform addons | All available | kube-vip and MetalLB skipped |
+| `spec.controlPlaneExposure` | Tenant API server exposure | Optional | Optional |
+
 ---
 
 ## butleradm status

--- a/docs/reference/crds/README.md
+++ b/docs/reference/crds/README.md
@@ -19,8 +19,9 @@ Butler extends the Kubernetes API with Custom Resource Definitions (CRDs) under 
 | CRD | Scope | Short Name | Description |
 |-----|-------|------------|-------------|
 | [TenantCluster](./tenantcluster.md) | Namespaced | `tc` | Tenant Kubernetes cluster |
-| ClusterBootstrap | Namespaced | `cb` | Management cluster bootstrap |
-| MachineRequest | Namespaced | `mr` | VM provisioning request |
+| [ClusterBootstrap](./clusterbootstrap.md) | Namespaced | `cb` | Management cluster bootstrap |
+| [MachineRequest](./machinerequest.md) | Namespaced | `mr` | VM provisioning request |
+| [LoadBalancerRequest](./loadbalancerrequest.md) | Namespaced | `lbr` | Cloud L4 load balancer for control plane |
 
 ### Platform Configuration
 
@@ -92,6 +93,8 @@ Butler uses finalizers to ensure proper cleanup:
 | `butler.butlerlabs.dev/networkpool` | NetworkPool | Block deletion with active allocations |
 | `butler.butlerlabs.dev/ipallocation` | IPAllocation | Ensure Released phase for audit trail |
 | `butler.butlerlabs.dev/providerconfig` | ProviderConfig | Block deletion if TenantClusters reference it |
+| `butler.butlerlabs.dev/loadbalancerrequest` | LoadBalancerRequest | Ensure cloud LB resources are deleted before CR removal |
+| `clusterbootstrap.butler.butlerlabs.dev/finalizer` | ClusterBootstrap | Cleanup MachineRequests, LoadBalancerRequests, and Secrets |
 
 ## See Also
 

--- a/docs/reference/crds/clusterbootstrap.md
+++ b/docs/reference/crds/clusterbootstrap.md
@@ -151,7 +151,7 @@ spec:
 | `podCIDR` | string | Yes | -- | CIDR for pod networking. Pattern: `^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$`. |
 | `serviceCIDR` | string | Yes | -- | CIDR for service networking. Same pattern. |
 | `vip` | string | No | -- | Control plane endpoint. For on-prem: a floating IP managed by kube-vip. For cloud: optional, set automatically from LoadBalancerRequest endpoint. Accepts IP addresses and DNS hostnames. |
-| `vipInterface` | string | No | auto | Network interface for the VIP. Only relevant for on-prem with kube-vip. |
+| `vipInterface` | string | No | -- | Network interface for the VIP. Only relevant for on-prem with kube-vip. Auto-detected by kube-vip if not specified. |
 | `loadBalancerPool` | LoadBalancerPoolSpec | No | -- | IP range for MetalLB. Must not overlap with VIP. |
 
 **LoadBalancerPoolSpec:**
@@ -197,6 +197,8 @@ All addon sub-specs are optional. Defaults are applied when the field is omitted
 | `butlerController` | ButlerControllerAddonSpec | enabled: true, version: latest | Butler platform controller. |
 | `gitOps` | GitOpsAddonSpec | type: flux, enabled: true | GitOps controller. |
 | `console` | ConsoleAddonSpec | enabled: false | Butler web console. |
+
+The CNI, Storage, CAPI, and Console sub-specs are detailed below. The remaining sub-specs (LoadBalancer, ControlPlaneHA, CertManager, Ingress, ControlPlaneProvider, GitOps, ButlerController) follow the same pattern: `enabled` (bool), `type` or `provider` (string), and `version` (string).
 
 #### CNIAddonSpec
 
@@ -363,7 +365,7 @@ The bootstrap flow adapts based on the provider type:
 |--------|---------------------------------------|------------------------|
 | Control plane HA | kube-vip floating VIP | Cloud L4 load balancer via LoadBalancerRequest |
 | CP endpoint source | `network.vip` field | LoadBalancerRequest `status.endpoint` |
-| MetalLB | Installed for LoadBalancer services | Skipped (cloud LBs handle this) |
+| MetalLB | Installed for LoadBalancer services | Not installed (no `loadBalancerPool` configured for cloud providers) |
 | kube-vip | Installed | Skipped |
 | Loopback patch | Not needed | Applied to each CP node so kube-apiserver accepts LB-routed packets |
 | Traefik | Installed for ingress | Skipped |

--- a/docs/reference/crds/clusterbootstrap.md
+++ b/docs/reference/crds/clusterbootstrap.md
@@ -1,0 +1,545 @@
+---
+title: ClusterBootstrap
+sidebar_position: 8
+---
+
+A ClusterBootstrap drives the end-to-end provisioning of a Butler management cluster from bare metal or cloud VMs through to a fully operational platform.
+
+## API Version
+
+`butler.butlerlabs.dev/v1alpha1`
+
+## Scope
+
+Namespaced
+
+## Short Name
+
+`cb`
+
+## Description
+
+ClusterBootstrap is the central resource for management cluster provisioning. It coordinates VM creation, Talos Linux configuration, Kubernetes bootstrap, and addon installation across both on-prem and cloud providers.
+
+The bootstrap controller runs inside a temporary KIND cluster on the operator's workstation. It watches ClusterBootstrap resources and reconciles through a strict phase sequence:
+
+1. Create MachineRequest resources for each node
+2. Wait for provider controllers to provision VMs and report IPs
+3. Generate and apply Talos machine configurations
+4. Bootstrap the first control plane node
+5. Install platform addons in dependency order
+6. (HA only) Pivot the management plane onto the new cluster
+
+On-prem providers (Harvester, Nutanix, Proxmox) use kube-vip for control plane HA with a floating VIP. Cloud providers (GCP, AWS, Azure) create a LoadBalancerRequest to provision a cloud-native L4 load balancer as the control plane endpoint.
+
+## Specification
+
+### Full Example (HA On-Prem)
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ClusterBootstrap
+metadata:
+  name: butler-mgmt
+  namespace: butler-system
+spec:
+  provider: harvester
+  providerRef:
+    name: harvester-prod
+    namespace: butler-system
+
+  cluster:
+    name: butler-mgmt
+    topology: ha
+    controlPlane:
+      replicas: 3
+      cpu: 4
+      memoryMB: 16384
+      diskGB: 100
+    workers:
+      replicas: 3
+      cpu: 8
+      memoryMB: 32768
+      diskGB: 200
+      extraDisks:
+        - sizeGB: 500
+          storageClass: longhorn
+
+  network:
+    podCIDR: 10.244.0.0/16
+    serviceCIDR: 10.96.0.0/12
+    vip: "10.40.0.200"
+    vipInterface: eth0
+    loadBalancerPool:
+      start: "10.40.0.210"
+      end: "10.40.0.250"
+
+  talos:
+    version: v1.9.2
+    schematic: ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515
+    installDisk: /dev/vda
+
+  addons:
+    cni:
+      type: cilium
+      hubbleEnabled: true
+    storage:
+      type: longhorn
+      replicaCount: 3
+    loadBalancer:
+      type: metallb
+    controlPlaneHA:
+      type: kube-vip
+    certManager:
+      enabled: true
+    ingress:
+      type: traefik
+      enabled: true
+    controlPlaneProvider:
+      type: steward
+      enabled: true
+    capi:
+      enabled: true
+      version: v1.9.4
+    butlerController:
+      enabled: true
+    gitOps:
+      type: flux
+      enabled: true
+
+  controlPlaneExposure:
+    mode: LoadBalancer
+```
+
+### Spec Fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `provider` | string | Yes | -- | Infrastructure provider. One of: `harvester`, `nutanix`, `proxmox`, `gcp`, `aws`, `azure`. |
+| `providerRef` | ProviderReference | Yes | -- | References the ProviderConfig with infrastructure credentials. |
+| `cluster` | ClusterBootstrapClusterSpec | Yes | -- | Cluster topology and node sizing. |
+| `network` | ClusterBootstrapNetworkSpec | Yes | -- | Pod CIDR, service CIDR, VIP, load balancer pool. |
+| `talos` | ClusterBootstrapTalosSpec | Yes | -- | Talos Linux version, schematic, install disk, config patches. |
+| `addons` | ClusterBootstrapAddonsSpec | No | See below | Platform addons to install. |
+| `controlPlaneExposure` | ControlPlaneExposureSpec | No | LoadBalancer | How tenant control planes are exposed after bootstrap. Written to ButlerConfig. |
+| `paused` | bool | No | false | Pauses reconciliation when true. |
+
+### ClusterBootstrapClusterSpec
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | Yes | -- | Cluster name. DNS-safe, 1-63 chars, pattern `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`. |
+| `topology` | string | No | `ha` | `ha` for high-availability (3+ CP nodes + workers) or `single-node` (1 CP, no workers). |
+| `controlPlane` | ClusterBootstrapNodePool | Yes | -- | Control plane node pool. |
+| `workers` | ClusterBootstrapNodePool | No | -- | Worker node pool. Ignored when topology is `single-node`. |
+
+### ClusterBootstrapNodePool
+
+| Field | Type | Required | Validation | Description |
+|-------|------|----------|------------|-------------|
+| `replicas` | int32 | Yes | 1-10 | Number of nodes. Forced to 1 for single-node topology. |
+| `cpu` | int32 | Yes | 1-128 | CPU cores per node. |
+| `memoryMB` | int32 | Yes | min 2048 | Memory in megabytes per node. |
+| `diskGB` | int32 | Yes | min 20 | Root disk size in gigabytes per node. |
+| `extraDisks` | []DiskSpec | No | -- | Additional disks. Each has `sizeGB` (min 1) and optional `storageClass`. |
+| `labels` | map[string]string | No | -- | Labels applied to nodes in this pool. |
+
+### ClusterBootstrapNetworkSpec
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `podCIDR` | string | Yes | -- | CIDR for pod networking. Pattern: `^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$`. |
+| `serviceCIDR` | string | Yes | -- | CIDR for service networking. Same pattern. |
+| `vip` | string | No | -- | Control plane endpoint. For on-prem: a floating IP managed by kube-vip. For cloud: optional, set automatically from LoadBalancerRequest endpoint. Accepts IP addresses and DNS hostnames. |
+| `vipInterface` | string | No | auto | Network interface for the VIP. Only relevant for on-prem with kube-vip. |
+| `loadBalancerPool` | LoadBalancerPoolSpec | No | -- | IP range for MetalLB. Must not overlap with VIP. |
+
+**LoadBalancerPoolSpec:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `start` | string | Yes | First IP in the pool (inclusive). |
+| `end` | string | Yes | Last IP in the pool (inclusive). |
+
+Validation: `start` must be less than or equal to `end`. If `vip` is an IP address (not a hostname), it must not fall within the pool range.
+
+### ClusterBootstrapTalosSpec
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `version` | string | Yes | -- | Talos version. Pattern: `^v[0-9]+\.[0-9]+\.[0-9]+$`. |
+| `schematic` | string | Yes | -- | Talos factory schematic ID for the boot image. |
+| `installDisk` | string | No | `/dev/vda` | Disk device for Talos installation. |
+| `configPatches` | []TalosConfigPatch | No | -- | Inline Talos config patches (RFC 6902 JSON Patch format). |
+
+**TalosConfigPatch:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `op` | string | Yes | Patch operation: `add`, `remove`, or `replace`. |
+| `path` | string | Yes | JSON path to patch. |
+| `value` | string | No | Value to set (required for `add` and `replace`). |
+
+### ClusterBootstrapAddonsSpec
+
+All addon sub-specs are optional. Defaults are applied when the field is omitted.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `cni` | CNIAddonSpec | type: cilium | Container networking. |
+| `storage` | StorageAddonSpec | type: longhorn, replicaCount: 3 | Persistent storage. |
+| `loadBalancer` | LoadBalancerAddonSpec | type: metallb | LoadBalancer service implementation. |
+| `controlPlaneHA` | ControlPlaneHAAddonSpec | type: kube-vip | Control plane HA (on-prem only). |
+| `certManager` | CertManagerAddonSpec | enabled: true | TLS certificate automation. |
+| `ingress` | IngressAddonSpec | type: traefik, enabled: true | Ingress controller. |
+| `controlPlaneProvider` | ControlPlaneProviderAddonSpec | type: steward, enabled: true | Hosted control plane operator. |
+| `capi` | CAPIAddonSpec | enabled: true, version: v1.9.4 | Cluster API core + infrastructure providers. |
+| `butlerController` | ButlerControllerAddonSpec | enabled: true, version: latest | Butler platform controller. |
+| `gitOps` | GitOpsAddonSpec | type: flux, enabled: true | GitOps controller. |
+| `console` | ConsoleAddonSpec | enabled: false | Butler web console. |
+
+#### CNIAddonSpec
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | string | `cilium` | CNI type. Enum: `cilium`, `none`. |
+| `version` | string | -- | Override chart version. |
+| `hubbleEnabled` | bool | true | Enable Hubble observability (Cilium only). |
+
+#### StorageAddonSpec
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | string | `longhorn` | Storage type. Enum: `longhorn`, `none`. |
+| `version` | string | -- | Override chart version. |
+| `replicaCount` | *int32 | 3 | Default volume replica count. Forced to 1 for single-node topology. |
+
+#### CAPIAddonSpec
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | *bool | true | Install Cluster API. |
+| `version` | string | `v1.9.4` | CAPI core version. |
+| `infrastructureProviders` | []CAPIInfraProviderSpec | -- | Additional CAPI infrastructure providers. The management cluster's own provider is always included. |
+
+**CAPIInfraProviderSpec:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Provider name. Enum: `harvester`, `nutanix`, `proxmox`, `gcp`, `aws`, `azure`. |
+| `version` | string | No | Override provider version. |
+| `credentialsSecretRef` | SecretReference | No | Credentials for providers other than the management cluster's own. |
+
+#### ConsoleAddonSpec
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | *bool | false | Install Butler Console. |
+| `version` | string | `latest` | Console image tag. |
+| `ingress` | ConsoleIngressSpec | -- | Ingress configuration for the console. |
+
+**ConsoleIngressSpec:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | false | Create an Ingress resource for the console. |
+| `host` | string | `butler.<cluster>.local` | Hostname for console access. |
+| `className` | string | -- | Ingress class (e.g., `traefik`, `nginx`). |
+| `tls` | bool | false | Enable TLS termination. |
+| `tlsSecretName` | string | -- | Name of TLS Secret. |
+
+### ControlPlaneExposureSpec
+
+Configures how tenant control planes are exposed after bootstrap. This setting is written to the ButlerConfig singleton and inherited by all TenantClusters.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | string | `LoadBalancer` | Exposure mode. Enum: `LoadBalancer`, `Ingress`, `Gateway`. |
+| `hostname` | string | -- | Wildcard domain for tenant API servers (e.g., `*.k8s.platform.example.com`). Required for Ingress and Gateway modes. |
+| `ingressClassName` | string | -- | Ingress class for Ingress mode. |
+| `controllerType` | string | -- | Ingress controller type for TLS passthrough. Enum: `haproxy`, `nginx`, `traefik`, `generic`. |
+| `gatewayRef` | string | -- | Gateway resource reference for Gateway mode (format: `namespace/name`). Required for Gateway mode. |
+
+## Status
+
+```yaml
+status:
+  phase: Ready
+  controlPlaneEndpoint: "10.40.0.200"
+  kubeconfig: "base64-encoded-kubeconfig..."
+  talosconfig: "base64-encoded-talosconfig..."
+  consoleURL: "https://butler.mgmt.example.com"
+  machines:
+    - name: butler-mgmt-cp-0
+      role: control-plane
+      phase: Running
+      ipAddress: "10.40.0.10"
+      talosConfigured: true
+      ready: true
+    - name: butler-mgmt-cp-1
+      role: control-plane
+      phase: Running
+      ipAddress: "10.40.0.11"
+      talosConfigured: true
+      ready: true
+    - name: butler-mgmt-cp-2
+      role: control-plane
+      phase: Running
+      ipAddress: "10.40.0.12"
+      talosConfigured: true
+      ready: true
+  addonsInstalled:
+    cilium: true
+    cert-manager: true
+    longhorn: true
+    metallb: true
+    kube-vip: true
+    steward: true
+    capi: true
+    butler-controller: true
+  conditions:
+    - type: Ready
+      status: "True"
+      lastTransitionTime: "2026-03-10T12:30:00Z"
+      reason: "BootstrapComplete"
+  lastUpdated: "2026-03-10T12:30:00Z"
+  observedGeneration: 1
+```
+
+### Status Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `phase` | ClusterBootstrapPhase | Current lifecycle phase (see Phases below). |
+| `controlPlaneEndpoint` | string | API server endpoint (VIP for on-prem, LB IP/DNS for cloud). |
+| `kubeconfig` | string | Base64-encoded admin kubeconfig for the new cluster. |
+| `talosconfig` | string | Base64-encoded talosconfig for Talos API access. |
+| `consoleURL` | string | URL of the Butler Console (if installed). |
+| `machines` | []ClusterBootstrapMachineStatus | Per-machine status. |
+| `failureReason` | string | Machine-readable failure reason. |
+| `failureMessage` | string | Human-readable failure details. |
+| `addonsInstalled` | map[string]bool | Tracks which addons completed installation. |
+| `conditions` | []Condition | Standard Kubernetes conditions. |
+| `lastUpdated` | Time | Timestamp of the last status update. |
+| `observedGeneration` | int64 | Last observed spec generation. |
+
+### ClusterBootstrapMachineStatus
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | MachineRequest name. |
+| `role` | string | `control-plane` or `worker`. |
+| `phase` | string | MachineRequest phase (Pending, Creating, Running, Failed). |
+| `ipAddress` | string | Assigned IP address. |
+| `talosConfigured` | bool | True after Talos config has been applied to the node. |
+| `ready` | bool | True after the node has joined the Kubernetes cluster. |
+
+## Phases
+
+| Phase | Description |
+|-------|-------------|
+| `Pending` | ClusterBootstrap created, not yet reconciled. |
+| `ProvisioningMachines` | MachineRequest resources created, waiting for VMs to report IPs. |
+| `ConfiguringTalos` | All VMs have IPs. Generating and applying Talos machine configurations. |
+| `BootstrappingCluster` | Talos configs applied. Bootstrapping etcd and Kubernetes on the first control plane node. |
+| `InstallingAddons` | Kubernetes API available. Installing platform addons in dependency order. |
+| `Pivoting` | (HA only) Moving management plane onto the new cluster. |
+| `Ready` | Bootstrap complete. Management cluster is fully operational. |
+| `Failed` | Bootstrap failed. Check `failureReason` and `failureMessage`. |
+
+## Conditions
+
+| Type | Description |
+|------|-------------|
+| `Ready` | True when bootstrap is complete and the cluster is operational. |
+| `Progressing` | True while bootstrap is actively working. |
+| `Failed` | True when bootstrap has encountered a terminal failure. |
+
+## On-Prem vs Cloud Bootstrap
+
+The bootstrap flow adapts based on the provider type:
+
+| Aspect | On-Prem (Harvester, Nutanix, Proxmox) | Cloud (GCP, AWS, Azure) |
+|--------|---------------------------------------|------------------------|
+| Control plane HA | kube-vip floating VIP | Cloud L4 load balancer via LoadBalancerRequest |
+| CP endpoint source | `network.vip` field | LoadBalancerRequest `status.endpoint` |
+| MetalLB | Installed for LoadBalancer services | Skipped (cloud LBs handle this) |
+| kube-vip | Installed | Skipped |
+| Loopback patch | Not needed | Applied to each CP node so kube-apiserver accepts LB-routed packets |
+| Traefik | Installed for ingress | Skipped |
+
+For cloud providers, the bootstrap controller creates a LoadBalancerRequest resource after VMs are provisioned. The cloud provider controller provisions the load balancer and reports its endpoint. That endpoint becomes the `controlPlaneEndpoint` used in Talos machine configs.
+
+## Validation Rules
+
+CEL validation rules enforce these constraints:
+
+- When `controlPlaneExposure.mode` is `Ingress`, `hostname` must be set.
+- When `controlPlaneExposure.mode` is `Gateway`, both `hostname` and `gatewayRef` must be set.
+- `network.vip` must not fall within `network.loadBalancerPool` range (validated in Go, prevents kube-vip and MetalLB conflicts).
+
+## Topology Comparison
+
+| | Single-Node | HA |
+|---|-------------|-----|
+| Control plane nodes | 1 | 3 (recommended) |
+| Worker nodes | 0 (CP is schedulable) | 1+ |
+| etcd | Single member | 3-member cluster |
+| Storage replicas | Forced to 1 | Default 3 |
+| kube-vip | Skipped | Installed (on-prem) |
+| Pivoting | Skipped | Enabled |
+| Use case | Dev, testing, edge | Production |
+
+## Finalizer
+
+| Finalizer | Purpose |
+|-----------|---------|
+| `clusterbootstrap.butler.butlerlabs.dev/finalizer` | Ensures cleanup of MachineRequests, LoadBalancerRequests, and Secrets before CR deletion. |
+
+## kubectl Output
+
+```
+$ kubectl get cb -n butler-system
+NAME           CLUSTER       TOPOLOGY   PHASE   ENDPOINT       AGE
+butler-mgmt   butler-mgmt   ha         Ready   10.40.0.200    2h
+```
+
+## Examples
+
+### Single-Node Development
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ClusterBootstrap
+metadata:
+  name: dev-cluster
+  namespace: butler-system
+spec:
+  provider: harvester
+  providerRef:
+    name: harvester-dev
+    namespace: butler-system
+  cluster:
+    name: dev-cluster
+    topology: single-node
+    controlPlane:
+      replicas: 1
+      cpu: 4
+      memoryMB: 16384
+      diskGB: 100
+  network:
+    podCIDR: 10.244.0.0/16
+    serviceCIDR: 10.96.0.0/12
+    vip: "10.40.0.100"
+  talos:
+    version: v1.9.2
+    schematic: ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515
+```
+
+### HA Cloud (GCP)
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ClusterBootstrap
+metadata:
+  name: butler-prod
+  namespace: butler-system
+spec:
+  provider: gcp
+  providerRef:
+    name: gcp-prod
+    namespace: butler-system
+  cluster:
+    name: butler-prod
+    topology: ha
+    controlPlane:
+      replicas: 3
+      cpu: 4
+      memoryMB: 16384
+      diskGB: 100
+    workers:
+      replicas: 3
+      cpu: 8
+      memoryMB: 32768
+      diskGB: 200
+  network:
+    podCIDR: 10.244.0.0/16
+    serviceCIDR: 10.96.0.0/12
+  talos:
+    version: v1.9.2
+    schematic: ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515
+  addons:
+    cni:
+      type: cilium
+      hubbleEnabled: true
+    storage:
+      type: longhorn
+    controlPlaneProvider:
+      type: steward
+    capi:
+      enabled: true
+      infrastructureProviders:
+        - name: gcp
+  controlPlaneExposure:
+    mode: LoadBalancer
+```
+
+### HA On-Prem with Gateway Exposure
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: ClusterBootstrap
+metadata:
+  name: butler-mgmt
+  namespace: butler-system
+spec:
+  provider: nutanix
+  providerRef:
+    name: nutanix-dc1
+    namespace: butler-system
+  cluster:
+    name: butler-mgmt
+    topology: ha
+    controlPlane:
+      replicas: 3
+      cpu: 4
+      memoryMB: 16384
+      diskGB: 100
+    workers:
+      replicas: 3
+      cpu: 8
+      memoryMB: 32768
+      diskGB: 200
+  network:
+    podCIDR: 10.244.0.0/16
+    serviceCIDR: 10.96.0.0/12
+    vip: "10.0.0.200"
+    loadBalancerPool:
+      start: "10.0.0.210"
+      end: "10.0.0.250"
+  talos:
+    version: v1.9.2
+    schematic: ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515
+  addons:
+    ingress:
+      type: traefik
+    console:
+      enabled: true
+      ingress:
+        enabled: true
+        host: butler.platform.example.com
+        className: traefik
+        tls: true
+  controlPlaneExposure:
+    mode: Gateway
+    hostname: "*.k8s.platform.example.com"
+    gatewayRef: "butler-system/tenant-gateway"
+```
+
+## See Also
+
+- [LoadBalancerRequest](./loadbalancerrequest.md) -- cloud control plane load balancer
+- [MachineRequest](./machinerequest.md) -- VM provisioning interface
+- [ProviderConfig](./providerconfig.md) -- infrastructure credentials
+- [Bootstrap Flow](../../architecture/bootstrap-flow.md) -- end-to-end bootstrap sequence
+- [Provider Guides](../../providers/) -- per-provider setup instructions

--- a/docs/reference/crds/clusterbootstrap.md
+++ b/docs/reference/crds/clusterbootstrap.md
@@ -540,8 +540,8 @@ spec:
 
 ## See Also
 
-- [LoadBalancerRequest](./loadbalancerrequest.md) -- cloud control plane load balancer
-- [MachineRequest](./machinerequest.md) -- VM provisioning interface
-- [ProviderConfig](./providerconfig.md) -- infrastructure credentials
-- [Bootstrap Flow](../../architecture/bootstrap-flow.md) -- end-to-end bootstrap sequence
-- [Provider Guides](../../providers/) -- per-provider setup instructions
+- [LoadBalancerRequest](./loadbalancerrequest.md) - cloud control plane load balancer
+- [MachineRequest](./machinerequest.md) - VM provisioning interface
+- [ProviderConfig](./providerconfig.md) - infrastructure credentials
+- [Bootstrap Flow](../../architecture/bootstrap-flow.md) - end-to-end bootstrap sequence
+- [Provider Guides](../../providers/) - per-provider setup instructions

--- a/docs/reference/crds/loadbalancerrequest.md
+++ b/docs/reference/crds/loadbalancerrequest.md
@@ -232,9 +232,9 @@ spec:
 
 ## See Also
 
-- [ClusterBootstrap](./clusterbootstrap.md) -- creates LoadBalancerRequest during cloud bootstrap
-- [ProviderConfig](./providerconfig.md) -- cloud credentials referenced by `providerConfigRef`
-- [Bootstrap Flow](../../architecture/bootstrap-flow.md) -- end-to-end bootstrap sequence
+- [ClusterBootstrap](./clusterbootstrap.md) - creates LoadBalancerRequest during cloud bootstrap
+- [ProviderConfig](./providerconfig.md) - cloud credentials referenced by `providerConfigRef`
+- [Bootstrap Flow](../../architecture/bootstrap-flow.md) - end-to-end bootstrap sequence
 - [GCP Provider Guide](../../providers/gcp.md)
 - [AWS Provider Guide](../../providers/aws.md)
 - [Azure Provider Guide](../../providers/azure.md)

--- a/docs/reference/crds/loadbalancerrequest.md
+++ b/docs/reference/crds/loadbalancerrequest.md
@@ -19,7 +19,7 @@ Namespaced
 
 ## Description
 
-LoadBalancerRequest is used during cloud bootstrap to create a load balancer that fronts the control plane nodes. The bootstrap controller creates a LoadBalancerRequest, and the appropriate cloud provider controller (GCP, AWS, or Azure) provisions the cloud-native load balancer and reports its endpoint. That endpoint is then baked into Talos machine configs as the control plane address before nodes boot.
+LoadBalancerRequest is used during cloud bootstrap to create a load balancer that fronts the control plane nodes. The bootstrap controller creates a LoadBalancerRequest, and the appropriate cloud provider controller (GCP, AWS, or Azure) provisions the cloud-native load balancer and reports its endpoint. That endpoint is then written into Talos machine configs as the control plane address before nodes boot.
 
 On-prem deployments do not use LoadBalancerRequest. They use kube-vip for control plane HA instead.
 

--- a/docs/reference/crds/loadbalancerrequest.md
+++ b/docs/reference/crds/loadbalancerrequest.md
@@ -1,0 +1,240 @@
+---
+title: LoadBalancerRequest
+sidebar_position: 7
+---
+
+A LoadBalancerRequest provisions a cloud-native L4 load balancer for a management cluster's control plane endpoint.
+
+## API Version
+
+`butler.butlerlabs.dev/v1alpha1`
+
+## Scope
+
+Namespaced
+
+## Short Name
+
+`lbr`
+
+## Description
+
+LoadBalancerRequest is used during cloud bootstrap to create a load balancer that fronts the control plane nodes. The bootstrap controller creates a LoadBalancerRequest, and the appropriate cloud provider controller (GCP, AWS, or Azure) provisions the cloud-native load balancer and reports its endpoint. That endpoint is then baked into Talos machine configs as the control plane address before nodes boot.
+
+On-prem deployments do not use LoadBalancerRequest. They use kube-vip for control plane HA instead.
+
+## Specification
+
+### Full Example
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: LoadBalancerRequest
+metadata:
+  name: butler-mgmt-lb
+  namespace: butler-system
+spec:
+  # Name of the cluster this LB serves. Used as a prefix for cloud resource names.
+  clusterName: butler-mgmt
+
+  # Reference to ProviderConfig with cloud credentials.
+  providerConfigRef:
+    name: gcp-prod
+    namespace: butler-system
+
+  # Backend port (default: 6443)
+  port: 6443
+
+  # Health check port (defaults to port value)
+  healthCheckPort: 6443
+
+  # Backend instances, updated incrementally as CP nodes come online.
+  targets:
+    - ip: "10.128.0.10"
+      instanceName: "butler-mgmt-cp-0"
+    - ip: "10.128.0.11"
+      instanceName: "butler-mgmt-cp-1"
+    - ip: "10.128.0.12"
+      instanceName: "butler-mgmt-cp-2"
+```
+
+### Spec Fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `clusterName` | string | Yes | -- | DNS-safe name (1-63 chars, `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`). Immutable after creation. |
+| `providerConfigRef` | ProviderReference | Yes | -- | References the ProviderConfig with cloud credentials. Immutable after creation. |
+| `port` | int32 | No | 6443 | Backend port on control plane nodes. Range: 1-65535. |
+| `healthCheckPort` | int32 | No | Same as `port` | Port for LB health checks. Range: 1-65535. |
+| `targets` | []LoadBalancerTarget | No | -- | Backend instances to register. Updated incrementally by the bootstrap controller. |
+
+### LoadBalancerTarget
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ip` | string | Target IP address. |
+| `instanceID` | string | Cloud instance identifier. Used by AWS for instance-based NLB target groups. |
+| `instanceName` | string | Cloud instance name. Used by GCP for target pool registration. |
+
+Which target fields are populated depends on the cloud provider:
+- **GCP**: `ip` and `instanceName`
+- **AWS**: `ip` and `instanceID`
+- **Azure**: `ip` only (NICs are added to the backend pool directly)
+
+## Status
+
+```yaml
+status:
+  phase: Ready
+  endpoint: "35.194.52.218"
+  resourceID: "butler-mgmt-lb-fwd"
+  registeredTargets: 3
+  conditions:
+    - type: Provisioned
+      status: "True"
+      lastTransitionTime: "2026-03-10T12:00:00Z"
+      reason: "LBReady"
+      message: "Load balancer resources created"
+    - type: TargetsSynced
+      status: "True"
+      lastTransitionTime: "2026-03-10T12:05:00Z"
+      reason: "AllTargetsRegistered"
+      message: "3 targets registered"
+  lastUpdated: "2026-03-10T12:05:00Z"
+  observedGeneration: 2
+```
+
+### Status Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `phase` | LoadBalancerPhase | Current lifecycle phase. |
+| `endpoint` | string | LB IP address or DNS name. Populated when phase reaches Ready. |
+| `resourceID` | string | Cloud resource identifier used for cleanup. |
+| `failureReason` | string | Machine-readable failure reason. |
+| `failureMessage` | string | Human-readable failure details. |
+| `registeredTargets` | int32 | Number of backends registered with the LB. |
+| `conditions` | []Condition | Standard Kubernetes conditions (see below). |
+| `lastUpdated` | Time | Timestamp of the last status update. |
+| `observedGeneration` | int64 | Last observed spec generation. |
+
+### Phases
+
+| Phase | Description |
+|-------|-------------|
+| `Pending` | Request received, not yet processed by the provider controller. |
+| `Creating` | Cloud LB resources are being provisioned. |
+| `Ready` | LB is provisioned and has an endpoint. Control plane traffic can flow. |
+| `Failed` | Provisioning failed. Check `failureReason` and `failureMessage`. |
+| `Deleting` | LB resources are being torn down. |
+
+### Conditions
+
+| Type | Description |
+|------|-------------|
+| `Provisioned` | True when all cloud LB resources (IP, health check, forwarding rule) exist. |
+| `TargetsSynced` | True when all `spec.targets` are registered with the LB backend. |
+
+## Cloud Resources by Provider
+
+Each provider controller creates different cloud resources to implement the L4 passthrough load balancer:
+
+| Provider | Resources Created |
+|----------|-------------------|
+| GCP | Regional static IP, legacy HTTP health check, target pool, forwarding rule |
+| AWS | Network Load Balancer (NLB), target group (TCP), listener on port 6443 |
+| Azure | Public IP, Standard Load Balancer, health probe, load balancing rule, backend pool |
+
+All providers use TCP passthrough (not TLS termination). The kube-apiserver handles TLS directly.
+
+### Loopback Interface Patch
+
+Cloud passthrough load balancers deliver packets with the original destination IP (the LB's IP) unchanged. For the kube-apiserver to accept these connections, each control plane node must recognize the LB IP as a local address. The bootstrap controller handles this by adding a Talos config patch that assigns the LB IP to the loopback interface on each control plane node.
+
+## Finalizer
+
+| Finalizer | Purpose |
+|-----------|---------|
+| `butler.butlerlabs.dev/loadbalancerrequest` | Ensures cloud LB resources are deleted before the CR is removed. |
+
+## kubectl Output
+
+```
+$ kubectl get lbr -n butler-system
+NAME              CLUSTER        PHASE   ENDPOINT         TARGETS   AGE
+butler-mgmt-lb   butler-mgmt    Ready   35.194.52.218    3         45m
+```
+
+## Examples
+
+### GCP
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: LoadBalancerRequest
+metadata:
+  name: mgmt-lb
+  namespace: butler-system
+spec:
+  clusterName: mgmt
+  providerConfigRef:
+    name: gcp-config
+    namespace: butler-system
+  targets:
+    - ip: "10.128.0.10"
+      instanceName: "mgmt-cp-0"
+    - ip: "10.128.0.11"
+      instanceName: "mgmt-cp-1"
+    - ip: "10.128.0.12"
+      instanceName: "mgmt-cp-2"
+```
+
+### AWS
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: LoadBalancerRequest
+metadata:
+  name: mgmt-lb
+  namespace: butler-system
+spec:
+  clusterName: mgmt
+  providerConfigRef:
+    name: aws-config
+    namespace: butler-system
+  targets:
+    - ip: "10.0.1.10"
+      instanceID: "i-0abcd1234efgh5678"
+    - ip: "10.0.1.11"
+      instanceID: "i-0abcd1234efgh9012"
+    - ip: "10.0.1.12"
+      instanceID: "i-0abcd1234efgh3456"
+```
+
+### Azure
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: LoadBalancerRequest
+metadata:
+  name: mgmt-lb
+  namespace: butler-system
+spec:
+  clusterName: mgmt
+  providerConfigRef:
+    name: azure-config
+    namespace: butler-system
+  targets:
+    - ip: "10.0.0.4"
+    - ip: "10.0.0.5"
+    - ip: "10.0.0.6"
+```
+
+## See Also
+
+- [ClusterBootstrap](./clusterbootstrap.md) -- creates LoadBalancerRequest during cloud bootstrap
+- [ProviderConfig](./providerconfig.md) -- cloud credentials referenced by `providerConfigRef`
+- [Bootstrap Flow](../../architecture/bootstrap-flow.md) -- end-to-end bootstrap sequence
+- [GCP Provider Guide](../../providers/gcp.md)
+- [AWS Provider Guide](../../providers/aws.md)
+- [Azure Provider Guide](../../providers/azure.md)

--- a/docs/reference/crds/machinerequest.md
+++ b/docs/reference/crds/machinerequest.md
@@ -1,0 +1,166 @@
+---
+title: MachineRequest
+sidebar_position: 9
+---
+
+A MachineRequest represents a request to provision a virtual machine on an infrastructure provider.
+
+## API Version
+
+`butler.butlerlabs.dev/v1alpha1`
+
+## Scope
+
+Namespaced
+
+## Short Name
+
+`mr`
+
+## Description
+
+MachineRequest is the interface contract between Butler's orchestration controllers and infrastructure provider controllers. The bootstrap controller creates MachineRequest resources for management cluster nodes. The butler-controller creates them for tenant cluster workers. Provider controllers (butler-provider-harvester, butler-provider-nutanix, etc.) watch for MachineRequest resources, provision the requested VM, and update the status with the assigned IP address.
+
+The MachineRequest spec is provider-agnostic. All provider-specific details (endpoint, network, image defaults) come from the referenced ProviderConfig.
+
+## Specification
+
+### Full Example
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: MachineRequest
+metadata:
+  name: butler-mgmt-cp-0
+  namespace: butler-system
+spec:
+  providerRef:
+    name: harvester-prod
+    namespace: butler-system
+  machineName: butler-mgmt-cp-0
+  role: control-plane
+  cpu: 4
+  memoryMB: 16384
+  diskGB: 100
+  extraDisks:
+    - sizeGB: 500
+      storageClass: longhorn
+  image: "default/talos-v1.9.2"
+  userData: |
+    #cloud-config
+    ...
+  labels:
+    butler.butlerlabs.dev/cluster: butler-mgmt
+    butler.butlerlabs.dev/role: control-plane
+```
+
+### Spec Fields
+
+| Field | Type | Required | Validation | Description |
+|-------|------|----------|------------|-------------|
+| `providerRef` | ProviderReference | Yes | -- | References the ProviderConfig with infrastructure credentials. |
+| `machineName` | string | Yes | 1-63 chars, DNS-safe | Desired VM name. Must be unique within the provider's namespace or project. |
+| `role` | MachineRole | Yes | Enum | Machine role: `control-plane` or `worker`. |
+| `cpu` | int32 | Yes | 1-128 | Virtual CPU cores. |
+| `memoryMB` | int32 | Yes | min 1024 | Memory in megabytes. |
+| `diskGB` | int32 | Yes | min 10 | Root disk size in gigabytes. |
+| `extraDisks` | []DiskSpec | No | -- | Additional disks to attach. |
+| `image` | string | No | -- | OS image override. Format is provider-specific (see below). Defaults to the image configured in ProviderConfig. |
+| `userData` | string | No | -- | Cloud-init user data. Typically contains the Talos machine configuration. |
+| `networkData` | string | No | -- | Cloud-init network configuration. |
+| `labels` | map[string]string | No | -- | Key-value pairs applied to the VM in the provider. |
+
+### DiskSpec
+
+| Field | Type | Required | Validation | Description |
+|-------|------|----------|------------|-------------|
+| `sizeGB` | int32 | Yes | min 1 | Disk size in gigabytes. |
+| `storageClass` | string | No | -- | Provider-specific storage class or tier. |
+
+### Image Format by Provider
+
+| Provider | Format | Example |
+|----------|--------|---------|
+| Harvester | `namespace/image-name` | `default/talos-v1.9.2` |
+| Nutanix | UUID | `a1b2c3d4-e5f6-7890-abcd-ef1234567890` |
+| Proxmox | Template ID or image name | `9000` |
+| GCP | Image family or self link | `projects/my-project/global/images/talos-v1-9-2` |
+| AWS | AMI ID | `ami-0abcdef1234567890` |
+| Azure | Image reference | `/subscriptions/.../images/talos-v1-9-2` |
+
+## Status
+
+```yaml
+status:
+  phase: Running
+  providerID: "abc123-def456"
+  ipAddress: "10.40.0.10"
+  ipAddresses:
+    - "10.40.0.10"
+  macAddress: "52:54:00:12:34:56"
+  conditions:
+    - type: Ready
+      status: "True"
+      lastTransitionTime: "2026-03-10T12:00:00Z"
+      reason: "VMRunning"
+      message: "Virtual machine is running"
+  lastUpdated: "2026-03-10T12:00:00Z"
+  observedGeneration: 1
+```
+
+### Status Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `phase` | MachinePhase | Current lifecycle phase (see Phases below). |
+| `providerID` | string | Provider-specific VM identifier (Harvester VM UID, Nutanix VM UUID, etc.). |
+| `ipAddress` | string | Primary IP address. Set when phase reaches Running. |
+| `ipAddresses` | []string | All IP addresses assigned to the machine. |
+| `macAddress` | string | Primary MAC address. |
+| `failureReason` | string | Machine-readable failure reason. |
+| `failureMessage` | string | Human-readable failure details. |
+| `conditions` | []Condition | Standard Kubernetes conditions. |
+| `lastUpdated` | Time | Timestamp of the last status update. |
+| `observedGeneration` | int64 | Last observed spec generation. |
+
+## Phases
+
+| Phase | Description |
+|-------|-------------|
+| `Pending` | Request received, not yet processed by the provider controller. |
+| `Creating` | Provider controller is creating the VM. |
+| `Running` | VM is running and has an IP address. |
+| `Failed` | VM creation failed. Check `failureReason` and `failureMessage`. |
+| `Deleting` | VM is being deleted. |
+| `Deleted` | VM has been deleted. |
+| `Unknown` | VM state cannot be determined. |
+
+## Provider Controller Contract
+
+Every provider controller must:
+
+1. Watch MachineRequest resources filtered by its provider type
+2. Read credentials from the ProviderConfig referenced by `providerRef`
+3. Create a VM matching the requested resources (CPU, memory, disk)
+4. Update `status.phase` through the lifecycle: Pending, Creating, Running
+5. Set `status.ipAddress` when the VM obtains an IP
+6. Add a finalizer to ensure VM cleanup on deletion
+7. Delete the VM and remove the finalizer during CR deletion
+8. Record Kubernetes events for audit trail
+
+## kubectl Output
+
+```
+$ kubectl get mr -n butler-system
+NAME                 MACHINE              ROLE            PHASE     IP           AGE
+butler-mgmt-cp-0    butler-mgmt-cp-0     control-plane   Running   10.40.0.10   30m
+butler-mgmt-cp-1    butler-mgmt-cp-1     control-plane   Running   10.40.0.11   30m
+butler-mgmt-cp-2    butler-mgmt-cp-2     control-plane   Running   10.40.0.12   30m
+butler-mgmt-w-0     butler-mgmt-w-0      worker          Running   10.40.0.20   28m
+```
+
+## See Also
+
+- [ClusterBootstrap](./clusterbootstrap.md) -- creates MachineRequests during management cluster bootstrap
+- [ProviderConfig](./providerconfig.md) -- credentials referenced by `providerRef`
+- [Provider Guides](../../providers/) -- per-provider setup instructions

--- a/docs/reference/crds/machinerequest.md
+++ b/docs/reference/crds/machinerequest.md
@@ -161,6 +161,6 @@ butler-mgmt-w-0     butler-mgmt-w-0      worker          Running   10.40.0.20   
 
 ## See Also
 
-- [ClusterBootstrap](./clusterbootstrap.md) -- creates MachineRequests during management cluster bootstrap
-- [ProviderConfig](./providerconfig.md) -- credentials referenced by `providerRef`
-- [Provider Guides](../../providers/) -- per-provider setup instructions
+- [ClusterBootstrap](./clusterbootstrap.md) - creates MachineRequests during management cluster bootstrap
+- [ProviderConfig](./providerconfig.md) - credentials referenced by `providerRef`
+- [Provider Guides](../../providers/) - per-provider setup instructions


### PR DESCRIPTION
## Summary

- Add CRD reference docs for ClusterBootstrap, MachineRequest, and LoadBalancerRequest
- Add cloud provider guides for GCP, AWS, and Azure following the existing Harvester/Nutanix pattern
- Rewrite bootstrap-flow architecture doc to cover both on-prem and cloud paths with separate sequence diagrams
- Update CRD reference index with links to new docs and LoadBalancerRequest/ClusterBootstrap finalizers
- Update providers index with cloud providers at Beta status and two-layer architecture diagram
- Add cloud bootstrap commands (gcp, aws, azure) to butleradm CLI reference

## Test plan

- [ ] All cross-links resolve to existing files
- [ ] Example YAML matches actual CRD field names and types from butler-api
- [ ] Mermaid diagrams render correctly on GitHub
- [ ] Existing on-prem provider docs unchanged
- [ ] No broken relative links in see-also sections