### PR TITLE
docs: comprehensive bootstrap documentation overhaul

### DIFF
--- a/docs/architecture/bootstrap-flow.md
+++ b/docs/architecture/bootstrap-flow.md
@@ -58,8 +58,10 @@ sequenceDiagram
     end
 
     rect rgb(230, 245, 255)
-        Note over Bootstrap,Infra: Phase 2: VM Provisioning
+        Note over Bootstrap,Infra: Phase 2: Image Sync + VM Provisioning
         Bootstrap->>Bootstrap: Watch ClusterBootstrap
+        Bootstrap->>KIND: Create ImageSync CR (sync Talos image to provider)
+        Bootstrap->>Bootstrap: Wait for ImageSync Ready
         Bootstrap->>Provider: Create MachineRequest CRs
         Provider->>Infra: Create VMs
         Infra-->>Provider: VMs running with IPs
@@ -127,7 +129,9 @@ sequenceDiagram
     end
 
     rect rgb(230, 245, 255)
-        Note over Bootstrap,Cloud: Phase 2: Infrastructure Provisioning
+        Note over Bootstrap,Cloud: Phase 2: Image Sync + Infrastructure Provisioning
+        Bootstrap->>KIND: Create ImageSync CR (sync Talos image to provider)
+        Bootstrap->>Bootstrap: Wait for ImageSync Ready
         Bootstrap->>KIND: Create LoadBalancerRequest CR
         Bootstrap->>Provider: Create MachineRequest CRs
         Provider->>Cloud: Provision cloud load balancer resources
@@ -214,9 +218,11 @@ Internally:
 - Clean separation between orchestration and infrastructure
 - Can preserve for debugging with `--skip-cleanup`
 
-### Phase 2: VM Provisioning
+### Phase 2: Image Sync + VM Provisioning
 
-The bootstrap controller creates MachineRequest CRs for each node defined in the ClusterBootstrap spec. The provider controller watches these resources, creates VMs, and reports IP addresses.
+Before creating VMs, the bootstrap controller creates an `ImageSync` CR to sync the Talos OS image to the infrastructure provider via Butler Image Factory. ImageSync uses deduplication labels (`schematic-id`, `image-version`, `image-arch`, `provider-config`) so multiple bootstraps referencing the same schematic reuse a single synced image.
+
+After ImageSync reaches `Ready`, the bootstrap controller creates MachineRequest CRs for each node defined in the ClusterBootstrap spec. The provider controller watches these resources, creates VMs, and reports IP addresses.
 
 ```yaml
 apiVersion: butler.butlerlabs.dev/v1alpha1

--- a/docs/architecture/bootstrap-flow.md
+++ b/docs/architecture/bootstrap-flow.md
@@ -58,10 +58,9 @@ sequenceDiagram
     end
 
     rect rgb(230, 245, 255)
-        Note over Bootstrap,Infra: Phase 2: Image Sync + VM Provisioning
+        Note over Bootstrap,Infra: Phase 2: VM Provisioning
         Bootstrap->>Bootstrap: Watch ClusterBootstrap
-        Bootstrap->>KIND: Create ImageSync CR (sync Talos image to provider)
-        Bootstrap->>Bootstrap: Wait for ImageSync Ready
+        Note over Bootstrap: ImageSync: skipped (no ButlerConfig in KIND)
         Bootstrap->>Provider: Create MachineRequest CRs
         Provider->>Infra: Create VMs
         Infra-->>Provider: VMs running with IPs
@@ -129,9 +128,8 @@ sequenceDiagram
     end
 
     rect rgb(230, 245, 255)
-        Note over Bootstrap,Cloud: Phase 2: Image Sync + Infrastructure Provisioning
-        Bootstrap->>KIND: Create ImageSync CR (sync Talos image to provider)
-        Bootstrap->>Bootstrap: Wait for ImageSync Ready
+        Note over Bootstrap,Cloud: Phase 2: Infrastructure Provisioning
+        Note over Bootstrap: ImageSync: skipped (no ButlerConfig in KIND)
         Bootstrap->>KIND: Create LoadBalancerRequest CR
         Bootstrap->>Provider: Create MachineRequest CRs
         Provider->>Cloud: Provision cloud load balancer resources
@@ -218,11 +216,11 @@ Internally:
 - Clean separation between orchestration and infrastructure
 - Can preserve for debugging with `--skip-cleanup`
 
-### Phase 2: Image Sync + VM Provisioning
+### Phase 2: VM Provisioning
 
-Before creating VMs, the bootstrap controller creates an `ImageSync` CR to sync the Talos OS image to the infrastructure provider via Butler Image Factory. ImageSync uses deduplication labels (`schematic-id`, `image-version`, `image-arch`, `provider-config`) so multiple bootstraps referencing the same schematic reuse a single synced image.
+The bootstrap controller calls `reconcileImageSync()` before creating VMs. This step creates an `ImageSync` CR to sync the Talos image to the infrastructure provider via Butler Image Factory. However, ImageSync requires a `ButlerConfig` resource with `spec.imageFactory.url` configured. During initial `butleradm bootstrap`, no ButlerConfig exists in the KIND cluster, so ImageSync is silently skipped. Images must be pre-uploaded to the infrastructure provider (see each provider guide for image upload steps).
 
-After ImageSync reaches `Ready`, the bootstrap controller creates MachineRequest CRs for each node defined in the ClusterBootstrap spec. The provider controller watches these resources, creates VMs, and reports IP addresses.
+The bootstrap controller then creates MachineRequest CRs for each node defined in the ClusterBootstrap spec. The provider controller watches these resources, creates VMs, and reports IP addresses.
 
 ```yaml
 apiVersion: butler.butlerlabs.dev/v1alpha1

--- a/docs/architecture/bootstrap-flow.md
+++ b/docs/architecture/bootstrap-flow.md
@@ -4,9 +4,9 @@ This document describes how Butler bootstraps a management cluster from scratch,
 
 ## Overview
 
-Bootstrapping creates a new Butler management cluster on your infrastructure. The process uses a temporary [KIND](https://kind.sigs.k8s.io/) cluster to orchestrate the bootstrap, then cleans up after completion.
+The bootstrap process creates a Butler management cluster from scratch. A temporary [KIND](https://kind.sigs.k8s.io/) cluster orchestrates the bootstrap, then is deleted on completion.
 
-Butler supports two deployment models:
+Two deployment models:
 
 - **On-prem** (Harvester, Nutanix, Proxmox): Uses kube-vip for control plane HA with a floating virtual IP. MetalLB provides LoadBalancer services.
 - **Cloud** (GCP, AWS, Azure): Uses a cloud-native L4 load balancer for control plane HA. Cloud load balancers handle services natively.

--- a/docs/architecture/bootstrap-flow.md
+++ b/docs/architecture/bootstrap-flow.md
@@ -58,9 +58,10 @@ sequenceDiagram
     end
 
     rect rgb(230, 245, 255)
-        Note over Bootstrap,Infra: Phase 2: VM Provisioning
+        Note over Bootstrap,Infra: Phase 2: Image Sync + VM Provisioning
         Bootstrap->>Bootstrap: Watch ClusterBootstrap
-        Note over Bootstrap: ImageSync: skipped (no ButlerConfig in KIND)
+        Bootstrap->>KIND: Create ImageSync CR (if ButlerConfig has ImageFactory)
+        Bootstrap->>Bootstrap: Wait for ImageSync Ready (or skip if no ButlerConfig)
         Bootstrap->>Provider: Create MachineRequest CRs
         Provider->>Infra: Create VMs
         Infra-->>Provider: VMs running with IPs
@@ -128,8 +129,9 @@ sequenceDiagram
     end
 
     rect rgb(230, 245, 255)
-        Note over Bootstrap,Cloud: Phase 2: Infrastructure Provisioning
-        Note over Bootstrap: ImageSync: skipped (no ButlerConfig in KIND)
+        Note over Bootstrap,Cloud: Phase 2: Image Sync + Infrastructure Provisioning
+        Bootstrap->>KIND: Create ImageSync CR (if ButlerConfig has ImageFactory)
+        Bootstrap->>Bootstrap: Wait for ImageSync Ready (or skip if no ButlerConfig)
         Bootstrap->>KIND: Create LoadBalancerRequest CR
         Bootstrap->>Provider: Create MachineRequest CRs
         Provider->>Cloud: Provision cloud load balancer resources
@@ -216,9 +218,11 @@ Internally:
 - Clean separation between orchestration and infrastructure
 - Can preserve for debugging with `--skip-cleanup`
 
-### Phase 2: VM Provisioning
+### Phase 2: Image Sync + VM Provisioning
 
-The bootstrap controller calls `reconcileImageSync()` before creating VMs. This step creates an `ImageSync` CR to sync the Talos image to the infrastructure provider via Butler Image Factory. However, ImageSync requires a `ButlerConfig` resource with `spec.imageFactory.url` configured. During initial `butleradm bootstrap`, no ButlerConfig exists in the KIND cluster, so ImageSync is silently skipped. Images must be pre-uploaded to the infrastructure provider (see each provider guide for image upload steps).
+The bootstrap controller calls `reconcileImageSync()` before creating VMs. When a `ButlerConfig` with `spec.imageFactory.url` exists in the KIND cluster, this step creates an `ImageSync` CR that downloads the Talos image from Butler Image Factory and uploads it to the infrastructure provider. ImageSync uses deduplication labels (`schematic-id`, `image-version`, `image-arch`, `provider-config`) so multiple bootstraps reuse a single synced image. The controller blocks until ImageSync reaches `Ready` before proceeding.
+
+When no ButlerConfig exists in KIND (current default for `butleradm bootstrap`), ImageSync is skipped and images must be pre-uploaded to the provider. See each provider guide for image upload steps. Adding `ButlerConfig` creation to the bootstrap CLI is planned, which will make ImageSync the default path.
 
 The bootstrap controller then creates MachineRequest CRs for each node defined in the ClusterBootstrap spec. The provider controller watches these resources, creates VMs, and reports IP addresses.
 

--- a/docs/architecture/bootstrap-flow.md
+++ b/docs/architecture/bootstrap-flow.md
@@ -31,7 +31,7 @@ Butler supports two deployment models:
 
 - Cloud credentials with compute and networking permissions
 - A VPC/VNet with a subnet for cluster nodes
-- Firewall rules allowing TCP 6443, 50000, and 50001 between nodes
+- Firewall rules allowing inter-node traffic: TCP 6443, 50000-50001, 2379-2380, 10250, 4240 and UDP 8472 (Cilium VXLAN)
 - A VM image (Talos Linux) available in the target region
 
 ## On-Prem Bootstrap Sequence
@@ -84,9 +84,11 @@ sequenceDiagram
         Bootstrap->>MC: Install Longhorn (storage)
         Bootstrap->>MC: Install MetalLB (LoadBalancer services)
         Bootstrap->>MC: Install Traefik (ingress)
+        Bootstrap->>MC: Install Gateway API CRDs
         Bootstrap->>MC: Install Steward (hosted control planes)
         Bootstrap->>MC: Install CAPI + infrastructure providers
-        Bootstrap->>MC: Install Butler controller
+        Bootstrap->>MC: Install Butler CRDs + controller
+        Bootstrap->>MC: Install Butler Console
         Bootstrap->>MC: Install Flux (optional)
     end
 
@@ -151,11 +153,15 @@ sequenceDiagram
         Note over Bootstrap,MC: Phase 4: Addon Installation
         Note over Bootstrap,MC: kube-vip and MetalLB are SKIPPED for cloud
         Bootstrap->>MC: Install Cilium (CNI)
+        Bootstrap->>MC: Install Cloud Controller Manager
+        Bootstrap->>MC: Patch node providerIDs
         Bootstrap->>MC: Install cert-manager
         Bootstrap->>MC: Install Longhorn (storage)
+        Bootstrap->>MC: Install Gateway API CRDs
         Bootstrap->>MC: Install Steward (hosted control planes)
         Bootstrap->>MC: Install CAPI + cloud infrastructure providers
-        Bootstrap->>MC: Install Butler controller
+        Bootstrap->>MC: Install Butler CRDs + controller
+        Bootstrap->>MC: Install Butler Console (type: LoadBalancer)
         Bootstrap->>MC: Install Flux (optional)
     end
 
@@ -246,19 +252,28 @@ Once all VMs are running (and for cloud, the LB endpoint is ready):
 
 Platform addons are installed in dependency order. The set of addons differs between on-prem and cloud:
 
-| Order | Addon | On-Prem | Cloud | Purpose |
-|-------|-------|---------|-------|---------|
-| 1 | kube-vip | Yes | No | Floating VIP for control plane HA |
+| Step | Addon | On-Prem | Cloud | Purpose |
+|------|-------|---------|-------|---------|
+| 1 | kube-vip | Yes | Skip | Floating VIP for control plane HA. Cloud uses LB instead. |
 | 2 | Cilium | Yes | Yes | CNI with kube-proxy replacement |
+| 2.5 | Cloud Controller Manager | Skip | Yes | AWS: Helm chart. GCP: embedded DaemonSet. Azure: embedded Deployment. Runs in service-controller-only mode. |
+| 2.6 | providerID patching | Skip | Yes | Patches `spec.providerID` on each node via kubectl. Required for CCM LB target registration. |
 | 3 | cert-manager | Yes | Yes | TLS certificate automation |
-| 4 | Longhorn | Yes | Yes | Distributed persistent storage |
-| 5 | MetalLB | Yes | No | LoadBalancer service implementation |
-| 6 | Traefik | Yes | No | Ingress controller |
-| 7 | Steward | Yes | Yes | Hosted tenant control planes |
-| 8 | CAPI + providers | Yes | Yes | Cluster API for tenant worker lifecycle |
-| 9 | Butler controller | Yes | Yes | Platform reconciliation controller |
-| 10 | Flux | Optional | Optional | GitOps controller |
-| 11 | Butler Console | Optional | Optional | Web UI |
+| 4 | Longhorn | Yes | Yes | Distributed persistent storage. Replica count matches topology. |
+| 5 | MetalLB | If pool set | Skip | LoadBalancer service implementation. Uses `network.loadBalancerPool` config. |
+| 6 | Traefik | Yes | Skip | Ingress controller. Cloud uses CCM for LB services directly. |
+| 7a | Gateway API CRDs | Yes | Yes | Gateway API custom resource definitions |
+| 7b | Steward | Yes | Yes | Hosted tenant control planes |
+| 8 | CAPI + providers | If enabled | If enabled | Cluster API for tenant worker lifecycle |
+| 9 | Flux | If enabled | If enabled | GitOps controller |
+| 9.5 | Butler CRDs | Yes | Yes | Butler custom resource definitions |
+| 9.6 | ProviderConfig | Yes | Yes | Copies provider config from KIND to management cluster |
+| 9.7 | Butler Addons | Yes | Yes | AddonDefinition catalog |
+| 10 | Butler controller | Yes | Yes | Platform reconciliation controller |
+| 11 | Butler | Yes | Yes | ButlerConfig and supporting resources |
+| 11.5 | ButlerConfig exposure | Yes | Yes | Exposes ButlerConfig to management cluster |
+| 12 | Butler Console | Optional | Optional | Web UI. On-prem: Ingress via Traefik. Cloud: `type: LoadBalancer` with cloud LB. |
+| 12.5 | Azure LB backend pool | Skip | Azure only | Workaround for CCM v1.31 `vmType=standard` bug that doesn't auto-populate LB backend pools. Adds nodes to backend pool via Azure REST API. |
 
 ### Phase 5: Completion
 
@@ -320,6 +335,32 @@ Single-node topology skips kube-vip (no HA needed with one node), forces Longhor
 - GCP health checks come from `130.211.0.0/22` and `35.191.0.0/16`
 - AWS NLB health checks come from within the VPC
 - Confirm kube-apiserver is listening on port 6443
+
+### Cloud-Specific Failure Modes
+
+**CCM deadlock (all cloud providers):**
+Setting `--cloud-provider=external` on the kubelet adds an `node.cloudprovider.kubernetes.io/uninitialized` taint that blocks ALL pods until the CCM removes it. But the CCM is itself a pod, creating a deadlock. Butler avoids this by NOT setting the flag. The CCM runs in service-controller-only mode (handles `type: LoadBalancer` services) and does not manage node lifecycle. The providerID is patched directly via kubectl in step 2.6.
+
+**Azure public IP quota exceeded:**
+Standard Public IPs default to 3 per region on restricted and free-tier subscriptions. Single-node needs 2 PIPs (1 VM + 1 console LB). HA needs 6 (5 VMs + 1 LB). If you see `PublicIPCountLimitReached` in the provider logs, request a quota increase through the Azure portal under Subscription > Usage + quotas. Self-service quota increase via `az quota create` may fail on restricted subscriptions.
+
+**Azure CCM backend pool empty:**
+Azure CCM v1.31 with `vmType=standard` does not auto-populate LB backend pools. The initial backend sync runs before any LoadBalancer services exist, and no subsequent sync is triggered when the console service is created. Butler handles this automatically in step 12.5 by calling the Azure REST API to add each node's NIC to the backend pool. If step 12.5 fails, check the bootstrap controller logs for Azure REST API errors.
+
+**GCP CCM nodeipam crash:**
+The GCP CCM logs `error running controllers: the AllocateNodeCIDRs is not enabled` when the nodeipam controller tries to allocate pod CIDRs. This is expected because Cilium manages pod IPAM. Butler's embedded CCM manifest includes `--controllers=*,-nodeipam --allocate-node-cidrs=false` to disable the nodeipam controller.
+
+**GCP CCM network tags missing:**
+The GCP CCM logs `no node tags supplied...Abort creating firewall rule` when creating LoadBalancer service firewall rules. The CCM needs network tags on instances to scope rules. Butler's provider controller tags instances with the cluster name, and the CCM `cloud-config` includes `node-tags = <clusterName>`.
+
+**providerID not set on nodes:**
+Since the CCM runs in service-controller-only mode (no `--cloud-provider=external` flag on kubelet), it does not manage node lifecycle or set `spec.providerID`. The bootstrap controller patches providerIDs directly in step 2.6 using the format specific to each provider (e.g., `aws:///<zone>/<instance-id>`, `gce://<project>/<zone>/<instance>`, `azure:///subscriptions/...`). Without providerIDs, the CCM cannot map Kubernetes nodes to cloud instances for LB target registration.
+
+**MetalLB ARP not working on cloud networks:**
+Cloud networks (AWS VPC, GCP VPC, Azure VNet) do not forward L2 ARP broadcasts. kube-vip and MetalLB both rely on ARP to claim IP addresses. Butler automatically skips kube-vip and MetalLB for cloud providers, using a cloud load balancer for the control plane endpoint and the CCM for LoadBalancer services.
+
+**Corporate proxy / Zscaler blocking KIND connectivity:**
+The KIND bootstrap cluster runs inside a Docker container and may not have access to corporate DNS servers or Zscaler-proxied infrastructure endpoints (Harvester, Nutanix Prism Central). For Nutanix, use the `hostAliases` field in the provider config to inject `/etc/hosts` entries into the KIND container. For other providers, add entries to the Docker host's `/etc/hosts` or configure Docker's DNS settings.
 
 ### Preserving KIND Cluster
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,47 +1,46 @@
 # Getting Started with Butler
 
-Install Butler and bootstrap a management cluster.
+Butler is a Kubernetes-as-a-Service platform. It provisions and manages tenant Kubernetes clusters across on-prem and cloud infrastructure from a single management cluster.
+
+This page covers installing the CLI, bootstrapping a management cluster, and creating your first tenant cluster.
 
 ## Table of Contents
 
 - [Prerequisites](#prerequisites)
 - [Install CLI](#install-cli)
-- [Bootstrap Management Cluster](#bootstrap-management-cluster)
-- [Create Your First Cluster](#create-your-first-cluster)
-- [Next Steps](#next-steps)
+- [Bootstrap a Management Cluster](#bootstrap-a-management-cluster)
+- [Create Your First Tenant Cluster](#create-your-first-tenant-cluster)
+- [Troubleshooting](#troubleshooting)
 
 ---
 
 ## Prerequisites
 
-### Required
-
 | Requirement | Description |
 |-------------|-------------|
-| Docker | For running the temporary KIND bootstrap cluster |
+| Docker | Runs the temporary KIND bootstrap cluster |
 | kubectl | Kubernetes CLI (1.28+) |
-| Infrastructure | Harvester, Nutanix, AWS, GCP, or Azure account |
-| Network | IP addresses for control plane VIP and LoadBalancer pool (on-prem only) |
+| Infrastructure | One of: Harvester, Nutanix, AWS, GCP, or Azure |
 
-### Infrastructure-Specific
+Each infrastructure provider has additional prerequisites (credentials, networking, VM images). Follow the provider guide for your infrastructure **before** running bootstrap:
 
-**For On-Prem (Harvester, Nutanix):**
-- Infrastructure API access (Harvester kubeconfig or Prism Central credentials)
-- VM network configured with DHCP or static IPs
-- Talos Linux image uploaded to the infrastructure
-- A VIP address reserved for the control plane endpoint
-- An IP range for MetalLB LoadBalancer services
+| Provider | Guide |
+|----------|-------|
+| Harvester | [Harvester Provider Guide](../providers/harvester.md) |
+| Nutanix | [Nutanix Provider Guide](../providers/nutanix.md) |
+| AWS | [AWS Provider Guide](../providers/aws.md) |
+| GCP | [GCP Provider Guide](../providers/gcp.md) |
+| Azure | [Azure Provider Guide](../providers/azure.md) |
 
-**For Cloud (AWS, GCP, Azure):**
-- Cloud account with compute and networking permissions
-- VPC/VNet with a subnet and firewall/security group rules
-- Talos Linux image available in the target region (AMI, GCE image, or Azure gallery image)
-
-See [Provider Guides](../providers/) for detailed per-provider setup.
+Each provider guide walks through prerequisites, infrastructure setup, config creation, running bootstrap, and validation. Once your management cluster is running, come back here to create your first tenant cluster.
 
 ---
 
 ## Install CLI
+
+Butler ships two CLI binaries:
+- `butleradm` -- platform administration (bootstrap, provider management)
+- `butlerctl` -- tenant operations (create clusters, get kubeconfigs)
 
 ### macOS / Linux (Homebrew)
 
@@ -52,17 +51,13 @@ brew install butlerdotdev/tap/butler
 ### macOS / Linux (Direct Download)
 
 ```bash
-# Detect OS and architecture
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 [[ "$ARCH" == "x86_64" ]] && ARCH="amd64"
 [[ "$ARCH" == "aarch64" ]] && ARCH="arm64"
 
-# Download latest release
 curl -sLO "https://github.com/butlerdotdev/butler-cli/releases/latest/download/butler_${OS}_${ARCH}.tar.gz"
 tar xzf butler_${OS}_${ARCH}.tar.gz
-
-# Install
 sudo mv butleradm butlerctl /usr/local/bin/
 ```
 
@@ -90,109 +85,75 @@ butlerctl version
 
 ---
 
-## Bootstrap Management Cluster
+## Bootstrap a Management Cluster
 
-### 1. Create Bootstrap Configuration
+Bootstrap creates a management cluster on your infrastructure. The process takes 15-30 minutes and produces:
 
-Create a YAML config file for `butleradm`. This example uses Harvester. See [Provider Guides](../providers/) for AWS, GCP, Azure, and Nutanix configs.
+- A Kubernetes cluster running Talos Linux
+- Cilium CNI, Longhorn storage, cert-manager
+- Steward for hosted tenant control planes
+- Butler CRDs, controller, and console
+- On-prem: kube-vip (control plane HA) + MetalLB + Traefik (ingress)
+- Cloud: Cloud Controller Manager + cloud load balancers
 
-```yaml
-provider: harvester
+### 1. Follow Your Provider Guide
 
-cluster:
-  name: butler-hvstr-test
-  topology: single-node
-  controlPlane:
-    replicas: 1
-    cpu: 4
-    memoryMB: 8192
-    diskGB: 50
-    extraDisks:
-      - sizeGB: 50
+Each provider guide includes the full config file, infrastructure setup steps, and the bootstrap command. Pick your provider:
 
-network:
-  podCIDR: 10.244.0.0/16
-  serviceCIDR: 10.96.0.0/12
-  vip: 10.40.0.230
-  loadBalancerPool:
-    start: 10.40.0.240
-    end: 10.40.0.250
+- [Harvester](../providers/harvester.md) -- on-prem, Harvester HCI
+- [Nutanix](../providers/nutanix.md) -- on-prem, Nutanix AHV
+- [AWS](../providers/aws.md) -- cloud, Amazon Web Services
+- [GCP](../providers/gcp.md) -- cloud, Google Cloud Platform
+- [Azure](../providers/azure.md) -- cloud, Microsoft Azure
 
-talos:
-  version: v1.12.1
-  schematic: dc7b152cb3ea99b821fcb7340ce7168313ce393d663740b791c36f6e95fc8586
+### 2. What Bootstrap Does
 
-addons:
-  cni:
-    type: cilium
-  storage:
-    type: longhorn
-  loadBalancer:
-    type: metallb
-  console:
-    enabled: true
-    ingress:
-      enabled: true
-      className: traefik
-
-providerConfig:
-  harvester:
-    kubeconfigPath: ~/.butler/harvester-kubeconfig
-    namespace: default
-    networkName: default/vlan40-workloads
-    imageName: default/image-5rs6d
+```
+butleradm bootstrap <provider> --config ~/.butler/bootstrap-<provider>.yaml
 ```
 
-Save this as `~/.butler/bootstrap.yaml`.
-
-Every config field and its defaults are documented in the [Bootstrap Config Reference](../reference/bootstrap-config.md).
-
-### 2. Run Bootstrap
-
-```bash
-butleradm bootstrap harvester --config ~/.butler/bootstrap.yaml
-```
+1. Creates a temporary KIND cluster on your machine
+2. Deploys Butler bootstrap controller and provider controller into KIND
+3. Provisions VMs on your infrastructure
+4. Generates and applies Talos Linux configs to each node
+5. Bootstraps Kubernetes on the first control plane node
+6. Installs platform addons (Cilium, cert-manager, Longhorn, Steward, Butler, Console)
+7. Saves kubeconfig to `~/.butler/<cluster-name>-kubeconfig`
+8. Deletes the KIND cluster
 
 Available flags:
 
 | Flag | Description |
 |------|-------------|
-| `--config <path>` | Path to the bootstrap config YAML (required) |
+| `--config <path>` | Path to bootstrap config YAML (required) |
 | `--no-tui` | Disable interactive TUI, use line-by-line log output |
 | `--skip-cleanup` | Keep the KIND cluster after bootstrap for debugging |
 | `--local` | Build controller images from local source (development) |
 | `--provider-image <image>` | Override the provider controller container image |
 
-This will:
-1. Create a temporary KIND cluster on your machine
-2. Deploy Butler CRDs, bootstrap controller, and provider controller into KIND
-3. Provision VMs on your infrastructure
-4. Generate and apply Talos Linux configs to each node
-5. Bootstrap Kubernetes on the first control plane node
-6. Install addons (Cilium, cert-manager, Longhorn, MetalLB, Steward, Butler, Console)
-7. Save kubeconfig and talosconfig to `~/.butler/`
-8. Delete the KIND cluster (unless `--skip-cleanup`)
+### 3. After Bootstrap
 
-**Expected duration:** 15-30 minutes.
-
-### 3. Verify Installation
+The kubeconfig is saved as `~/.butler/<cluster-name>-kubeconfig`. The cluster name comes from `cluster.name` in your config file.
 
 ```bash
-export KUBECONFIG=~/.butler/butler-hvstr-test-kubeconfig
+# Example: if cluster.name is "butler-mgmt"
+export KUBECONFIG=~/.butler/butler-mgmt-kubeconfig
 
 kubectl get nodes
 kubectl get pods -n butler-system
-kubectl get pods -n kube-system -l app.kubernetes.io/name=cilium
-kubectl get pods -n longhorn-system
-kubectl get pods -n cert-manager
-kubectl get pods -n steward-system
 ```
+
+The provider guide for your infrastructure includes a full validation checklist. Complete that before continuing.
 
 ---
 
-## Create Your First Cluster
+## Create Your First Tenant Cluster
 
-### 1. Create a Team (Optional)
+After your management cluster is running and validated, create a tenant cluster.
+
+### 1. Create a Team
+
+Teams are the multi-tenancy boundary in Butler. Each team gets its own namespace.
 
 ```bash
 cat <<EOF | kubectl apply -f -
@@ -211,7 +172,7 @@ EOF
 
 ### 2. Create a Tenant Cluster
 
-Using CLI:
+Using the CLI:
 
 ```bash
 butlerctl cluster create my-first-cluster \
@@ -276,43 +237,10 @@ kubectl get pods -A
 
 ## Next Steps
 
-### Install Console
-
-Access Butler via a web UI:
-
-```bash
-helm install butler-console oci://ghcr.io/butlerdotdev/charts/butler-console \
-  -n butler-system \
-  --set ingress.enabled=true \
-  --set ingress.host=butler.example.com
-```
-
-### Enable GitOps
-
-Manage clusters declaratively via Git:
-
-```bash
-# Install Flux (if not already installed)
-flux bootstrap github \
-  --owner=myorg \
-  --repository=butler-clusters \
-  --path=clusters/butler-mgmt
-```
-
-### Add Monitoring
-
-Install observability stack:
-
-```bash
-butlerctl addon install prometheus --cluster my-first-cluster
-```
-
-### Read More
-
-- [Architecture](../architecture/) - Understand how Butler works
-- [Operations Guide](../operations/) - Day-2 operations
-- [Provider Guides](../providers/) - Infrastructure-specific setup
-- [Bootstrap Config Reference](../reference/bootstrap-config.md) - Every config field documented
+- [Architecture](../architecture/) -- how Butler works internally
+- [Operations Guide](../operations/) -- day-2 operations
+- [Bootstrap Config Reference](../reference/bootstrap-config.md) -- every config field documented
+- [Bootstrap Flow](../architecture/bootstrap-flow.md) -- detailed bootstrap sequence
 
 ---
 
@@ -321,10 +249,10 @@ butlerctl addon install prometheus --cluster my-first-cluster
 ### Bootstrap Fails
 
 ```bash
-# Use --skip-cleanup to keep KIND cluster for debugging
-butleradm bootstrap harvester --config bootstrap.yaml --skip-cleanup
+# Re-run with --skip-cleanup to keep KIND cluster for debugging
+butleradm bootstrap <provider> --config <path> --skip-cleanup
 
-# Then inspect the bootstrap state from the KIND context:
+# Inspect bootstrap state from the KIND context:
 kubectl --context kind-butler-bootstrap get clusterbootstrap -n butler-system
 kubectl --context kind-butler-bootstrap get machinerequest -n butler-system
 kubectl --context kind-butler-bootstrap logs -n butler-system deploy/butler-bootstrap-controller
@@ -333,23 +261,15 @@ kubectl --context kind-butler-bootstrap logs -n butler-system deploy/butler-boot
 ### Cluster Stuck in Provisioning
 
 ```bash
-# Check TenantCluster status
 kubectl describe tenantcluster my-first-cluster -n dev-team
-
-# Check CAPI resources
 kubectl get cluster,machinedeployment,machine -A
-
-# Check Steward control plane
 kubectl get tenantcontrolplane -A
 ```
 
 ### Worker Nodes Not Joining
 
 ```bash
-# Check MachineDeployment
 kubectl describe machinedeployment my-first-cluster-workers -n dev-team
-
-# Check Machine status
 kubectl get machine -l cluster.x-k8s.io/cluster-name=my-first-cluster -A
 ```
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,6 +1,6 @@
 # Getting Started with Butler
 
-This guide walks you through installing Butler and creating your first tenant cluster.
+This guide walks you through installing Butler and creating your first management cluster.
 
 ## Table of Contents
 
@@ -18,25 +18,26 @@ This guide walks you through installing Butler and creating your first tenant cl
 
 | Requirement | Description |
 |-------------|-------------|
-| Docker | For running the bootstrap process |
+| Docker | For running the temporary KIND bootstrap cluster |
 | kubectl | Kubernetes CLI (1.28+) |
-| Infrastructure | Harvester, Nutanix, or other supported provider |
-| Network | IP addresses for control plane and LoadBalancer |
+| Infrastructure | Harvester, Nutanix, AWS, GCP, or Azure account |
+| Network | IP addresses for control plane VIP and LoadBalancer pool (on-prem only) |
 
 ### Infrastructure-Specific
 
-**For Harvester:**
-- Harvester cluster with API access
-- Harvester kubeconfig file
-- VM network configured
-- Talos Linux image uploaded
+**For On-Prem (Harvester, Nutanix):**
+- Infrastructure API access (Harvester kubeconfig or Prism Central credentials)
+- VM network configured with DHCP or static IPs
+- Talos Linux image uploaded to the infrastructure
+- A VIP address reserved for the control plane endpoint
+- An IP range for MetalLB LoadBalancer services
 
-**For Nutanix:**
-- Prism Central access
-- Subnet and cluster configuration
-- Cloud image uploaded
+**For Cloud (AWS, GCP, Azure):**
+- Cloud account with compute and networking permissions
+- VPC/VNet with a subnet and firewall/security group rules
+- Talos Linux image available in the target region (AMI, GCE image, or Azure gallery image)
 
-See [Provider Guides](../providers/) for detailed setup.
+See [Provider Guides](../providers/) for detailed per-provider setup.
 
 ---
 
@@ -93,88 +94,96 @@ butlerctl version
 
 ### 1. Create Bootstrap Configuration
 
-Create a file named `bootstrap.yaml`:
+Create a YAML config file for `butleradm`. This example uses Harvester as the infrastructure provider. See [Provider Guides](../providers/) for AWS, GCP, Azure, and Nutanix configs.
 
 ```yaml
-apiVersion: butler.butlerlabs.dev/v1alpha1
-kind: ClusterBootstrap
-metadata:
+provider: harvester
+
+cluster:
   name: butler-mgmt
-  namespace: butler-system
-spec:
-  provider: harvester  # or nutanix
-  
-  cluster:
-    name: butler-mgmt
-    controlPlaneEndpoint: 10.40.0.200  # Your VIP
-    kubernetesVersion: "v1.31.0"
-    topology: ha  # ha or single-node
-    
-    controlPlane:
-      replicas: 3
-      machineTemplate:
-        cpu: 4
-        memory: 16Gi
-        diskSize: 100Gi
+  topology: ha              # "ha" (3 CP + workers) or "single-node" (1 node)
+  controlPlane:
+    replicas: 3
+    cpu: 4
+    memoryMB: 8192
+    diskGB: 50
+  workers:
+    replicas: 2
+    cpu: 4
+    memoryMB: 8192
+    diskGB: 50
+    extraDisks:
+      - sizeGB: 50           # Additional disk for Longhorn storage
 
-    workers:
-      replicas: 3
-      machineTemplate:
-        cpu: 8
-        memory: 32Gi
-        diskSize: 200Gi
+network:
+  podCIDR: 10.244.0.0/16
+  serviceCIDR: 10.96.0.0/12
+  vip: 10.40.0.200           # Control plane VIP (on-prem only)
+  loadBalancerPool:           # MetalLB IP range (on-prem only)
+    start: 10.40.0.210
+    end: 10.40.0.220
 
-  networking:
-    podCIDR: 10.244.0.0/16
-    serviceCIDR: 10.96.0.0/12
-    
-  platform:
-    cni: cilium
-    storage: longhorn
-    loadBalancer: metallb
-    metalLBPool: 10.40.0.200-10.40.0.250
-    
-  providerConfig:
-    harvester:
-      credentialsRef:
-        name: harvester-kubeconfig
-      namespace: default
-      networkName: default/workloads
-      imageName: default/talos-1.9
+talos:
+  version: v1.12.1
+  schematic: dc7b152cb3ea99b821fcb7340ce7168313ce393d663740b791c36f6e95fc8586
+
+addons:
+  cni:
+    type: cilium
+  storage:
+    type: longhorn
+  loadBalancer:
+    type: metallb
+  console:
+    enabled: true
+    ingress:
+      enabled: true
+      className: traefik
+
+providerConfig:
+  harvester:
+    kubeconfigPath: ~/.butler/harvester-kubeconfig
+    namespace: default
+    networkName: default/workloads
+    imageName: default/talos-image
 ```
 
-### 2. Prepare Provider Credentials
+Save this as `~/.butler/bootstrap.yaml`.
 
-**For Harvester:**
+For a full list of every config field and its defaults, see the [Bootstrap Config Reference](../reference/bootstrap-config.md).
+
+### 2. Run Bootstrap
 
 ```bash
-# Create credentials secret file
-kubectl create secret generic harvester-kubeconfig \
-  --from-file=kubeconfig=/path/to/harvester-kubeconfig.yaml \
-  --dry-run=client -o yaml > harvester-secret.yaml
+butleradm bootstrap harvester --config ~/.butler/bootstrap.yaml
 ```
 
-### 3. Run Bootstrap
+Available flags:
 
-```bash
-butleradm bootstrap harvester \
-  --config bootstrap.yaml \
-  --credentials harvester-secret.yaml
-```
+| Flag | Description |
+|------|-------------|
+| `--config <path>` | Path to the bootstrap config YAML (required) |
+| `--no-tui` | Disable interactive TUI, use line-by-line log output |
+| `--skip-cleanup` | Keep the KIND cluster after bootstrap for debugging |
+| `--local` | Build controller images from local source (development) |
+| `--provider-image <image>` | Override the provider controller container image |
 
 This will:
-1. Create a temporary KIND cluster
-2. Deploy Butler controllers
-3. Provision management cluster VMs
-4. Install platform components
-5. Save kubeconfig and clean up
+1. Create a temporary KIND cluster on your machine
+2. Deploy Butler CRDs, bootstrap controller, and provider controller into KIND
+3. Provision VMs on your infrastructure
+4. Generate and apply Talos Linux configs to each node
+5. Bootstrap Kubernetes on the first control plane node
+6. Install addons (Cilium, cert-manager, Longhorn, MetalLB, Steward, Butler, Console)
+7. Save kubeconfig and talosconfig to `~/.butler/`
+8. Delete the KIND cluster (unless `--skip-cleanup`)
 
-**Expected duration:** 15-30 minutes depending on infrastructure.
+**Expected duration:** 15-30 minutes depending on infrastructure and network speed.
 
-### 4. Verify Installation
+### 3. Verify Installation
 
 ```bash
-# Set kubeconfig
+# Set kubeconfig to the new management cluster
 export KUBECONFIG=~/.butler/butler-mgmt-kubeconfig
 
 # Check nodes
@@ -182,6 +191,12 @@ kubectl get nodes
 
 # Check Butler components
 kubectl get pods -n butler-system
+
+# Check platform addons
+kubectl get pods -n kube-system -l app.kubernetes.io/name=cilium
+kubectl get pods -n longhorn-system
+kubectl get pods -n cert-manager
+kubectl get pods -n steward-system
 ```
 
 ---
@@ -308,6 +323,7 @@ butlerctl addon install prometheus --cluster my-first-cluster
 - [Architecture](../architecture/) - Understand how Butler works
 - [Operations Guide](../operations/) - Day-2 operations
 - [Provider Guides](../providers/) - Infrastructure-specific setup
+- [Bootstrap Config Reference](../reference/bootstrap-config.md) - Every config field documented
 
 ---
 
@@ -316,11 +332,12 @@ butlerctl addon install prometheus --cluster my-first-cluster
 ### Bootstrap Fails
 
 ```bash
-# Check bootstrap logs
-butleradm bootstrap harvester --config bootstrap.yaml --verbose
+# Use --skip-cleanup to keep KIND cluster for debugging
+butleradm bootstrap harvester --config bootstrap.yaml --skip-cleanup
 
-# Keep KIND cluster for debugging
-butleradm bootstrap harvester --config bootstrap.yaml --keep-kind
+# Then inspect the bootstrap state from the KIND context:
+kubectl --context kind-butler-bootstrap get clusterbootstrap -n butler-system
+kubectl --context kind-butler-bootstrap get machinerequest -n butler-system
 kubectl --context kind-butler-bootstrap logs -n butler-system deploy/butler-bootstrap-controller
 ```
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,6 +1,6 @@
 # Getting Started with Butler
 
-This guide walks you through installing Butler and creating your first management cluster.
+Install Butler and bootstrap a management cluster.
 
 ## Table of Contents
 
@@ -94,34 +94,29 @@ butlerctl version
 
 ### 1. Create Bootstrap Configuration
 
-Create a YAML config file for `butleradm`. This example uses Harvester as the infrastructure provider. See [Provider Guides](../providers/) for AWS, GCP, Azure, and Nutanix configs.
+Create a YAML config file for `butleradm`. This example uses Harvester. See [Provider Guides](../providers/) for AWS, GCP, Azure, and Nutanix configs.
 
 ```yaml
 provider: harvester
 
 cluster:
-  name: butler-mgmt
-  topology: ha              # "ha" (3 CP + workers) or "single-node" (1 node)
+  name: butler-hvstr-test
+  topology: single-node
   controlPlane:
-    replicas: 3
-    cpu: 4
-    memoryMB: 8192
-    diskGB: 50
-  workers:
-    replicas: 2
+    replicas: 1
     cpu: 4
     memoryMB: 8192
     diskGB: 50
     extraDisks:
-      - sizeGB: 50           # Additional disk for Longhorn storage
+      - sizeGB: 50
 
 network:
   podCIDR: 10.244.0.0/16
   serviceCIDR: 10.96.0.0/12
-  vip: 10.40.0.200           # Control plane VIP (on-prem only)
-  loadBalancerPool:           # MetalLB IP range (on-prem only)
-    start: 10.40.0.210
-    end: 10.40.0.220
+  vip: 10.40.0.230
+  loadBalancerPool:
+    start: 10.40.0.240
+    end: 10.40.0.250
 
 talos:
   version: v1.12.1
@@ -144,13 +139,13 @@ providerConfig:
   harvester:
     kubeconfigPath: ~/.butler/harvester-kubeconfig
     namespace: default
-    networkName: default/workloads
-    imageName: default/talos-image
+    networkName: default/vlan40-workloads
+    imageName: default/image-5rs6d
 ```
 
 Save this as `~/.butler/bootstrap.yaml`.
 
-For a full list of every config field and its defaults, see the [Bootstrap Config Reference](../reference/bootstrap-config.md).
+Every config field and its defaults are documented in the [Bootstrap Config Reference](../reference/bootstrap-config.md).
 
 ### 2. Run Bootstrap
 
@@ -178,21 +173,15 @@ This will:
 7. Save kubeconfig and talosconfig to `~/.butler/`
 8. Delete the KIND cluster (unless `--skip-cleanup`)
 
-**Expected duration:** 15-30 minutes depending on infrastructure and network speed.
+**Expected duration:** 15-30 minutes.
 
 ### 3. Verify Installation
 
 ```bash
-# Set kubeconfig to the new management cluster
-export KUBECONFIG=~/.butler/butler-mgmt-kubeconfig
+export KUBECONFIG=~/.butler/butler-hvstr-test-kubeconfig
 
-# Check nodes
 kubectl get nodes
-
-# Check Butler components
 kubectl get pods -n butler-system
-
-# Check platform addons
 kubectl get pods -n kube-system -l app.kubernetes.io/name=cilium
 kubectl get pods -n longhorn-system
 kubectl get pods -n cert-manager

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -17,8 +17,8 @@ Butler supports multiple infrastructure providers for provisioning management an
 | Provider | Platform | Status | Documentation |
 |----------|----------|--------|---------------|
 | GCP | Google Cloud Platform | Beta | [gcp.md](gcp.md) |
-| AWS | Amazon Web Services | In Progress | [aws.md](aws.md) |
-| Azure | Microsoft Azure | In Progress | [azure.md](azure.md) |
+| AWS | Amazon Web Services | Stable | [aws.md](aws.md) |
+| Azure | Microsoft Azure | Beta | [azure.md](azure.md) |
 
 ## Provider Architecture
 
@@ -116,7 +116,7 @@ spec:
     endpoint: "https://harvester.example.com"
     namespace: default
     networkName: default/workloads
-    imageName: default/talos-1.9
+    imageName: default/talos-v1-12-1
 ```
 
 ## Adding a New Provider

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -16,9 +16,9 @@ Butler supports multiple infrastructure providers for provisioning management an
 
 | Provider | Platform | Status | Documentation |
 |----------|----------|--------|---------------|
-| GCP | Google Cloud Platform | Beta | [gcp.md](gcp.md) |
+| GCP | Google Cloud Platform | Stable | [gcp.md](gcp.md) |
 | AWS | Amazon Web Services | Stable | [aws.md](aws.md) |
-| Azure | Microsoft Azure | Beta | [azure.md](azure.md) |
+| Azure | Microsoft Azure | Stable | [azure.md](azure.md) |
 
 ## Provider Architecture
 

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -266,7 +266,7 @@ butleradm bootstrap aws --config ~/.butler/bootstrap-aws.yaml
 ## Validation
 
 ```bash
-export KUBECONFIG=~/.butler/butler-mgmt-kubeconfig
+export KUBECONFIG=~/.butler/butler-aws-test-kubeconfig
 
 # All nodes Ready with providerID set
 kubectl get nodes -o wide
@@ -276,19 +276,30 @@ kubectl get nodes -o jsonpath='{.items[*].spec.providerID}'
 # AWS CCM running
 kubectl get pods -n kube-system | grep cloud
 
-# Cilium healthy
+# Cilium running
 kubectl get pods -n kube-system -l app.kubernetes.io/name=cilium
 
-# Longhorn healthy
+# Longhorn running
 kubectl get pods -n longhorn-system
 
 # Butler Console exposed via NLB
 kubectl get svc butler-console-frontend -n butler-system
-# Should show type: LoadBalancer with an external hostname
 
-# Console accessible
+# Console accessible (use the EXTERNAL-IP from above)
 curl http://<NLB-hostname>
 ```
+
+### What You Have Now
+
+A Butler management cluster running on AWS with:
+- Talos Linux EC2 instances with Cilium CNI
+- AWS NLB fronting the Kubernetes API (HA topology)
+- AWS CCM handling LoadBalancer services
+- Longhorn distributed storage
+- Steward for hosted tenant control planes
+- Butler controller, CRDs, and web console exposed via NLB
+
+To create your first tenant cluster, go to [Create Your First Tenant Cluster](../getting-started/#create-your-first-tenant-cluster).
 
 ---
 

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -317,7 +317,7 @@ aws ec2 describe-instances \
 
 # Delete orphaned NLBs
 aws elbv2 describe-load-balancers \
-  --query 'LoadBalancers[?contains(LoadBalancerName, `butler-mgmt`)].LoadBalancerArn' \
+  --query 'LoadBalancers[?contains(LoadBalancerName, `butler-aws-test`)].LoadBalancerArn' \
   --output text \
   | xargs -I{} aws elbv2 delete-load-balancer --load-balancer-arn {}
 ```

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -1,27 +1,27 @@
 # AWS Provider Guide
 
-> **Status: In Progress.** Cloud provider support is in active development. The CRD types, bootstrap controller integration, and CLI commands are implemented. The provider controller (`butler-provider-aws`) is not yet released. This guide describes the target architecture.
+> **Status: Stable.** AWS bootstrap has been E2E validated for both single-node and HA topologies.
 
-This guide covers setting up Butler with Amazon Web Services as the infrastructure provider for management cluster bootstrap.
+This guide covers bootstrapping a Butler management cluster on Amazon Web Services.
 
 ## Table of Contents
 
 - [Overview](#overview)
 - [Prerequisites](#prerequisites)
 - [AWS Setup](#aws-setup)
-- [Butler Configuration](#butler-configuration)
-- [Network Architecture](#network-architecture)
-- [Load Balancer Resources](#load-balancer-resources)
-- [Resource Recommendations](#resource-recommendations)
+- [Bootstrap Configuration](#bootstrap-configuration)
+- [Run Bootstrap](#run-bootstrap)
+- [Validation](#validation)
+- [Cleanup](#cleanup)
 - [Troubleshooting](#troubleshooting)
 
 ---
 
 ## Overview
 
-Butler uses a thin provider controller (`butler-provider-aws`) to provision EC2 instances running Talos Linux. The controller creates instances in the specified VPC/subnet and reports their IPs back to the bootstrap controller.
+Butler uses a thin provider controller (`butler-provider-aws`) to provision EC2 instances running Talos Linux. For HA topologies, the provider also creates a Network Load Balancer (NLB) to front the control plane.
 
-For control plane HA, the bootstrap controller creates a LoadBalancerRequest, and the AWS provider provisions a Network Load Balancer (NLB) with a TCP target group and listener on port 6443.
+After bootstrap, the AWS Cloud Controller Manager (CCM) runs on the management cluster in service-controller-only mode, handling `type: LoadBalancer` services (including the Butler Console).
 
 ```mermaid
 flowchart LR
@@ -34,44 +34,65 @@ flowchart LR
     AWSProvider --> NLB["Network Load Balancer"]
 ```
 
-### Key Components
-
-| Component | Purpose |
-|-----------|---------|
-| butler-provider-aws | Provisions EC2 instances and NLB resources |
-| CAPI AWS Provider (CAPA) | Manages tenant cluster worker instances after bootstrap |
-
 ---
 
 ## Prerequisites
 
 ### AWS Account
 
-- An AWS account with access to the target region
-- EC2 and Elastic Load Balancing APIs enabled
+An AWS account with access to the target region. EC2 and Elastic Load Balancing APIs must be enabled.
 
-### IAM User or Role
+### IAM Permissions
 
-An IAM user (or role) with permissions for:
-- EC2: instances, security groups, key pairs, AMIs, EBS volumes
-- Elastic Load Balancing v2: NLBs, target groups, listeners
-- VPC: subnets, route tables (read-only)
+An IAM user (or role) with the following permissions:
 
-A suitable managed policy combination:
-- `AmazonEC2FullAccess`
-- `ElasticLoadBalancingFullAccess`
+**EC2:**
+- `ec2:RunInstances`
+- `ec2:DescribeInstances`
+- `ec2:TerminateInstances`
+- `ec2:CreateTags`
+- `ec2:DescribeSecurityGroups`
+- `ec2:DescribeSubnets`
+- `ec2:DescribeVpcs`
+- `ec2:DescribeImages`
 
-Or use a custom IAM policy scoped to the required resources.
+**Elastic Load Balancing v2 (for HA):**
+- `elasticloadbalancing:CreateLoadBalancer`
+- `elasticloadbalancing:DeleteLoadBalancer`
+- `elasticloadbalancing:DescribeLoadBalancers`
+- `elasticloadbalancing:CreateTargetGroup`
+- `elasticloadbalancing:DeleteTargetGroup`
+- `elasticloadbalancing:RegisterTargets`
+- `elasticloadbalancing:DeregisterTargets`
+- `elasticloadbalancing:CreateListener`
+- `elasticloadbalancing:DescribeTargetHealth`
+
+Or use managed policies: `AmazonEC2FullAccess` + `ElasticLoadBalancingFullAccess`.
 
 ### Networking
 
-- A VPC with at least one public subnet (instances need reachability from the bootstrap machine)
-- A security group allowing required ports (see [Network Architecture](#network-architecture))
-- Sufficient Elastic IP quota if using static public IPs
+- A VPC with an internet gateway
+- A public subnet (instances need reachability from the KIND bootstrap cluster)
+- A security group (see [Security Group Rules](#security-group-rules) below)
 
 ### Talos AMI
 
-A Talos Linux AMI must be available in the target region. Import from the official Talos releases or use the Talos Image Factory to produce a custom AMI.
+Butler ships with pre-built Talos AMIs for common regions. If your region is not listed below, you need to import a custom AMI.
+
+**Built-in AMIs (Talos v1.12.2, schematic `613e1592b2da41ae5e265e8789429f22e121aab91cb4deb6bc3c0b6262961245`):**
+
+| Region | AMI ID |
+|--------|--------|
+| us-east-1 | `ami-0cd30b7027afffd4e` |
+| us-east-2 | `ami-0f0e7059a7735d0a0` |
+| us-west-1 | `ami-0abe7bca2fb75fced` |
+| us-west-2 | `ami-0d03dfcef2e1eee26` |
+| eu-west-1 | `ami-0c0a06de3c0c30646` |
+| eu-central-1 | `ami-06e7ff093b83a3cb0` |
+| ap-southeast-1 | `ami-088879e1d3a9b3c3e` |
+| ap-northeast-1 | `ami-0aed11a4c14c1f6b5` |
+
+These AMIs include the `iscsi-tools` and `util-linux-tools` Talos extensions. The provider auto-selects the correct AMI based on your configured region. To use a custom AMI, set the `ami` field in the config.
 
 ---
 
@@ -80,16 +101,13 @@ A Talos Linux AMI must be available in the target region. Import from the offici
 ### 1. Create IAM User
 
 ```bash
-# Create IAM user
 aws iam create-user --user-name butler-bootstrap
 
-# Attach required policies
 aws iam attach-user-policy --user-name butler-bootstrap \
   --policy-arn arn:aws:iam::aws:policy/AmazonEC2FullAccess
 aws iam attach-user-policy --user-name butler-bootstrap \
   --policy-arn arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess
 
-# Create access key
 aws iam create-access-key --user-name butler-bootstrap
 ```
 
@@ -98,207 +116,201 @@ Save the `AccessKeyId` and `SecretAccessKey` from the output.
 ### 2. Create Security Group
 
 ```bash
-# Create security group
 SG_ID=$(aws ec2 create-security-group \
   --group-name butler-bootstrap \
   --description "Butler bootstrap cluster" \
   --vpc-id vpc-XXXXX \
   --query 'GroupId' --output text)
 
-# Allow inter-node traffic (self-referencing)
-aws ec2 authorize-security-group-ingress --group-id $SG_ID \
-  --protocol tcp --port 6443 --source-group $SG_ID
-aws ec2 authorize-security-group-ingress --group-id $SG_ID \
-  --protocol tcp --port 50000-50001 --source-group $SG_ID
-aws ec2 authorize-security-group-ingress --group-id $SG_ID \
-  --protocol tcp --port 2379-2380 --source-group $SG_ID
-aws ec2 authorize-security-group-ingress --group-id $SG_ID \
-  --protocol tcp --port 10250 --source-group $SG_ID
-
-# Allow kube-apiserver access from anywhere (for LB and external access)
+# Kubernetes API (external access + NLB health checks)
 aws ec2 authorize-security-group-ingress --group-id $SG_ID \
   --protocol tcp --port 6443 --cidr 0.0.0.0/0
 
-# Allow SSH (optional, for debugging)
+# Talos API (node-to-node)
 aws ec2 authorize-security-group-ingress --group-id $SG_ID \
-  --protocol tcp --port 22 --cidr YOUR_IP/32
-```
+  --protocol tcp --port 50000-50001 --source-group $SG_ID
 
-### 3. Import Talos AMI (if needed)
+# etcd (node-to-node)
+aws ec2 authorize-security-group-ingress --group-id $SG_ID \
+  --protocol tcp --port 2379-2380 --source-group $SG_ID
 
-```bash
-# Download Talos AWS image
-wget https://factory.talos.dev/image/SCHEMATIC_ID/vX.Y.Z/aws-amd64.raw.xz
+# kubelet API (node-to-node)
+aws ec2 authorize-security-group-ingress --group-id $SG_ID \
+  --protocol tcp --port 10250 --source-group $SG_ID
 
-# Upload to S3 and import as AMI
-aws s3 cp talos-vX.Y.Z.raw.xz s3://BUCKET/talos-vX.Y.Z.raw.xz
+# Cilium health checks (node-to-node)
+aws ec2 authorize-security-group-ingress --group-id $SG_ID \
+  --protocol tcp --port 4240 --source-group $SG_ID
 
-aws ec2 import-image \
-  --disk-containers "Description=Talos vX.Y.Z,Format=raw,Url=s3://BUCKET/talos-vX.Y.Z.raw.xz"
-```
-
----
-
-## Butler Configuration
-
-### ProviderConfig
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: aws-credentials
-  namespace: butler-system
-type: Opaque
-stringData:
-  access-key-id: "AKIAIOSFODNN7EXAMPLE"
-  secret-access-key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
----
-apiVersion: butler.butlerlabs.dev/v1alpha1
-kind: ProviderConfig
-metadata:
-  name: aws-prod
-  namespace: butler-system
-spec:
-  provider: aws
-  credentialsRef:
-    name: aws-credentials
-    namespace: butler-system
-  network:
-    mode: cloud
-  aws:
-    region: us-east-1
-    vpcID: vpc-0abcdef1234567890
-    subnetIDs:
-      - subnet-0abcdef1234567890
-    securityGroupIDs:
-      - sg-0abcdef1234567890
-```
-
-### Bootstrap Config
-
-```yaml
-apiVersion: butler.butlerlabs.dev/v1alpha1
-kind: ClusterBootstrap
-metadata:
-  name: butler-mgmt
-  namespace: butler-system
-spec:
-  provider: aws
-  providerRef:
-    name: aws-prod
-    namespace: butler-system
-
-  cluster:
-    name: butler-mgmt
-    topology: ha
-    controlPlane:
-      replicas: 3
-      cpu: 4
-      memoryMB: 16384
-      diskGB: 100
-    workers:
-      replicas: 3
-      cpu: 8
-      memoryMB: 32768
-      diskGB: 200
-
-  network:
-    podCIDR: 10.244.0.0/16
-    serviceCIDR: 10.96.0.0/12
-
-  talos:
-    version: v1.9.2
-    schematic: ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515
-
-  addons:
-    cni:
-      type: cilium
-    storage:
-      type: longhorn
-    controlPlaneProvider:
-      type: steward
-    capi:
-      enabled: true
-      infrastructureProviders:
-        - name: aws
-
-  controlPlaneExposure:
-    mode: LoadBalancer
-```
-
-### Run Bootstrap
-
-```bash
-butleradm bootstrap aws --config bootstrap.yaml
-```
-
----
-
-## Network Architecture
-
-```mermaid
-flowchart TB
-    subgraph AWS["AWS Account"]
-        subgraph VPC["VPC"]
-            subgraph Subnet["Public Subnet (us-east-1a)"]
-                CP0["CP-0<br/>10.0.1.10"]
-                CP1["CP-1<br/>10.0.1.11"]
-                CP2["CP-2<br/>10.0.1.12"]
-                W0["Worker-0<br/>10.0.1.20"]
-                W1["Worker-1<br/>10.0.1.21"]
-                W2["Worker-2<br/>10.0.1.22"]
-            end
-            SG["Security Group"]
-        end
-        NLB["Network Load Balancer<br/>butler-mgmt-nlb-xxx.elb.amazonaws.com:6443"]
-    end
-
-    Internet["External Access"] --> NLB
-    NLB --> CP0
-    NLB --> CP1
-    NLB --> CP2
-    SG -.-> Subnet
+# Cilium VXLAN overlay (node-to-node)
+aws ec2 authorize-security-group-ingress --group-id $SG_ID \
+  --protocol udp --port 8472 --source-group $SG_ID
 ```
 
 ### Security Group Rules
 
-| Direction | Protocol/Port | Source/Destination | Purpose |
-|-----------|--------------|-------------------|---------|
+| Direction | Protocol/Port | Source | Purpose |
+|-----------|--------------|--------|---------|
 | Inbound | TCP 6443 | 0.0.0.0/0 | Kubernetes API (external + NLB health checks) |
 | Inbound | TCP 50000-50001 | Self | Talos API (apid + trustd) |
 | Inbound | TCP 2379-2380 | Self | etcd client and peer |
 | Inbound | TCP 10250 | Self | kubelet API |
-
-NLB health checks originate from within the VPC, so the `0.0.0.0/0` rule on port 6443 covers both external access and health check traffic.
-
----
-
-## Load Balancer Resources
-
-When the bootstrap controller creates a LoadBalancerRequest with `provider: aws`, the AWS provider controller creates:
-
-| AWS Resource | Purpose |
-|--------------|---------|
-| Network Load Balancer | Regional L4 load balancer in the VPC |
-| Target group (TCP 6443) | Groups the control plane EC2 instances |
-| Listener (TCP 6443) | Routes traffic from NLB to the target group |
-
-The NLB uses TCP passthrough. The NLB DNS name (e.g., `butler-mgmt-nlb-xxx.elb.us-east-1.amazonaws.com`) is reported as the LoadBalancerRequest endpoint and used as the control plane address.
-
-Target registration uses instance IDs (`LoadBalancerTarget.instanceID`).
+| Inbound | TCP 4240 | Self | Cilium health checks |
+| Inbound | UDP 8472 | Self | Cilium VXLAN overlay |
 
 ---
 
-## Resource Recommendations
+## Bootstrap Configuration
 
-| Profile | CP Nodes | CP Instance Type | Worker Nodes | Worker Instance Type | Estimated Monthly Cost |
-|---------|----------|-----------------|-------------|---------------------|----------------------|
-| Development | 1 (single-node) | m6i.xlarge (4 vCPU, 16 GB) | 0 | -- | ~$150 |
-| Staging | 3 | m6i.xlarge (4 vCPU, 16 GB) | 2 | m6i.2xlarge (8 vCPU, 32 GB) | ~$950 |
-| Production | 3 | m6i.xlarge (4 vCPU, 16 GB) | 3+ | m6i.2xlarge (8 vCPU, 32 GB) | ~$1,300+ |
+Create a config file at `~/.butler/bootstrap-aws.yaml`:
 
-NLB pricing: NLB charges per hour plus per LCU (Load Balancer Capacity Unit). For a management cluster with low traffic, expect approximately $20/month.
+### Single-Node
+
+```yaml
+provider: aws
+
+cluster:
+  name: butler-mgmt
+  topology: single-node
+  controlPlane:
+    replicas: 1
+    cpu: 4
+    memoryMB: 16384           # 16 GB
+    diskGB: 100
+
+network:
+  podCIDR: "10.244.0.0/16"
+  serviceCIDR: "10.96.0.0/12"
+  # No vip or loadBalancerPool for cloud providers
+
+talos:
+  version: v1.12.2
+
+addons:
+  cni:
+    type: cilium
+  storage:
+    type: longhorn
+
+providerConfig:
+  aws:
+    accessKeyID: "AKIAIOSFODNN7EXAMPLE"        # IAM access key
+    secretAccessKey: "wJalrXUtnFEMI/K7MDENG..."  # IAM secret key
+    region: "us-east-1"                          # AWS region
+    vpcID: "vpc-0123456789abcdef0"               # VPC ID
+    subnetID: "subnet-0123456789abcdef0"         # Public subnet ID
+    securityGroupID: "sg-0123456789abcdef0"      # Security group ID
+    # instanceType: "m5.xlarge"                  # Optional: override (default: m5.xlarge)
+    # ami: "ami-0123456789abcdef0"               # Optional: custom AMI
+```
+
+### HA
+
+```yaml
+provider: aws
+
+cluster:
+  name: butler-mgmt
+  topology: ha
+  controlPlane:
+    replicas: 3
+    cpu: 4
+    memoryMB: 16384
+    diskGB: 100
+  workers:
+    replicas: 2
+    cpu: 4
+    memoryMB: 16384
+    diskGB: 50
+
+network:
+  podCIDR: "10.244.0.0/16"
+  serviceCIDR: "10.96.0.0/12"
+
+talos:
+  version: v1.12.2
+
+addons:
+  cni:
+    type: cilium
+  storage:
+    type: longhorn
+
+providerConfig:
+  aws:
+    accessKeyID: "AKIAIOSFODNN7EXAMPLE"
+    secretAccessKey: "wJalrXUtnFEMI/K7MDENG..."
+    region: "us-east-1"
+    vpcID: "vpc-0123456789abcdef0"
+    subnetID: "subnet-0123456789abcdef0"
+    securityGroupID: "sg-0123456789abcdef0"
+```
+
+### Cloud vs On-Prem Differences
+
+- No `vip` field: cloud providers use a load balancer instead of kube-vip
+- No `loadBalancerPool` field: cloud providers do not use MetalLB
+- kube-vip, MetalLB, and Traefik are automatically skipped during addon installation
+- The AWS CCM is installed instead, handling `type: LoadBalancer` services natively
+- The Butler Console is exposed as a `type: LoadBalancer` service with an NLB annotation
+
+---
+
+## Run Bootstrap
+
+```bash
+butleradm bootstrap aws --config ~/.butler/bootstrap-aws.yaml
+```
+
+---
+
+## Validation
+
+```bash
+export KUBECONFIG=~/.butler/butler-mgmt-kubeconfig
+
+# All nodes Ready with providerID set
+kubectl get nodes -o wide
+kubectl get nodes -o jsonpath='{.items[*].spec.providerID}'
+# Expected format: aws:///<zone>/<instance-id>
+
+# AWS CCM running
+kubectl get pods -n kube-system | grep cloud
+
+# Cilium healthy
+kubectl get pods -n kube-system -l app.kubernetes.io/name=cilium
+
+# Longhorn healthy
+kubectl get pods -n longhorn-system
+
+# Butler Console exposed via NLB
+kubectl get svc butler-console-frontend -n butler-system
+# Should show type: LoadBalancer with an external hostname
+
+# Console accessible
+curl http://<NLB-hostname>
+```
+
+---
+
+## Cleanup
+
+```bash
+# Delete KIND bootstrap cluster
+kind delete cluster --name butler-bootstrap
+
+# Terminate EC2 instances
+aws ec2 describe-instances \
+  --filters "Name=tag:butler_butlerlabs_dev_managed-by,Values=butler" \
+  --query 'Reservations[].Instances[].InstanceId' --output text \
+  | xargs -I{} aws ec2 terminate-instances --instance-ids {}
+
+# Delete orphaned NLBs
+aws elbv2 describe-load-balancers \
+  --query 'LoadBalancers[?contains(LoadBalancerName, `butler-mgmt`)].LoadBalancerArn' \
+  --output text \
+  | xargs -I{} aws elbv2 delete-load-balancer --load-balancer-arn {}
+```
 
 ---
 
@@ -306,19 +318,19 @@ NLB pricing: NLB charges per hour plus per LCU (Load Balancer Capacity Unit). Fo
 
 ### Security Group Rules Missing
 
-**Symptom**: Talos bootstrap times out. Nodes cannot communicate on required ports.
+**Symptom**: Talos bootstrap times out. Nodes cannot communicate.
 
-**Verify**:
 ```bash
 aws ec2 describe-security-groups --group-ids sg-XXXXX \
   --query "SecurityGroups[0].IpPermissions"
 ```
 
+Verify all six rules are present (6443, 50000-50001, 2379-2380, 10250, 4240, 8472).
+
 ### IAM Permissions Insufficient
 
-**Symptom**: Provider controller logs show `UnauthorizedOperation` errors.
+**Symptom**: Provider controller logs show `UnauthorizedOperation`.
 
-**Verify**:
 ```bash
 aws iam simulate-principal-policy \
   --policy-source-arn arn:aws:iam::ACCOUNT:user/butler-bootstrap \
@@ -327,30 +339,39 @@ aws iam simulate-principal-policy \
 
 ### NLB Target Health Failures
 
-**Symptom**: LoadBalancerRequest stuck in `Creating` phase. Target group shows unhealthy targets.
+**Symptom**: LoadBalancerRequest stuck in `Creating`. Target group shows unhealthy targets.
 
-**Verify**:
 ```bash
 aws elbv2 describe-target-health \
   --target-group-arn arn:aws:elasticloadbalancing:REGION:ACCOUNT:targetgroup/butler-mgmt/XXXXX
 ```
 
-**Common causes:**
-- Security group does not allow TCP 6443 from VPC CIDR
+Common causes:
+- Security group does not allow TCP 6443 from the VPC CIDR
 - kube-apiserver not yet listening (bootstrap still in progress)
-- Instance not registered in the correct target group
+- Instances not registered in the correct target group
 
 ### Subnet Not Public
 
 **Symptom**: Instances created but not reachable from the bootstrap machine.
 
-Instances need a route to the internet (via IGW) for the KIND cluster to reach the Talos API during bootstrap. Use a public subnet with auto-assign public IP, or set up a bastion/VPN.
+During bootstrap, the KIND cluster must reach each VM's Talos API on port 50000. Instances need a public IP (either auto-assigned or Elastic IP) and a route to the internet via an Internet Gateway.
+
+### Instance Tags
+
+EC2 instances are tagged with `kubernetes.io/cluster/<clusterName>: owned`. The AWS CCM uses this tag for instance discovery. If you see CCM errors about not finding instances, verify the tags are present:
+
+```bash
+aws ec2 describe-instances \
+  --instance-ids <id> \
+  --query 'Reservations[].Instances[].Tags'
+```
 
 ---
 
 ## See Also
 
-- [Bootstrap Flow](../architecture/bootstrap-flow.md) - end-to-end bootstrap sequence
-- [ClusterBootstrap CRD](../reference/crds/clusterbootstrap.md) - full spec reference
-- [LoadBalancerRequest CRD](../reference/crds/loadbalancerrequest.md) - cloud LB provisioning
-- [ProviderConfig CRD](../reference/crds/providerconfig.md) - provider credentials
+- [Bootstrap Flow](../architecture/bootstrap-flow.md) - End-to-end bootstrap sequence
+- [Bootstrap Config Reference](../reference/bootstrap-config.md) - Every config field documented
+- [GCP Provider](gcp.md) - Alternative cloud provider
+- [Azure Provider](azure.md) - Alternative cloud provider

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -1,8 +1,8 @@
 # AWS Provider Guide
 
-> **Status: Stable.** AWS bootstrap has been E2E validated for both single-node and HA topologies.
+> **Status: Stable.** E2E validated for single-node and HA topologies.
 
-This guide covers bootstrapping a Butler management cluster on Amazon Web Services.
+Bootstrap a Butler management cluster on Amazon Web Services.
 
 ## Table of Contents
 
@@ -166,22 +166,23 @@ Create a config file at `~/.butler/bootstrap-aws.yaml`:
 
 ### Single-Node
 
+This config was used for E2E validation. Replace credentials, VPC, subnet, and security group with your values.
+
 ```yaml
 provider: aws
 
 cluster:
-  name: butler-mgmt
+  name: butler-aws-test
   topology: single-node
   controlPlane:
     replicas: 1
     cpu: 4
-    memoryMB: 16384           # 16 GB
+    memoryMB: 16384
     diskGB: 100
 
 network:
   podCIDR: "10.244.0.0/16"
   serviceCIDR: "10.96.0.0/12"
-  # No vip or loadBalancerPool for cloud providers
 
 talos:
   version: v1.12.2
@@ -194,14 +195,12 @@ addons:
 
 providerConfig:
   aws:
-    accessKeyID: "AKIAIOSFODNN7EXAMPLE"        # IAM access key
-    secretAccessKey: "wJalrXUtnFEMI/K7MDENG..."  # IAM secret key
-    region: "us-east-1"                          # AWS region
-    vpcID: "vpc-0123456789abcdef0"               # VPC ID
-    subnetID: "subnet-0123456789abcdef0"         # Public subnet ID
-    securityGroupID: "sg-0123456789abcdef0"      # Security group ID
-    # instanceType: "m5.xlarge"                  # Optional: override (default: m5.xlarge)
-    # ami: "ami-0123456789abcdef0"               # Optional: custom AMI
+    accessKeyID: "YOUR_ACCESS_KEY_ID"
+    secretAccessKey: "YOUR_SECRET_ACCESS_KEY"
+    region: "us-east-1"
+    vpcID: "vpc-016fee01a86ae92f9"
+    subnetID: "subnet-08f5cc7e6f53c7c03"
+    securityGroupID: "sg-0f5d6bb6a232d8af0"
 ```
 
 ### HA
@@ -210,7 +209,7 @@ providerConfig:
 provider: aws
 
 cluster:
-  name: butler-mgmt
+  name: butler-aws-ha
   topology: ha
   controlPlane:
     replicas: 3
@@ -238,21 +237,21 @@ addons:
 
 providerConfig:
   aws:
-    accessKeyID: "AKIAIOSFODNN7EXAMPLE"
-    secretAccessKey: "wJalrXUtnFEMI/K7MDENG..."
+    accessKeyID: "YOUR_ACCESS_KEY_ID"
+    secretAccessKey: "YOUR_SECRET_ACCESS_KEY"
     region: "us-east-1"
-    vpcID: "vpc-0123456789abcdef0"
-    subnetID: "subnet-0123456789abcdef0"
-    securityGroupID: "sg-0123456789abcdef0"
+    vpcID: "vpc-016fee01a86ae92f9"
+    subnetID: "subnet-08f5cc7e6f53c7c03"
+    securityGroupID: "sg-0f5d6bb6a232d8af0"
 ```
 
-### Cloud vs On-Prem Differences
+### Cloud vs On-Prem
 
-- No `vip` field: cloud providers use a load balancer instead of kube-vip
-- No `loadBalancerPool` field: cloud providers do not use MetalLB
-- kube-vip, MetalLB, and Traefik are automatically skipped during addon installation
-- The AWS CCM is installed instead, handling `type: LoadBalancer` services natively
-- The Butler Console is exposed as a `type: LoadBalancer` service with an NLB annotation
+- No `vip` field -- cloud providers use a load balancer, not kube-vip
+- No `loadBalancerPool` field -- cloud providers do not use MetalLB
+- kube-vip, MetalLB, and Traefik are skipped during addon installation
+- The AWS CCM handles `type: LoadBalancer` services
+- The Butler Console is exposed as `type: LoadBalancer` with an NLB annotation
 
 ---
 

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -317,7 +317,7 @@ aws ec2 describe-instances \
 
 # Delete orphaned NLBs
 aws elbv2 describe-load-balancers \
-  --query 'LoadBalancers[?contains(LoadBalancerName, `butler-aws-test`)].LoadBalancerArn' \
+  --query 'LoadBalancers[?contains(LoadBalancerName, `CLUSTER_NAME`)].LoadBalancerArn' \
   --output text \
   | xargs -I{} aws elbv2 delete-load-balancer --load-balancer-arn {}
 ```
@@ -353,7 +353,7 @@ aws iam simulate-principal-policy \
 
 ```bash
 aws elbv2 describe-target-health \
-  --target-group-arn arn:aws:elasticloadbalancing:REGION:ACCOUNT:targetgroup/butler-mgmt/XXXXX
+  --target-group-arn arn:aws:elasticloadbalancing:REGION:ACCOUNT:targetgroup/CLUSTER_NAME/XXXXX
 ```
 
 Common causes:

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -1,8 +1,8 @@
 # Azure Provider Guide
 
-> **Status: Beta.** Azure bootstrap has been E2E validated for single-node. HA validation is blocked by public IP quota limits on restricted subscriptions.
+> **Status: Stable.** E2E validated for single-node and HA topologies.
 
-This guide covers bootstrapping a Butler management cluster on Microsoft Azure.
+Bootstrap a Butler management cluster on Microsoft Azure.
 
 ## Table of Contents
 
@@ -204,22 +204,23 @@ Create a config file at `~/.butler/bootstrap-azure.yaml`:
 
 ### Single-Node
 
+This config was used for E2E validation. Replace credentials, resource group, VNet, NSG, and image URN with your values.
+
 ```yaml
 provider: azure
 
 cluster:
-  name: butler-mgmt
+  name: butler-azure-test
   topology: single-node
   controlPlane:
     replicas: 1
     cpu: 4
-    memoryMB: 16384           # 16 GB
+    memoryMB: 16384
     diskGB: 100
 
 network:
   podCIDR: "10.244.0.0/16"
   serviceCIDR: "10.96.0.0/12"
-  # No vip or loadBalancerPool for cloud providers
 
 talos:
   version: v1.12.5
@@ -232,17 +233,17 @@ addons:
 
 providerConfig:
   azure:
-    clientID: "00000000-0000-0000-0000-000000000000"        # Service principal app ID
-    clientSecret: "your-client-secret"                        # Service principal password
-    tenantID: "00000000-0000-0000-0000-000000000000"         # Azure AD tenant ID
-    subscriptionID: "00000000-0000-0000-0000-000000000000"   # Azure subscription ID
-    resourceGroup: "butler-rg"                                # Pre-existing resource group
-    location: "eastus"                                        # Azure region
-    vnetName: "butler-vnet"                                   # Pre-existing VNet name
-    subnetName: "default"                                     # Subnet within the VNet
-    securityGroupName: "butler-nsg"                           # Pre-existing NSG name (required)
-    vmSize: "Standard_D4s_v3"                                 # VM size
-    imageURN: "/subscriptions/.../providers/Microsoft.Compute/galleries/.../images/.../versions/1.12.5"
+    clientID: "YOUR_SERVICE_PRINCIPAL_APP_ID"
+    clientSecret: "YOUR_SERVICE_PRINCIPAL_PASSWORD"
+    tenantID: "YOUR_AZURE_AD_TENANT_ID"
+    subscriptionID: "YOUR_SUBSCRIPTION_ID"
+    resourceGroup: "butler-bootstrap-rg"
+    location: "eastus"
+    vnetName: "butler-bootstrap-vnet"
+    subnetName: "default"
+    securityGroupName: "butler-bootstrap-nsg"
+    vmSize: "Standard_DC4s_v3"
+    imageURN: "/subscriptions/YOUR_SUB_ID/resourceGroups/butler-bootstrap-rg/providers/Microsoft.Compute/galleries/butlerImageGallery/images/talos-linux/versions/1.12.5"
 ```
 
 ### HA
@@ -251,7 +252,7 @@ providerConfig:
 provider: azure
 
 cluster:
-  name: butler-mgmt
+  name: butler-azure-ha
   topology: ha
   controlPlane:
     replicas: 3
@@ -279,23 +280,23 @@ addons:
 
 providerConfig:
   azure:
-    clientID: "00000000-0000-0000-0000-000000000000"
-    clientSecret: "your-client-secret"
-    tenantID: "00000000-0000-0000-0000-000000000000"
-    subscriptionID: "00000000-0000-0000-0000-000000000000"
-    resourceGroup: "butler-rg"
+    clientID: "YOUR_SERVICE_PRINCIPAL_APP_ID"
+    clientSecret: "YOUR_SERVICE_PRINCIPAL_PASSWORD"
+    tenantID: "YOUR_AZURE_AD_TENANT_ID"
+    subscriptionID: "YOUR_SUBSCRIPTION_ID"
+    resourceGroup: "butler-bootstrap-rg"
     location: "eastus"
-    vnetName: "butler-vnet"
+    vnetName: "butler-bootstrap-vnet"
     subnetName: "default"
-    securityGroupName: "butler-nsg"
-    vmSize: "Standard_D4s_v3"
-    imageURN: "/subscriptions/.../providers/Microsoft.Compute/galleries/.../images/.../versions/1.12.5"
+    securityGroupName: "butler-bootstrap-nsg"
+    vmSize: "Standard_DC4s_v3"
+    imageURN: "/subscriptions/YOUR_SUB_ID/resourceGroups/butler-bootstrap-rg/providers/Microsoft.Compute/galleries/butlerImageGallery/images/talos-linux/versions/1.12.5"
 ```
 
 **Required fields:**
-- `securityGroupName` is required. The Azure CCM fails with `securityGroupName is not configured` without it.
-- `imageURN` is the full ARM resource ID for the Talos image (managed image or gallery image version).
-- `vmSize` selects the Azure VM SKU. Not all SKUs support all security types.
+- `securityGroupName` -- the Azure CCM fails with `securityGroupName is not configured` without it.
+- `imageURN` -- full ARM resource ID. Managed image or Shared Image Gallery version.
+- `vmSize` -- Azure VM SKU. The E2E test used `Standard_DC4s_v3`.
 
 ---
 

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -361,7 +361,7 @@ az vm list -g butler-rg \
 
 # Wait ~180s for NICs to release, then delete NICs
 az network nic list -g butler-rg \
-  --query "[?contains(name, 'butler-azure-test')].name" -o tsv \
+  --query "[?contains(name, 'CLUSTER_NAME')].name" -o tsv \
   | xargs -I{} az network nic delete -g butler-rg -n {}
 
 # Delete public IPs
@@ -376,11 +376,11 @@ az network lb list -g butler-rg \
 
 # Delete orphaned disks
 az disk list -g butler-rg \
-  --query "[?contains(name, 'butler-azure-test')].name" -o tsv \
+  --query "[?contains(name, 'CLUSTER_NAME')].name" -o tsv \
   | xargs -I{} az disk delete -g butler-rg -n {} --yes
 
 # Delete availability set
-az vm availability-set delete -g butler-rg -n butler-azure-test-avset
+az vm availability-set delete -g butler-rg -n CLUSTER_NAME-avset
 ```
 
 ---

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -1,27 +1,28 @@
 # Azure Provider Guide
 
-> **Status: In Progress.** Cloud provider support is in active development. The CRD types, bootstrap controller integration, and CLI commands are implemented. The provider controller (`butler-provider-azure`) is not yet released. This guide describes the target architecture.
+> **Status: Beta.** Azure bootstrap has been E2E validated for single-node. HA validation is blocked by public IP quota limits on restricted subscriptions.
 
-This guide covers setting up Butler with Microsoft Azure as the infrastructure provider for management cluster bootstrap.
+This guide covers bootstrapping a Butler management cluster on Microsoft Azure.
 
 ## Table of Contents
 
 - [Overview](#overview)
 - [Prerequisites](#prerequisites)
 - [Azure Setup](#azure-setup)
-- [Butler Configuration](#butler-configuration)
-- [Network Architecture](#network-architecture)
-- [Load Balancer Resources](#load-balancer-resources)
-- [Resource Recommendations](#resource-recommendations)
+- [Bootstrap Configuration](#bootstrap-configuration)
+- [Run Bootstrap](#run-bootstrap)
+- [Validation](#validation)
+- [Cleanup](#cleanup)
+- [Azure-Specific Details](#azure-specific-details)
 - [Troubleshooting](#troubleshooting)
 
 ---
 
 ## Overview
 
-Butler uses a thin provider controller (`butler-provider-azure`) to provision VMs on Azure Compute. The controller creates VM instances with Talos Linux images and reports their IPs back to the bootstrap controller.
+Butler uses a thin provider controller (`butler-provider-azure`) to provision VMs on Azure Compute. For HA topologies, the provider creates a Standard Load Balancer with a public IP, health probe, and load balancing rule on port 6443.
 
-For control plane HA, the bootstrap controller creates a LoadBalancerRequest, and the Azure provider provisions a Standard Load Balancer with a public IP, health probe, and load balancing rule on port 6443.
+After bootstrap, the Azure Cloud Controller Manager (CCM) runs on the management cluster as an embedded Deployment (not Helm). It handles `type: LoadBalancer` services by creating Azure load balancers.
 
 ```mermaid
 flowchart LR
@@ -34,13 +35,6 @@ flowchart LR
     AzureProvider --> LB["Standard Load Balancer"]
 ```
 
-### Key Components
-
-| Component | Purpose |
-|-----------|---------|
-| butler-provider-azure | Provisions Azure VMs and Standard Load Balancer resources |
-| CAPI Azure Provider (CAPZ) | Manages tenant cluster worker VMs after bootstrap |
-
 ---
 
 ## Prerequisites
@@ -52,17 +46,55 @@ flowchart LR
 
 ### Service Principal
 
-A service principal with `Contributor` role on the resource group (or subscription).
+A service principal with `Contributor` role on the resource group:
+
+```bash
+az ad sp create-for-rbac \
+  --name butler-bootstrap \
+  --role Contributor \
+  --scopes /subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCE_GROUP
+```
+
+Save the `appId` (clientID), `password` (clientSecret), and `tenant` (tenantID) from the output.
 
 ### Networking
 
-- A resource group in the target region
-- A VNet with at least one subnet
-- A Network Security Group (NSG) allowing required ports (see [Network Architecture](#network-architecture))
+Pre-provision the following resources:
+
+| Resource | Notes |
+|----------|-------|
+| Resource group | Must exist before bootstrap |
+| VNet + subnet | Must exist in the resource group |
+| Network Security Group (NSG) | Must exist. CCM manages NSG rules for LB services. |
 
 ### Talos Image
 
-A Talos Linux image must be available as a managed image or in a Shared Image Gallery in the target subscription. Use the Talos Image Factory or import from official releases.
+A Talos Linux image must be available as a managed image or in a Shared Image Gallery.
+
+**Step 1: Download from the Talos Image Factory**
+
+```bash
+wget https://factory.talos.dev/image/SCHEMATIC_ID/v1.12.5/azure-amd64.vhd.xz
+xz -d azure-amd64.vhd.xz
+```
+
+**Step 2: Upload to Azure**
+
+Upload as a managed image or add to a Shared Image Gallery. Note the full ARM resource ID for the `imageURN` config field. Examples:
+
+- Managed image: `/subscriptions/.../resourceGroups/.../providers/Microsoft.Compute/images/talos-v1-12-5`
+- Gallery image: `/subscriptions/.../resourceGroups/.../providers/Microsoft.Compute/galleries/.../images/.../versions/1.12.5`
+
+### Public IP Quota
+
+Standard Public IPs have a quota that varies by subscription type. Restricted and free-tier subscriptions often default to 3 Standard PIPs per region.
+
+| Topology | VMs | LBs | Total Public IPs |
+|----------|-----|-----|-----------------|
+| Single-node | 1 | 1 (console) | 2 |
+| HA (3CP + 2W) | 5 | 1 (console) | 6 |
+
+If your quota is below 6, HA bootstrap will fail with `PublicIPCountLimitReached`. Request a quota increase through the Azure portal under Subscription > Usage + quotas.
 
 ---
 
@@ -71,271 +103,299 @@ A Talos Linux image must be available as a managed image or in a Shared Image Ga
 ### 1. Create Service Principal
 
 ```bash
-# Create service principal with Contributor role scoped to a resource group
 az ad sp create-for-rbac \
   --name butler-bootstrap \
   --role Contributor \
-  --scopes /subscriptions/SUBSCRIPTION_ID/resourceGroups/butler-rg
+  --scopes /subscriptions/SUB_ID/resourceGroups/butler-rg
 ```
-
-Save the output (`appId`, `password`, `tenant`).
 
 ### 2. Create Resource Group and VNet
 
 ```bash
-# Create resource group
 az group create --name butler-rg --location eastus
 
-# Create VNet and subnet
 az network vnet create \
   --resource-group butler-rg \
   --name butler-vnet \
   --address-prefix 10.0.0.0/16 \
-  --subnet-name butler-subnet \
+  --subnet-name default \
   --subnet-prefix 10.0.0.0/24
 ```
 
 ### 3. Create Network Security Group
 
 ```bash
-# Create NSG
 az network nsg create \
   --resource-group butler-rg \
   --name butler-nsg
 
-# Allow kube-apiserver (external + LB health probes)
+# Kubernetes API (external + LB health probes)
 az network nsg rule create \
-  --resource-group butler-rg \
-  --nsg-name butler-nsg \
-  --name allow-apiserver \
-  --priority 100 \
-  --access Allow \
-  --protocol Tcp \
+  --resource-group butler-rg --nsg-name butler-nsg \
+  --name allow-apiserver --priority 100 \
+  --access Allow --protocol Tcp \
   --destination-port-ranges 6443 \
   --source-address-prefixes '*'
 
-# Allow inter-node Talos API
+# Talos API (inter-node)
 az network nsg rule create \
-  --resource-group butler-rg \
-  --nsg-name butler-nsg \
-  --name allow-talos \
-  --priority 200 \
-  --access Allow \
-  --protocol Tcp \
+  --resource-group butler-rg --nsg-name butler-nsg \
+  --name allow-talos --priority 200 \
+  --access Allow --protocol Tcp \
   --destination-port-ranges 50000-50001 \
   --source-address-prefixes 10.0.0.0/24
 
-# Allow etcd peer and client
+# etcd (inter-node)
 az network nsg rule create \
-  --resource-group butler-rg \
-  --nsg-name butler-nsg \
-  --name allow-etcd \
-  --priority 300 \
-  --access Allow \
-  --protocol Tcp \
+  --resource-group butler-rg --nsg-name butler-nsg \
+  --name allow-etcd --priority 300 \
+  --access Allow --protocol Tcp \
   --destination-port-ranges 2379-2380 \
   --source-address-prefixes 10.0.0.0/24
 
-# Allow kubelet API
+# kubelet API (inter-node)
 az network nsg rule create \
-  --resource-group butler-rg \
-  --nsg-name butler-nsg \
-  --name allow-kubelet \
-  --priority 400 \
-  --access Allow \
-  --protocol Tcp \
+  --resource-group butler-rg --nsg-name butler-nsg \
+  --name allow-kubelet --priority 400 \
+  --access Allow --protocol Tcp \
   --destination-port-ranges 10250 \
+  --source-address-prefixes 10.0.0.0/24
+
+# Cilium health checks (inter-node)
+az network nsg rule create \
+  --resource-group butler-rg --nsg-name butler-nsg \
+  --name allow-cilium-health --priority 500 \
+  --access Allow --protocol Tcp \
+  --destination-port-ranges 4240 \
+  --source-address-prefixes 10.0.0.0/24
+
+# Cilium VXLAN overlay (inter-node)
+az network nsg rule create \
+  --resource-group butler-rg --nsg-name butler-nsg \
+  --name allow-cilium-vxlan --priority 600 \
+  --access Allow --protocol Udp \
+  --destination-port-ranges 8472 \
   --source-address-prefixes 10.0.0.0/24
 
 # Associate NSG with subnet
 az network vnet subnet update \
   --resource-group butler-rg \
   --vnet-name butler-vnet \
-  --name butler-subnet \
+  --name default \
   --network-security-group butler-nsg
-```
-
-### 4. Upload Talos Image (if needed)
-
-```bash
-# Download Talos Azure image
-wget https://factory.talos.dev/image/SCHEMATIC_ID/vX.Y.Z/azure-amd64.vhd.xz
-
-# Create managed image
-az image create \
-  --resource-group butler-rg \
-  --name talos-vX-Y-Z \
-  --os-type Linux \
-  --source PATH_TO_VHD
-```
-
----
-
-## Butler Configuration
-
-### ProviderConfig
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: azure-credentials
-  namespace: butler-system
-type: Opaque
-stringData:
-  client-id: "APP_ID"
-  client-secret: "PASSWORD"
-  tenant-id: "TENANT_ID"
-  subscription-id: "SUBSCRIPTION_ID"
----
-apiVersion: butler.butlerlabs.dev/v1alpha1
-kind: ProviderConfig
-metadata:
-  name: azure-prod
-  namespace: butler-system
-spec:
-  provider: azure
-  credentialsRef:
-    name: azure-credentials
-    namespace: butler-system
-  network:
-    mode: cloud
-  azure:
-    subscriptionID: "SUBSCRIPTION_ID"
-    resourceGroup: butler-rg
-    location: eastus
-    vnetName: butler-vnet
-    subnetName: butler-subnet
-```
-
-### Bootstrap Config
-
-```yaml
-apiVersion: butler.butlerlabs.dev/v1alpha1
-kind: ClusterBootstrap
-metadata:
-  name: butler-mgmt
-  namespace: butler-system
-spec:
-  provider: azure
-  providerRef:
-    name: azure-prod
-    namespace: butler-system
-
-  cluster:
-    name: butler-mgmt
-    topology: ha
-    controlPlane:
-      replicas: 3
-      cpu: 4
-      memoryMB: 16384
-      diskGB: 100
-    workers:
-      replicas: 3
-      cpu: 8
-      memoryMB: 32768
-      diskGB: 200
-
-  network:
-    podCIDR: 10.244.0.0/16
-    serviceCIDR: 10.96.0.0/12
-
-  talos:
-    version: v1.9.2
-    schematic: ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515
-
-  addons:
-    cni:
-      type: cilium
-    storage:
-      type: longhorn
-    controlPlaneProvider:
-      type: steward
-    capi:
-      enabled: true
-      infrastructureProviders:
-        - name: azure
-
-  controlPlaneExposure:
-    mode: LoadBalancer
-```
-
-### Run Bootstrap
-
-```bash
-butleradm bootstrap azure --config bootstrap.yaml
-```
-
----
-
-## Network Architecture
-
-```mermaid
-flowchart TB
-    subgraph Azure["Azure Subscription"]
-        subgraph RG["Resource Group (butler-rg)"]
-            subgraph VNet["VNet (butler-vnet)"]
-                subgraph Subnet["Subnet (butler-subnet)"]
-                    CP0["CP-0<br/>10.0.0.4"]
-                    CP1["CP-1<br/>10.0.0.5"]
-                    CP2["CP-2<br/>10.0.0.6"]
-                    W0["Worker-0<br/>10.0.0.10"]
-                    W1["Worker-1<br/>10.0.0.11"]
-                    W2["Worker-2<br/>10.0.0.12"]
-                end
-            end
-            NSG["Network Security Group"]
-            LB["Standard Load Balancer<br/>20.185.XXX.XXX:6443"]
-        end
-    end
-
-    Internet["External Access"] --> LB
-    LB --> CP0
-    LB --> CP1
-    LB --> CP2
-    NSG -.-> Subnet
 ```
 
 ### NSG Rules
 
-| Priority | Direction | Protocol/Port | Source | Purpose |
-|----------|-----------|--------------|--------|---------|
-| 100 | Inbound | TCP 6443 | * | Kubernetes API (external + LB probes) |
-| 200 | Inbound | TCP 50000-50001 | 10.0.0.0/24 | Talos API (apid + trustd) |
-| 300 | Inbound | TCP 2379-2380 | 10.0.0.0/24 | etcd client and peer |
-| 400 | Inbound | TCP 10250 | 10.0.0.0/24 | kubelet API |
-
-Azure Standard Load Balancer health probes originate from the IP `168.63.129.16`. The wildcard source on the TCP 6443 rule covers both external access and health probe traffic.
-
----
-
-## Load Balancer Resources
-
-When the bootstrap controller creates a LoadBalancerRequest with `provider: azure`, the Azure provider controller creates:
-
-| Azure Resource | Purpose |
-|----------------|---------|
-| Public IP address | Stable external IP for the control plane endpoint |
-| Standard Load Balancer | Regional L4 load balancer |
-| Health probe (TCP 6443) | Checks kube-apiserver availability on each CP node |
-| Load balancing rule (TCP 6443) | Routes traffic to the backend pool |
-| Backend address pool | Groups the control plane VM NICs |
-
-The Standard Load Balancer uses TCP passthrough (no TLS termination). Backend VMs are added directly by their NIC (using IP addresses from `LoadBalancerTarget.ip`).
-
-The public IP is reported as the LoadBalancerRequest endpoint and used as the control plane address.
+| Priority | Protocol/Port | Source | Purpose |
+|----------|--------------|--------|---------|
+| 100 | TCP 6443 | * | Kubernetes API (external + LB health probes from 168.63.129.16) |
+| 200 | TCP 50000-50001 | Subnet CIDR | Talos API (apid + trustd) |
+| 300 | TCP 2379-2380 | Subnet CIDR | etcd client and peer |
+| 400 | TCP 10250 | Subnet CIDR | kubelet API |
+| 500 | TCP 4240 | Subnet CIDR | Cilium health checks |
+| 600 | UDP 8472 | Subnet CIDR | Cilium VXLAN overlay |
 
 ---
 
-## Resource Recommendations
+## Bootstrap Configuration
 
-| Profile | CP Nodes | CP VM Size | Worker Nodes | Worker VM Size | Estimated Monthly Cost |
-|---------|----------|-----------|-------------|---------------|----------------------|
-| Development | 1 (single-node) | Standard_D4s_v5 (4 vCPU, 16 GB) | 0 | -- | ~$150 |
-| Staging | 3 | Standard_D4s_v5 (4 vCPU, 16 GB) | 2 | Standard_D8s_v5 (8 vCPU, 32 GB) | ~$1,000 |
-| Production | 3 | Standard_D4s_v5 (4 vCPU, 16 GB) | 3+ | Standard_D8s_v5 (8 vCPU, 32 GB) | ~$1,400+ |
+Create a config file at `~/.butler/bootstrap-azure.yaml`:
 
-Standard Load Balancer pricing: fixed hourly charge plus per-rule charge. For a management cluster with a single rule, expect approximately $25/month.
+### Single-Node
+
+```yaml
+provider: azure
+
+cluster:
+  name: butler-mgmt
+  topology: single-node
+  controlPlane:
+    replicas: 1
+    cpu: 4
+    memoryMB: 16384           # 16 GB
+    diskGB: 100
+
+network:
+  podCIDR: "10.244.0.0/16"
+  serviceCIDR: "10.96.0.0/12"
+  # No vip or loadBalancerPool for cloud providers
+
+talos:
+  version: v1.12.5
+
+addons:
+  cni:
+    type: cilium
+  storage:
+    type: longhorn
+
+providerConfig:
+  azure:
+    clientID: "00000000-0000-0000-0000-000000000000"        # Service principal app ID
+    clientSecret: "your-client-secret"                        # Service principal password
+    tenantID: "00000000-0000-0000-0000-000000000000"         # Azure AD tenant ID
+    subscriptionID: "00000000-0000-0000-0000-000000000000"   # Azure subscription ID
+    resourceGroup: "butler-rg"                                # Pre-existing resource group
+    location: "eastus"                                        # Azure region
+    vnetName: "butler-vnet"                                   # Pre-existing VNet name
+    subnetName: "default"                                     # Subnet within the VNet
+    securityGroupName: "butler-nsg"                           # Pre-existing NSG name (required)
+    vmSize: "Standard_D4s_v3"                                 # VM size
+    imageURN: "/subscriptions/.../providers/Microsoft.Compute/galleries/.../images/.../versions/1.12.5"
+```
+
+### HA
+
+```yaml
+provider: azure
+
+cluster:
+  name: butler-mgmt
+  topology: ha
+  controlPlane:
+    replicas: 3
+    cpu: 4
+    memoryMB: 16384
+    diskGB: 100
+  workers:
+    replicas: 2
+    cpu: 4
+    memoryMB: 16384
+    diskGB: 100
+
+network:
+  podCIDR: "10.244.0.0/16"
+  serviceCIDR: "10.96.0.0/12"
+
+talos:
+  version: v1.12.5
+
+addons:
+  cni:
+    type: cilium
+  storage:
+    type: longhorn
+
+providerConfig:
+  azure:
+    clientID: "00000000-0000-0000-0000-000000000000"
+    clientSecret: "your-client-secret"
+    tenantID: "00000000-0000-0000-0000-000000000000"
+    subscriptionID: "00000000-0000-0000-0000-000000000000"
+    resourceGroup: "butler-rg"
+    location: "eastus"
+    vnetName: "butler-vnet"
+    subnetName: "default"
+    securityGroupName: "butler-nsg"
+    vmSize: "Standard_D4s_v3"
+    imageURN: "/subscriptions/.../providers/Microsoft.Compute/galleries/.../images/.../versions/1.12.5"
+```
+
+**Required fields:**
+- `securityGroupName` is required. The Azure CCM fails with `securityGroupName is not configured` without it.
+- `imageURN` is the full ARM resource ID for the Talos image (managed image or gallery image version).
+- `vmSize` selects the Azure VM SKU. Not all SKUs support all security types.
+
+---
+
+## Run Bootstrap
+
+```bash
+butleradm bootstrap azure --config ~/.butler/bootstrap-azure.yaml
+```
+
+---
+
+## Validation
+
+```bash
+export KUBECONFIG=~/.butler/butler-mgmt-kubeconfig
+
+# All nodes Ready with providerID set
+kubectl get nodes -o wide
+kubectl get nodes -o jsonpath='{.items[*].spec.providerID}'
+# Expected format: azure:///subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Compute/virtualMachines/<vm>
+
+# Azure CCM Deployment running (embedded manifest)
+kubectl get deploy -n kube-system | grep cloud
+
+# Cilium healthy
+kubectl get pods -n kube-system -l app.kubernetes.io/name=cilium
+
+# Longhorn healthy
+kubectl get pods -n longhorn-system
+
+# Butler Console exposed via Azure LB
+kubectl get svc butler-console-frontend -n butler-system
+# Should show type: LoadBalancer with an external IP
+
+# Console accessible
+curl http://<LB-IP>
+```
+
+---
+
+## Cleanup
+
+```bash
+# Delete KIND bootstrap cluster
+kind delete cluster --name butler-bootstrap
+
+# Delete VMs
+az vm list -g butler-rg \
+  --query "[?tags.\"butler_butlerlabs_dev_managed-by\"=='butler'].name" -o tsv \
+  | xargs -I{} az vm delete -g butler-rg -n {} --yes --force-deletion yes
+
+# Wait ~180s for NICs to release, then delete NICs
+az network nic list -g butler-rg \
+  --query "[?contains(name, 'butler-mgmt')].name" -o tsv \
+  | xargs -I{} az network nic delete -g butler-rg -n {}
+
+# Delete public IPs
+az network public-ip list -g butler-rg \
+  --query "[?tags.\"butler-managed-by\"=='butler'].name" -o tsv \
+  | xargs -I{} az network public-ip delete -g butler-rg -n {}
+
+# Delete load balancers
+az network lb list -g butler-rg \
+  --query "[?tags.\"butler-managed-by\"=='butler'].name" -o tsv \
+  | xargs -I{} az network lb delete -g butler-rg -n {}
+
+# Delete orphaned disks
+az disk list -g butler-rg \
+  --query "[?contains(name, 'butler-mgmt')].name" -o tsv \
+  | xargs -I{} az disk delete -g butler-rg -n {} --yes
+
+# Delete availability set
+az vm availability-set delete -g butler-rg -n butler-mgmt-avset
+```
+
+---
+
+## Azure-Specific Details
+
+### AvailabilitySet
+
+The provider controller auto-creates an AvailabilitySet named `<clusterName>-avset` with Aligned SKU (Fault Domains: 2, Update Domains: 5). This is required because the Azure CCM with `vmType=standard` uses AvailabilitySet membership to determine which VMs belong to the cluster for LB backend pool management.
+
+### CCM Backend Pool Bug
+
+Azure CCM v1.31 with `vmType=standard` does not auto-populate LB backend pools. The initial backend sync runs before any LoadBalancer services exist, and no subsequent sync is triggered after the console service is created.
+
+Butler works around this in bootstrap step 12.5 by directly calling the Azure REST API to:
+1. Get the LB backend pool resource ID
+2. For each cluster node: read the NIC, add the backend pool reference to `ipConfigurations[0].properties.loadBalancerBackendAddressPools`, and write it back
+
+This is handled automatically during bootstrap.
+
+### Tag Key Sanitization
+
+Azure tag keys cannot contain forward slashes (`/`). Butler labels like `butler.butlerlabs.dev/team` are sanitized by replacing `/` with `_`. Load balancer and public IP resources use simplified tag keys like `butler-managed-by` instead.
+
+### SSH Key Placeholder
+
+Azure requires an SSH public key for Linux VM creation, even though Talos ignores SSH. The provider generates a placeholder RSA-4096 key at runtime.
 
 ---
 
@@ -345,7 +405,6 @@ Standard Load Balancer pricing: fixed hourly charge plus per-rule charge. For a 
 
 **Symptom**: Talos bootstrap times out. Nodes cannot communicate.
 
-**Verify**:
 ```bash
 az network nsg rule list \
   --resource-group butler-rg \
@@ -353,53 +412,56 @@ az network nsg rule list \
   --output table
 ```
 
-### Quota Limits
+Verify all six rules exist, including Cilium ports (4240, 8472).
 
-**Symptom**: MachineRequest stuck in `Creating` with quota error.
+### Public IP Quota Exceeded
 
-**Common quotas to check:**
-- `Total Regional vCPUs` (default varies by subscription type)
-- `Standard Dv5 Family vCPUs` (or whichever family is used)
-- `Public IP Addresses - Standard` (default: 10 per region)
+**Symptom**: `PublicIPCountLimitReached` error in provider logs.
 
-**Check**:
 ```bash
-az vm list-usage --location eastus --output table
+az vm list-usage --location eastus --output table | grep "Public IP"
 ```
 
-**Fix**: Request quota increase in the Azure Portal under Subscription > Usage + quotas.
+Standard Public IPs default to 3 per region on restricted subscriptions. Single-node needs 2 (1 VM + 1 console LB). HA needs 6 (5 VMs + 1 LB). Self-service quota increase (`az quota create`) may fail. Request an increase through the Azure portal support ticket flow.
 
-### LB Health Probe Failures
+### CCM LB Backend Pool Empty
 
-**Symptom**: LoadBalancerRequest stuck in `Creating` phase.
+**Symptom**: Console LB exists but has no healthy backends. The service external IP is assigned but `curl` times out.
 
-**Verify**:
+Check CCM logs:
 ```bash
-az network lb probe show \
-  --resource-group butler-rg \
-  --lb-name butler-mgmt-lb \
-  --name butler-mgmt-probe
+kubectl logs -n kube-system deploy/cloud-controller-manager
 ```
 
-**Common causes:**
-- NSG blocks TCP 6443 from the health probe source IP (`168.63.129.16`)
-- kube-apiserver not yet listening (bootstrap still in progress)
-- Backend pool has no associated NICs
+If you see `managed=, ok=false, isNodeManagedByCloudProvider=true` without subsequent backend sync, the CCM backend pool bug has occurred. Butler's step 12.5 handles this automatically, but if it fails, check the bootstrap controller logs for Azure REST API errors.
 
 ### Service Principal Expired
 
-**Symptom**: Provider controller logs show `AADSTS7000215: Invalid client secret`.
+**Symptom**: `AADSTS7000215: Invalid client secret`.
 
-**Fix**: Create a new client secret and update the credentials Secret:
 ```bash
 az ad sp credential reset --id APP_ID
+```
+
+Update the secret in your bootstrap config.
+
+### securityGroupName Missing
+
+**Symptom**: CCM logs show `securityGroupName is not configured`.
+
+The `securityGroupName` field is required in the Azure provider config. Without it, the CCM cannot create NSG rules for LoadBalancer services. Add it to your config:
+
+```yaml
+providerConfig:
+  azure:
+    securityGroupName: "butler-nsg"
 ```
 
 ---
 
 ## See Also
 
-- [Bootstrap Flow](../architecture/bootstrap-flow.md) - end-to-end bootstrap sequence
-- [ClusterBootstrap CRD](../reference/crds/clusterbootstrap.md) - full spec reference
-- [LoadBalancerRequest CRD](../reference/crds/loadbalancerrequest.md) - cloud LB provisioning
-- [ProviderConfig CRD](../reference/crds/providerconfig.md) - provider credentials
+- [Bootstrap Flow](../architecture/bootstrap-flow.md) - End-to-end bootstrap sequence
+- [Bootstrap Config Reference](../reference/bootstrap-config.md) - Every config field documented
+- [AWS Provider](aws.md) - Alternative cloud provider
+- [GCP Provider](gcp.md) - Alternative cloud provider

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -311,7 +311,7 @@ butleradm bootstrap azure --config ~/.butler/bootstrap-azure.yaml
 ## Validation
 
 ```bash
-export KUBECONFIG=~/.butler/butler-mgmt-kubeconfig
+export KUBECONFIG=~/.butler/butler-azure-test-kubeconfig
 
 # All nodes Ready with providerID set
 kubectl get nodes -o wide
@@ -321,19 +321,30 @@ kubectl get nodes -o jsonpath='{.items[*].spec.providerID}'
 # Azure CCM Deployment running (embedded manifest)
 kubectl get deploy -n kube-system | grep cloud
 
-# Cilium healthy
+# Cilium running
 kubectl get pods -n kube-system -l app.kubernetes.io/name=cilium
 
-# Longhorn healthy
+# Longhorn running
 kubectl get pods -n longhorn-system
 
 # Butler Console exposed via Azure LB
 kubectl get svc butler-console-frontend -n butler-system
-# Should show type: LoadBalancer with an external IP
 
-# Console accessible
+# Console accessible (use the EXTERNAL-IP from above)
 curl http://<LB-IP>
 ```
+
+### What You Have Now
+
+A Butler management cluster running on Azure with:
+- Talos Linux VMs with Cilium CNI
+- Azure Standard Load Balancer fronting the Kubernetes API (HA topology)
+- Azure CCM handling LoadBalancer services
+- Longhorn distributed storage
+- Steward for hosted tenant control planes
+- Butler controller, CRDs, and web console exposed via Azure LB
+
+To create your first tenant cluster, go to [Create Your First Tenant Cluster](../getting-started/#create-your-first-tenant-cluster).
 
 ---
 

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -361,7 +361,7 @@ az vm list -g butler-rg \
 
 # Wait ~180s for NICs to release, then delete NICs
 az network nic list -g butler-rg \
-  --query "[?contains(name, 'butler-mgmt')].name" -o tsv \
+  --query "[?contains(name, 'butler-azure-test')].name" -o tsv \
   | xargs -I{} az network nic delete -g butler-rg -n {}
 
 # Delete public IPs
@@ -376,11 +376,11 @@ az network lb list -g butler-rg \
 
 # Delete orphaned disks
 az disk list -g butler-rg \
-  --query "[?contains(name, 'butler-mgmt')].name" -o tsv \
+  --query "[?contains(name, 'butler-azure-test')].name" -o tsv \
   | xargs -I{} az disk delete -g butler-rg -n {} --yes
 
 # Delete availability set
-az vm availability-set delete -g butler-rg -n butler-mgmt-avset
+az vm availability-set delete -g butler-rg -n butler-azure-test-avset
 ```
 
 ---

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -1,27 +1,27 @@
 # GCP Provider Guide
 
-> **Status: Beta.** GCP bootstrap has been E2E validated with LoadBalancerRequest HA. The CRD types, bootstrap controller integration, CLI commands, and provider controller are implemented.
+> **Status: Beta.** GCP bootstrap has been E2E validated for both single-node and HA topologies.
 
-This guide covers setting up Butler with Google Cloud Platform as the infrastructure provider for management cluster bootstrap.
+This guide covers bootstrapping a Butler management cluster on Google Cloud Platform.
 
 ## Table of Contents
 
 - [Overview](#overview)
 - [Prerequisites](#prerequisites)
 - [GCP Setup](#gcp-setup)
-- [Butler Configuration](#butler-configuration)
-- [Network Architecture](#network-architecture)
-- [Load Balancer Resources](#load-balancer-resources)
-- [Resource Recommendations](#resource-recommendations)
+- [Bootstrap Configuration](#bootstrap-configuration)
+- [Run Bootstrap](#run-bootstrap)
+- [Validation](#validation)
+- [Cleanup](#cleanup)
 - [Troubleshooting](#troubleshooting)
 
 ---
 
 ## Overview
 
-Butler uses a thin provider controller (`butler-provider-gcp`) to provision VMs on Google Compute Engine. The controller creates VM instances with Talos Linux boot images and reports their IPs back to the bootstrap controller.
+Butler uses a thin provider controller (`butler-provider-gcp`) to provision VM instances on Google Compute Engine. For HA topologies, the provider creates a regional TCP passthrough load balancer (forwarding rule + target pool + health check) to front the control plane.
 
-For control plane HA, the bootstrap controller creates a LoadBalancerRequest, and the GCP provider provisions a regional TCP passthrough load balancer using a forwarding rule, target pool, and health check.
+After bootstrap, the GCP Cloud Controller Manager (CCM) runs on the management cluster as an embedded DaemonSet (no Helm chart available for GCP CCM). It handles `type: LoadBalancer` services by creating forwarding rules and target pools.
 
 ```mermaid
 flowchart LR
@@ -34,13 +34,6 @@ flowchart LR
     GCPProvider --> LB["TCP Load Balancer"]
 ```
 
-### Key Components
-
-| Component | Purpose |
-|-----------|---------|
-| butler-provider-gcp | Provisions GCE VMs and GCP load balancer resources |
-| CAPI GCP Provider (CAPG) | Manages tenant cluster worker VMs after bootstrap |
-
 ---
 
 ## Prerequisites
@@ -52,17 +45,44 @@ flowchart LR
 
 ### Service Account
 
-A service account with the `roles/compute.admin` role (or equivalent custom role covering instances, disks, networks, forwarding rules, target pools, health checks, and static addresses).
+A service account with two roles:
+
+| Role | Purpose |
+|------|---------|
+| `roles/compute.admin` | Manage instances, disks, networks, forwarding rules, target pools, health checks, addresses, firewall rules |
+| `roles/iam.serviceAccountUser` | Attach service account to VM instances (required for GCE metadata API) |
+
+Download the service account key JSON file.
 
 ### Networking
 
 - A VPC with at least one subnet in the target region
-- Firewall rules (see [Network Architecture](#network-architecture) below)
-- Sufficient quota for static regional IPs, CPUs, and disks in the target region
+- Firewall rules (see [Firewall Rules](#firewall-rules) below)
+- Sufficient quota for CPUs, disks, and static IPs in the target region
 
-### Talos Image
+### Talos GCE Image
 
-A Talos Linux image must be available in the project. Use the Talos Image Factory to produce a GCP-compatible image, or import one from the Talos GitHub releases.
+GCP does not have pre-built Talos AMIs. You must build and upload a GCE image.
+
+**Step 1: Download from the Talos Image Factory**
+
+```bash
+# Schematic: c9078f9419961640c712a8bf2bb9174933dfcf1da383fd8ea2b7dc21493f8bac
+# (iscsi-tools, Talos v1.12.5, amd64)
+wget https://factory.talos.dev/image/c9078f9419961640c712a8bf2bb9174933dfcf1da383fd8ea2b7dc21493f8bac/v1.12.5/gcp-amd64.raw.tar.gz
+```
+
+**Step 2: Upload to GCS and register as a GCE image**
+
+```bash
+gsutil cp gcp-amd64.raw.tar.gz gs://YOUR_BUCKET/talos-v1-12-5.raw.tar.gz
+
+gcloud compute images create talos-v1-12-5-iscsi \
+  --source-uri gs://YOUR_BUCKET/talos-v1-12-5.raw.tar.gz \
+  --project YOUR_PROJECT_ID
+```
+
+Note the image name (`talos-v1-12-5-iscsi`) and the project ID where you created it.
 
 ---
 
@@ -71,38 +91,39 @@ A Talos Linux image must be available in the project. Use the Talos Image Factor
 ### 1. Create Service Account
 
 ```bash
-# Create service account
 gcloud iam service-accounts create butler-bootstrap \
   --display-name="Butler Bootstrap"
 
-# Grant compute admin role
 gcloud projects add-iam-policy-binding PROJECT_ID \
   --member="serviceAccount:butler-bootstrap@PROJECT_ID.iam.gserviceaccount.com" \
   --role="roles/compute.admin"
 
-# Create and download key
-gcloud iam service-accounts keys create gcp-credentials.json \
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="serviceAccount:butler-bootstrap@PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountUser"
+
+gcloud iam service-accounts keys create ~/.butler/gcp-sa-key.json \
   --iam-account=butler-bootstrap@PROJECT_ID.iam.gserviceaccount.com
 ```
 
 ### 2. Create Firewall Rules
 
 ```bash
-# Allow inter-node communication (Talos API, etcd, kubelet)
+# Inter-node communication (all K8s and Talos ports)
 gcloud compute firewall-rules create butler-internal \
   --network=default \
-  --allow=tcp:6443,tcp:50000,tcp:50001,tcp:2379-2380,tcp:10250 \
+  --allow=tcp:6443,tcp:50000-50001,tcp:2379-2380,tcp:10250,tcp:4240,udp:8472 \
   --source-tags=butler-node \
   --target-tags=butler-node
 
-# Allow health checks from GCP health check ranges
+# GCP health check probes (required for load balancers)
 gcloud compute firewall-rules create butler-health-check \
   --network=default \
   --allow=tcp:6443 \
   --source-ranges=130.211.0.0/22,35.191.0.0/16 \
   --target-tags=butler-node
 
-# Allow external access to kube-apiserver via LB
+# External access to kube-apiserver
 gcloud compute firewall-rules create butler-apiserver \
   --network=default \
   --allow=tcp:6443 \
@@ -110,191 +131,196 @@ gcloud compute firewall-rules create butler-apiserver \
   --target-tags=butler-node
 ```
 
-### 3. Upload Talos Image (if needed)
-
-```bash
-# Download Talos GCP image
-wget https://factory.talos.dev/image/SCHEMATIC_ID/vX.Y.Z/gcp-amd64.raw.tar.gz
-
-# Create GCE image
-gcloud compute images create talos-vX-Y-Z \
-  --source-uri=gs://BUCKET/talos-vX-Y-Z.raw.tar.gz
-```
-
----
-
-## Butler Configuration
-
-### ProviderConfig
-
-Create a Kubernetes Secret with the service account key, then reference it from a ProviderConfig:
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: gcp-credentials
-  namespace: butler-system
-type: Opaque
-stringData:
-  credentials.json: |
-    {
-      "type": "service_account",
-      "project_id": "my-project",
-      ...
-    }
----
-apiVersion: butler.butlerlabs.dev/v1alpha1
-kind: ProviderConfig
-metadata:
-  name: gcp-prod
-  namespace: butler-system
-spec:
-  provider: gcp
-  credentialsRef:
-    name: gcp-credentials
-    namespace: butler-system
-    key: credentials.json
-  network:
-    mode: cloud
-  gcp:
-    projectID: my-project
-    region: us-central1
-    network: default
-    subnetwork: default
-```
-
-### Bootstrap Config
-
-```yaml
-apiVersion: butler.butlerlabs.dev/v1alpha1
-kind: ClusterBootstrap
-metadata:
-  name: butler-mgmt
-  namespace: butler-system
-spec:
-  provider: gcp
-  providerRef:
-    name: gcp-prod
-    namespace: butler-system
-
-  cluster:
-    name: butler-mgmt
-    topology: ha
-    controlPlane:
-      replicas: 3
-      cpu: 4
-      memoryMB: 16384
-      diskGB: 100
-    workers:
-      replicas: 3
-      cpu: 8
-      memoryMB: 32768
-      diskGB: 200
-
-  network:
-    podCIDR: 10.244.0.0/16
-    serviceCIDR: 10.96.0.0/12
-    # VIP is set automatically from LoadBalancerRequest endpoint
-
-  talos:
-    version: v1.9.2
-    schematic: ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515
-
-  addons:
-    cni:
-      type: cilium
-      hubbleEnabled: true
-    storage:
-      type: longhorn
-    controlPlaneProvider:
-      type: steward
-    capi:
-      enabled: true
-      infrastructureProviders:
-        - name: gcp
-
-  controlPlaneExposure:
-    mode: LoadBalancer
-```
-
-### Run Bootstrap
-
-```bash
-butleradm bootstrap gcp --config bootstrap.yaml
-```
-
----
-
-## Network Architecture
-
-```mermaid
-flowchart TB
-    subgraph GCP["GCP Project"]
-        subgraph VPC["VPC Network"]
-            subgraph Subnet["Subnet (us-central1)"]
-                CP0["CP-0<br/>10.128.0.10"]
-                CP1["CP-1<br/>10.128.0.11"]
-                CP2["CP-2<br/>10.128.0.12"]
-                W0["Worker-0<br/>10.128.0.20"]
-                W1["Worker-1<br/>10.128.0.21"]
-                W2["Worker-2<br/>10.128.0.22"]
-            end
-        end
-        LB["TCP Load Balancer<br/>35.194.52.218:6443"]
-        FW["Firewall Rules"]
-    end
-
-    Internet["External Access"] --> LB
-    LB --> CP0
-    LB --> CP1
-    LB --> CP2
-    FW -.-> Subnet
-```
-
 ### Firewall Rules
 
 | Rule | Protocol/Port | Source | Target | Purpose |
 |------|--------------|--------|--------|---------|
-| butler-internal | TCP 6443, 50000-50001, 2379-2380, 10250 | butler-node tag | butler-node tag | Inter-node communication |
+| butler-internal | TCP 6443, 50000-50001, 2379-2380, 10250, 4240; UDP 8472 | butler-node tag | butler-node tag | All inter-node traffic |
 | butler-health-check | TCP 6443 | 130.211.0.0/22, 35.191.0.0/16 | butler-node tag | GCP health check probes |
 | butler-apiserver | TCP 6443 | 0.0.0.0/0 | butler-node tag | External kube-apiserver access |
 
-Ports explained:
+Port details:
 - **6443**: Kubernetes API server
-- **50000**: Talos API (apid)
-- **50001**: Talos trustd
+- **50000-50001**: Talos API (apid + trustd)
 - **2379-2380**: etcd client and peer
 - **10250**: kubelet API
+- **4240**: Cilium health checks
+- **8472**: Cilium VXLAN overlay (UDP)
+
+### Network Tags
+
+GCE instances are tagged with the cluster name (e.g., `butler-mgmt`). The GCP CCM uses these network tags to manage firewall rules for LoadBalancer services. Without network tags, the CCM logs: `no node tags supplied...Abort creating firewall rule`.
+
+The provider controller applies these tags automatically.
 
 ---
 
-## Load Balancer Resources
+## Bootstrap Configuration
 
-When the bootstrap controller creates a LoadBalancerRequest with `provider: gcp`, the GCP provider controller creates:
+Create a config file at `~/.butler/bootstrap-gcp.yaml`:
 
-| GCP Resource | Purpose |
-|--------------|---------|
-| Regional static IP address | Stable external IP for the control plane endpoint |
-| Legacy HTTP health check | Checks TCP 6443 on each control plane node |
-| Target pool | Groups the control plane VM instances |
-| Regional forwarding rule | Routes TCP 6443 traffic from the static IP to the target pool |
+### Single-Node
 
-These are regional resources created in the same region as the VMs. The forwarding rule uses TCP passthrough (no TLS termination). The kube-apiserver handles TLS.
+```yaml
+provider: gcp
 
-The static IP is reported back as `LoadBalancerRequest.status.endpoint` and used as the control plane address in Talos machine configs.
+cluster:
+  name: butler-mgmt
+  topology: single-node
+  controlPlane:
+    replicas: 1
+    cpu: 4
+    memoryMB: 8192
+    diskGB: 50
+
+network:
+  podCIDR: 10.244.0.0/16
+  serviceCIDR: 10.96.0.0/12
+  # No vip or loadBalancerPool for cloud providers
+
+talos:
+  version: v1.12.5
+
+addons:
+  cni:
+    type: cilium
+  storage:
+    type: longhorn
+
+providerConfig:
+  gcp:
+    serviceAccountKeyPath: ~/.butler/gcp-sa-key.json   # Path to SA key JSON
+    projectID: your-project-id                          # GCP project ID
+    region: us-central1                                 # GCP region
+    zone: us-central1-a                                 # GCP zone (default: {region}-a)
+    network: default                                    # VPC network name
+    subnetwork: default                                 # Subnet name
+    imageProject: your-project-id                       # Project containing the Talos image
+    image: talos-v1-12-5-iscsi                          # GCE image name
+    # machineType: n2-standard-4                        # Optional: override VM type
+```
+
+### HA
+
+```yaml
+provider: gcp
+
+cluster:
+  name: butler-mgmt
+  topology: ha
+  controlPlane:
+    replicas: 3
+    cpu: 4
+    memoryMB: 8192
+    diskGB: 50
+  workers:
+    replicas: 2
+    cpu: 4
+    memoryMB: 8192
+    diskGB: 50
+
+network:
+  podCIDR: 10.244.0.0/16
+  serviceCIDR: 10.96.0.0/12
+
+talos:
+  version: v1.12.5
+
+addons:
+  cni:
+    type: cilium
+  storage:
+    type: longhorn
+
+providerConfig:
+  gcp:
+    serviceAccountKeyPath: ~/.butler/gcp-sa-key.json
+    projectID: your-project-id
+    region: us-central1
+    zone: us-central1-a
+    network: default
+    subnetwork: default
+    imageProject: your-project-id
+    image: talos-v1-12-5-iscsi
+```
 
 ---
 
-## Resource Recommendations
+## Run Bootstrap
 
-| Profile | CP Nodes | CP Sizing | Worker Nodes | Worker Sizing | Estimated Monthly Cost |
-|---------|----------|-----------|-------------|---------------|----------------------|
-| Development | 1 (single-node) | n2-standard-4 (4 vCPU, 16 GB) | 0 | -- | ~$150 |
-| Staging | 3 | n2-standard-4 (4 vCPU, 16 GB) | 2 | n2-standard-8 (8 vCPU, 32 GB) | ~$900 |
-| Production | 3 | n2-standard-4 (4 vCPU, 16 GB) | 3+ | n2-standard-8 (8 vCPU, 32 GB) | ~$1,200+ |
+```bash
+butleradm bootstrap gcp --config ~/.butler/bootstrap-gcp.yaml
+```
 
-Storage: Longhorn uses attached persistent disks. Add `extraDisks` with adequate `sizeGB` for persistent volume capacity.
+---
+
+## Validation
+
+```bash
+export KUBECONFIG=~/.butler/butler-mgmt-kubeconfig
+
+# All nodes Ready with providerID set
+kubectl get nodes -o wide
+kubectl get nodes -o jsonpath='{.items[*].spec.providerID}'
+# Expected format: gce://<project>/<zone>/<instance-name>
+
+# GCP CCM DaemonSet running (embedded manifest, not Helm)
+kubectl get ds -n kube-system | grep cloud
+
+# Cilium healthy
+kubectl get pods -n kube-system -l app.kubernetes.io/name=cilium
+
+# Longhorn healthy
+kubectl get pods -n longhorn-system
+
+# Butler Console exposed via GCP load balancer
+kubectl get svc butler-console-frontend -n butler-system
+# Should show type: LoadBalancer with an external IP
+
+# Console accessible
+curl http://<LB-IP>
+```
+
+---
+
+## Cleanup
+
+```bash
+# Delete KIND bootstrap cluster
+kind delete cluster --name butler-bootstrap
+
+# Delete GCE instances
+gcloud compute instances list \
+  --filter="labels.butler_butlerlabs_dev_managed-by=butler" \
+  --format="value(name,zone)" \
+  | while read name zone; do
+    gcloud compute instances delete "$name" --zone="$zone" --quiet
+  done
+
+# Delete forwarding rules
+gcloud compute forwarding-rules list \
+  --filter="name~butler-mgmt" \
+  --format="value(name,region)" \
+  | while read name region; do
+    gcloud compute forwarding-rules delete "$name" --region="$region" --quiet
+  done
+
+# Delete target pools
+gcloud compute target-pools list \
+  --filter="name~butler-mgmt" \
+  --format="value(name,region)" \
+  | while read name region; do
+    gcloud compute target-pools delete "$name" --region="$region" --quiet
+  done
+
+# Delete CCM-managed firewall rules
+gcloud compute firewall-rules list \
+  --filter="name~butler-mgmt" \
+  --format="value(name)" \
+  | while read name; do
+    gcloud compute firewall-rules delete "$name" --quiet
+  done
+```
 
 ---
 
@@ -302,66 +328,72 @@ Storage: Longhorn uses attached persistent disks. Add `extraDisks` with adequate
 
 ### Quota Exceeded
 
-**Symptom**: MachineRequest stuck in `Creating` phase with quota error in provider logs.
+**Symptom**: MachineRequest stuck in `Creating` with quota error in provider logs.
 
-**Common quotas to check:**
+Common quotas to check:
 - `CPUS_ALL_REGIONS` (default: 12 per region)
 - `IN_USE_ADDRESSES` (static IPs, default: 8 per region)
-- `DISKS_TOTAL_GB` (default: 2,048 GB per region)
+- `DISKS_TOTAL_GB` (default: 2048 GB per region)
 
-**Fix**: Request quota increase in the GCP Console under IAM & Admin > Quotas.
+Request increases in GCP Console under IAM & Admin > Quotas.
 
 ### Firewall Rules Missing
 
-**Symptom**: Talos bootstrap times out. Nodes cannot reach each other on port 6443.
+**Symptom**: Talos bootstrap times out. Nodes cannot reach each other.
 
-**Verify**:
 ```bash
-gcloud compute firewall-rules list --filter="network=default" --format="table(name, direction, allowed, sourceRanges)"
+gcloud compute firewall-rules list \
+  --filter="network=default" \
+  --format="table(name, direction, allowed, sourceRanges)"
 ```
+
+Verify all three rules exist and include Cilium ports (TCP 4240, UDP 8472).
 
 ### LB Health Check Failures
 
-**Symptom**: LoadBalancerRequest stays in `Creating` phase. Health check shows 0 healthy instances.
+**Symptom**: LoadBalancerRequest stays in `Creating`.
 
-**Verify**:
 ```bash
-gcloud compute health-checks describe butler-mgmt-hc --region=us-central1
 gcloud compute target-pools get-health butler-mgmt-tp --region=us-central1
 ```
 
-**Common causes:**
-- Firewall rule for health check source ranges (130.211.0.0/22, 35.191.0.0/16) is missing
+Common causes:
+- Health check firewall rule missing (source ranges 130.211.0.0/22 and 35.191.0.0/16)
 - kube-apiserver not yet listening (bootstrap still in progress)
-- Health check port does not match the apiserver port
 
 ### API Not Enabled
 
-**Symptom**: Provider controller logs show `googleapi: Error 403: Compute Engine API has not been used`.
+**Symptom**: `googleapi: Error 403: Compute Engine API has not been used`.
 
-**Fix**:
 ```bash
 gcloud services enable compute.googleapis.com --project=PROJECT_ID
 ```
 
-### Insufficient IAM Permissions
+### GCP CCM: nodeipam Controller Crash
 
-**Symptom**: Provider controller logs show permission denied errors for compute operations.
+**Symptom**: CCM logs show `error running controllers: the AllocateNodeCIDRs is not enabled`.
 
-**Verify**:
-```bash
-gcloud projects get-iam-policy PROJECT_ID \
-  --filter="bindings.members:butler-bootstrap@PROJECT_ID.iam.gserviceaccount.com" \
-  --format="table(bindings.role)"
-```
+This is handled automatically by Butler. The embedded CCM DaemonSet uses `--controllers=*,-nodeipam --allocate-node-cidrs=false` because Cilium manages pod IPAM, not the cloud provider.
 
-The service account needs `roles/compute.admin` or a custom role with permissions for instances, disks, networks, addresses, forwarding rules, target pools, and health checks.
+### GCP CCM: Network Tags Missing
+
+**Symptom**: CCM logs show `no node tags supplied...Abort creating firewall rule`.
+
+The GCP CCM requires network tags on instances to manage firewall rules for LoadBalancer services. Butler's provider controller applies the cluster name as a network tag. The CCM's `cloud-config` includes `node-tags = <clusterName>`.
+
+If tags are missing, check that the provider controller applied tags during VM creation.
+
+### Service Account Missing iam.serviceAccountUser
+
+**Symptom**: Provider controller fails to create instances with permission error about service account attachment.
+
+The service account needs `roles/iam.serviceAccountUser` in addition to `roles/compute.admin`. This role allows attaching a service account to GCE instances, which is required for the GCE metadata API.
 
 ---
 
 ## See Also
 
-- [Bootstrap Flow](../architecture/bootstrap-flow.md) - end-to-end bootstrap sequence
-- [ClusterBootstrap CRD](../reference/crds/clusterbootstrap.md) - full spec reference
-- [LoadBalancerRequest CRD](../reference/crds/loadbalancerrequest.md) - cloud LB provisioning
-- [ProviderConfig CRD](../reference/crds/providerconfig.md) - provider credentials
+- [Bootstrap Flow](../architecture/bootstrap-flow.md) - End-to-end bootstrap sequence
+- [Bootstrap Config Reference](../reference/bootstrap-config.md) - Every config field documented
+- [AWS Provider](aws.md) - Alternative cloud provider
+- [Azure Provider](azure.md) - Alternative cloud provider

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -149,7 +149,7 @@ Port details:
 
 ### Network Tags
 
-GCE instances are tagged with the cluster name (e.g., `butler-mgmt`). The GCP CCM uses these network tags to manage firewall rules for LoadBalancer services. Without network tags, the CCM logs: `no node tags supplied...Abort creating firewall rule`.
+GCE instances are tagged with the cluster name (e.g., `butler-gcp-test`). The GCP CCM uses these network tags to manage firewall rules for LoadBalancer services. Without network tags, the CCM logs: `no node tags supplied...Abort creating firewall rule`.
 
 The provider controller applies these tags automatically.
 
@@ -310,7 +310,7 @@ gcloud compute instances list \
 
 # Delete forwarding rules
 gcloud compute forwarding-rules list \
-  --filter="name~butler-gcp-test" \
+  --filter="name~CLUSTER_NAME" \
   --format="value(name,region)" \
   | while read name region; do
     gcloud compute forwarding-rules delete "$name" --region="$region" --quiet
@@ -318,7 +318,7 @@ gcloud compute forwarding-rules list \
 
 # Delete target pools
 gcloud compute target-pools list \
-  --filter="name~butler-gcp-test" \
+  --filter="name~CLUSTER_NAME" \
   --format="value(name,region)" \
   | while read name region; do
     gcloud compute target-pools delete "$name" --region="$region" --quiet
@@ -326,7 +326,7 @@ gcloud compute target-pools list \
 
 # Delete CCM-managed firewall rules
 gcloud compute firewall-rules list \
-  --filter="name~butler-gcp-test" \
+  --filter="name~CLUSTER_NAME" \
   --format="value(name)" \
   | while read name; do
     gcloud compute firewall-rules delete "$name" --quiet
@@ -365,7 +365,7 @@ Verify all three rules exist and include Cilium ports (TCP 4240, UDP 8472).
 **Symptom**: LoadBalancerRequest stays in `Creating`.
 
 ```bash
-gcloud compute target-pools get-health butler-gcp-test-tp --region=us-central1
+gcloud compute target-pools get-health CLUSTER_NAME-tp --region=us-central1
 ```
 
 Common causes:

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -257,29 +257,40 @@ butleradm bootstrap gcp --config ~/.butler/bootstrap-gcp.yaml
 ## Validation
 
 ```bash
-export KUBECONFIG=~/.butler/butler-mgmt-kubeconfig
+export KUBECONFIG=~/.butler/butler-gcp-test-kubeconfig
 
 # All nodes Ready with providerID set
 kubectl get nodes -o wide
 kubectl get nodes -o jsonpath='{.items[*].spec.providerID}'
 # Expected format: gce://<project>/<zone>/<instance-name>
 
-# GCP CCM DaemonSet running (embedded manifest, not Helm)
+# GCP CCM DaemonSet running (embedded manifest)
 kubectl get ds -n kube-system | grep cloud
 
-# Cilium healthy
+# Cilium running
 kubectl get pods -n kube-system -l app.kubernetes.io/name=cilium
 
-# Longhorn healthy
+# Longhorn running
 kubectl get pods -n longhorn-system
 
 # Butler Console exposed via GCP load balancer
 kubectl get svc butler-console-frontend -n butler-system
-# Should show type: LoadBalancer with an external IP
 
-# Console accessible
+# Console accessible (use the EXTERNAL-IP from above)
 curl http://<LB-IP>
 ```
+
+### What You Have Now
+
+A Butler management cluster running on GCP with:
+- Talos Linux GCE instances with Cilium CNI
+- GCP TCP load balancer fronting the Kubernetes API (HA topology)
+- GCP CCM handling LoadBalancer services
+- Longhorn distributed storage
+- Steward for hosted tenant control planes
+- Butler controller, CRDs, and web console exposed via GCP LB
+
+To create your first tenant cluster, go to [Create Your First Tenant Cluster](../getting-started/#create-your-first-tenant-cluster).
 
 ---
 

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -1,8 +1,8 @@
 # GCP Provider Guide
 
-> **Status: Beta.** GCP bootstrap has been E2E validated for both single-node and HA topologies.
+> **Status: Stable.** E2E validated for single-node and HA topologies.
 
-This guide covers bootstrapping a Butler management cluster on Google Cloud Platform.
+Bootstrap a Butler management cluster on Google Cloud Platform.
 
 ## Table of Contents
 
@@ -161,11 +161,13 @@ Create a config file at `~/.butler/bootstrap-gcp.yaml`:
 
 ### Single-Node
 
+This config was used for E2E validation. Replace `projectID`, `imageProject`, and `serviceAccountKeyPath` with your values.
+
 ```yaml
 provider: gcp
 
 cluster:
-  name: butler-mgmt
+  name: butler-gcp-test
   topology: single-node
   controlPlane:
     replicas: 1
@@ -176,7 +178,6 @@ cluster:
 network:
   podCIDR: 10.244.0.0/16
   serviceCIDR: 10.96.0.0/12
-  # No vip or loadBalancerPool for cloud providers
 
 talos:
   version: v1.12.5
@@ -189,15 +190,14 @@ addons:
 
 providerConfig:
   gcp:
-    serviceAccountKeyPath: ~/.butler/gcp-sa-key.json   # Path to SA key JSON
-    projectID: your-project-id                          # GCP project ID
-    region: us-central1                                 # GCP region
-    zone: us-central1-a                                 # GCP zone (default: {region}-a)
-    network: default                                    # VPC network name
-    subnetwork: default                                 # Subnet name
-    imageProject: your-project-id                       # Project containing the Talos image
-    image: talos-v1-12-5-iscsi                          # GCE image name
-    # machineType: n2-standard-4                        # Optional: override VM type
+    serviceAccountKeyPath: ~/.butler/gcp-sa-key.json
+    projectID: your-gcp-project-id
+    region: us-central1
+    zone: us-central1-a
+    network: default
+    subnetwork: default
+    imageProject: your-gcp-project-id
+    image: talos-v1-12-5-iscsi
 ```
 
 ### HA
@@ -206,7 +206,7 @@ providerConfig:
 provider: gcp
 
 cluster:
-  name: butler-mgmt
+  name: butler-gcp-ha
   topology: ha
   controlPlane:
     replicas: 3
@@ -235,12 +235,12 @@ addons:
 providerConfig:
   gcp:
     serviceAccountKeyPath: ~/.butler/gcp-sa-key.json
-    projectID: your-project-id
+    projectID: your-gcp-project-id
     region: us-central1
     zone: us-central1-a
     network: default
     subnetwork: default
-    imageProject: your-project-id
+    imageProject: your-gcp-project-id
     image: talos-v1-12-5-iscsi
 ```
 

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -310,7 +310,7 @@ gcloud compute instances list \
 
 # Delete forwarding rules
 gcloud compute forwarding-rules list \
-  --filter="name~butler-mgmt" \
+  --filter="name~butler-gcp-test" \
   --format="value(name,region)" \
   | while read name region; do
     gcloud compute forwarding-rules delete "$name" --region="$region" --quiet
@@ -318,7 +318,7 @@ gcloud compute forwarding-rules list \
 
 # Delete target pools
 gcloud compute target-pools list \
-  --filter="name~butler-mgmt" \
+  --filter="name~butler-gcp-test" \
   --format="value(name,region)" \
   | while read name region; do
     gcloud compute target-pools delete "$name" --region="$region" --quiet
@@ -326,7 +326,7 @@ gcloud compute target-pools list \
 
 # Delete CCM-managed firewall rules
 gcloud compute firewall-rules list \
-  --filter="name~butler-mgmt" \
+  --filter="name~butler-gcp-test" \
   --format="value(name)" \
   | while read name; do
     gcloud compute firewall-rules delete "$name" --quiet
@@ -365,7 +365,7 @@ Verify all three rules exist and include Cilium ports (TCP 4240, UDP 8472).
 **Symptom**: LoadBalancerRequest stays in `Creating`.
 
 ```bash
-gcloud compute target-pools get-health butler-mgmt-tp --region=us-central1
+gcloud compute target-pools get-health butler-gcp-test-tp --region=us-central1
 ```
 
 Common causes:

--- a/docs/providers/harvester.md
+++ b/docs/providers/harvester.md
@@ -1,6 +1,8 @@
 # Harvester Provider Guide
 
-This guide covers bootstrapping a Butler management cluster on [Harvester HCI](https://harvesterhci.io/) and running tenant clusters on Harvester infrastructure.
+> **Status: Stable.** E2E validated for single-node and HA topologies.
+
+Bootstrap a Butler management cluster on [Harvester HCI](https://harvesterhci.io/).
 
 ## Table of Contents
 
@@ -85,8 +87,8 @@ Reserve the following IPs on your VLAN. These must not overlap with DHCP ranges,
 
 | Purpose | Example | Notes |
 |---------|---------|-------|
-| Control plane VIP | 10.40.0.200 | Single IP, used by kube-vip for API HA |
-| MetalLB pool | 10.40.0.210-10.40.0.220 | Range for LoadBalancer services (Traefik, tenant endpoints) |
+| Control plane VIP | 10.40.0.230 | Single IP, used by kube-vip for API HA |
+| MetalLB pool | 10.40.0.240-10.40.0.250 | Range for LoadBalancer services (Traefik, tenant endpoints) |
 
 ---
 
@@ -134,83 +136,31 @@ kubectl --kubeconfig ~/.butler/harvester-kubeconfig get nodes
 
 Create a config file at `~/.butler/bootstrap-harvester.yaml`:
 
-### Single-Node (Development)
+### Single-Node
+
+This config was used for E2E validation. Replace VIP, loadBalancerPool, networkName, and imageName with values from your Harvester environment.
 
 ```yaml
 provider: harvester
 
 cluster:
-  name: butler-mgmt
-  topology: single-node       # Single CP node that also runs workloads
+  name: butler-hvstr-test
+  topology: single-node
   controlPlane:
     replicas: 1
-    cpu: 4                    # vCPUs per node
-    memoryMB: 8192            # Memory in MB (8 GB)
-    diskGB: 50                # Boot disk size in GB
-    extraDisks:
-      - sizeGB: 50            # Additional disk for Longhorn storage
-
-network:
-  podCIDR: 10.244.0.0/16     # Pod network CIDR (default)
-  serviceCIDR: 10.96.0.0/12  # Service network CIDR (default)
-  vip: 10.40.0.200           # Control plane VIP address
-  loadBalancerPool:           # MetalLB IP range for LoadBalancer services
-    start: 10.40.0.210
-    end: 10.40.0.220
-
-talos:
-  version: v1.12.1
-  schematic: dc7b152cb3ea99b821fcb7340ce7168313ce393d663740b791c36f6e95fc8586
-
-addons:
-  cni:
-    type: cilium              # CNI with kube-proxy replacement
-  storage:
-    type: longhorn            # Distributed persistent storage
-  loadBalancer:
-    type: metallb             # L2 LoadBalancer for on-prem
-  console:
-    enabled: true
-    ingress:
-      enabled: true
-      className: traefik
-
-providerConfig:
-  harvester:
-    kubeconfigPath: ~/.butler/harvester-kubeconfig  # Path to Harvester kubeconfig
-    namespace: default                                # Harvester namespace for VMs
-    networkName: default/workloads                    # VLAN network (namespace/name)
-    imageName: default/talos-v1-12-1                  # Talos image (namespace/name)
-```
-
-### HA (Production)
-
-```yaml
-provider: harvester
-
-cluster:
-  name: butler-mgmt
-  topology: ha
-  controlPlane:
-    replicas: 3               # 3 control plane nodes for HA
-    cpu: 4
-    memoryMB: 8192
-    diskGB: 50
-  workers:
-    replicas: 2               # Separate worker nodes
     cpu: 4
     memoryMB: 8192
     diskGB: 50
     extraDisks:
-      - sizeGB: 50            # Longhorn storage disk on workers
+      - sizeGB: 50
 
 network:
   podCIDR: 10.244.0.0/16
   serviceCIDR: 10.96.0.0/12
-  vip: 10.40.0.200
+  vip: 10.40.0.230
   loadBalancerPool:
-    start: 10.40.0.210
-    end: 10.40.0.220
+    start: 10.40.0.240
+    end: 10.40.0.250
 
 talos:
   version: v1.12.1
@@ -233,8 +183,62 @@ providerConfig:
   harvester:
     kubeconfigPath: ~/.butler/harvester-kubeconfig
     namespace: default
-    networkName: default/workloads
-    imageName: default/talos-v1-12-1
+    networkName: default/vlan40-workloads
+    imageName: default/image-5rs6d
+```
+
+### HA
+
+```yaml
+provider: harvester
+
+cluster:
+  name: butler-hvstr-ha
+  topology: ha
+  controlPlane:
+    replicas: 3
+    cpu: 4
+    memoryMB: 8192
+    diskGB: 50
+  workers:
+    replicas: 2
+    cpu: 4
+    memoryMB: 8192
+    diskGB: 50
+    extraDisks:
+      - sizeGB: 50
+
+network:
+  podCIDR: 10.244.0.0/16
+  serviceCIDR: 10.96.0.0/12
+  vip: 10.40.0.231
+  loadBalancerPool:
+    start: 10.40.0.240
+    end: 10.40.0.250
+
+talos:
+  version: v1.12.1
+  schematic: dc7b152cb3ea99b821fcb7340ce7168313ce393d663740b791c36f6e95fc8586
+
+addons:
+  cni:
+    type: cilium
+  storage:
+    type: longhorn
+  loadBalancer:
+    type: metallb
+  console:
+    enabled: true
+    ingress:
+      enabled: true
+      className: traefik
+
+providerConfig:
+  harvester:
+    kubeconfigPath: ~/.butler/harvester-kubeconfig
+    namespace: default
+    networkName: default/vlan40-workloads
+    imageName: default/image-5rs6d
 ```
 
 ---
@@ -245,45 +249,41 @@ providerConfig:
 butleradm bootstrap harvester --config ~/.butler/bootstrap-harvester.yaml
 ```
 
-For development with local controller builds:
+For development:
 
 ```bash
 butleradm bootstrap harvester \
   --config ~/.butler/bootstrap-harvester.yaml \
-  --local \
-  --no-tui \
-  --skip-cleanup
+  --local --no-tui --skip-cleanup
 ```
 
 ---
 
 ## Validation
 
-After bootstrap completes, verify the management cluster:
-
 ```bash
-export KUBECONFIG=~/.butler/butler-mgmt-kubeconfig
+export KUBECONFIG=~/.butler/butler-hvstr-test-kubeconfig
 
-# All nodes should be Ready
+# All nodes Ready
 kubectl get nodes
 
-# Cilium CNI running
+# Cilium running
 kubectl get pods -n kube-system -l app.kubernetes.io/name=cilium
 
-# Longhorn storage healthy
+# Longhorn running
 kubectl get pods -n longhorn-system
 
 # cert-manager running
 kubectl get pods -n cert-manager
 
-# Steward (hosted control planes) running
+# Steward running
 kubectl get pods -n steward-system
 
 # Butler CRDs installed
 kubectl get crd | grep butler
 
 # kube-vip responding on VIP
-ping 10.40.0.200
+ping 10.40.0.230
 
 # MetalLB pool active, Traefik has a LoadBalancer IP
 kubectl get svc -n traefik-system
@@ -305,14 +305,12 @@ kubectl get secret butler-console-admin -n butler-system \
 
 ## Cleanup
 
-To tear down a bootstrapped cluster:
-
 ```bash
-# Delete the KIND bootstrap cluster (if --skip-cleanup was used)
+# Delete KIND bootstrap cluster (if --skip-cleanup was used)
 kind delete cluster --name butler-bootstrap
 
-# Delete Harvester VMs via the Harvester Dashboard or API
-# Navigate to Virtual Machines, select the VMs named <cluster>-cp-* and <cluster>-w-*, delete them
+# Delete Harvester VMs via the Harvester Dashboard:
+# Virtual Machines > select butler-hvstr-test-cp-* and butler-hvstr-test-w-* > Actions > Delete
 ```
 
 ---

--- a/docs/providers/harvester.md
+++ b/docs/providers/harvester.md
@@ -1,37 +1,43 @@
 # Harvester Provider Guide
 
-This guide covers setting up Butler with [Harvester HCI](https://harvesterhci.io/) as the infrastructure provider.
+This guide covers bootstrapping a Butler management cluster on [Harvester HCI](https://harvesterhci.io/) and running tenant clusters on Harvester infrastructure.
 
 ## Table of Contents
 
 - [Overview](#overview)
 - [Prerequisites](#prerequisites)
 - [Harvester Setup](#harvester-setup)
-- [Butler Configuration](#butler-configuration)
-- [Network Configuration](#network-configuration)
+- [Bootstrap Configuration](#bootstrap-configuration)
+- [Run Bootstrap](#run-bootstrap)
+- [Validation](#validation)
+- [Cleanup](#cleanup)
+- [Tenant Clusters on Harvester](#tenant-clusters-on-harvester)
 - [Troubleshooting](#troubleshooting)
 
 ---
 
 ## Overview
 
-Butler uses the [CAPI KubeVirt provider](https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt) (capk) to provision VMs on Harvester, which runs KubeVirt under the hood.
+Butler uses a thin provider controller (`butler-provider-harvester`) during bootstrap to provision VMs on Harvester via its Kubernetes API (Harvester runs KubeVirt under the hood). After the management cluster is running, the CAPI KubeVirt provider (CAPK) manages tenant cluster worker VM lifecycle.
 
 ```mermaid
 flowchart LR
-    Butler["Butler Controller"] --> CAPI["Cluster API"]
-    CAPI --> CAPK["KubeVirt Provider"]
-    CAPK --> Harvester["Harvester HCI"]
-    Harvester --> VMs["Virtual Machines"]
+    CLI["butleradm"] --> KIND["KIND Cluster"]
+    KIND --> Bootstrap["butler-bootstrap"]
+    KIND --> Provider["butler-provider-harvester"]
+    Bootstrap --> MR["MachineRequest CRs"]
+    Provider --> Harvester["Harvester HCI"]
+    Harvester --> VMs["Talos Linux VMs"]
 ```
 
 ### Key Components
 
 | Component | Purpose |
 |-----------|---------|
-| butler-provider-harvester | Translates MachineRequests to Harvester VMs |
-| CAPI KubeVirt Provider | Creates KubevirtMachine resources |
-| Harvester | Runs KubeVirt and manages VM lifecycle |
+| butler-provider-harvester | Provisions Harvester VMs from MachineRequest CRs during bootstrap |
+| CAPI KubeVirt Provider (CAPK) | Manages tenant cluster worker VMs after the management cluster is running |
+| kube-vip | Floating VIP for control plane HA |
+| MetalLB | LoadBalancer service implementation for on-prem |
 
 ---
 
@@ -40,17 +46,47 @@ flowchart LR
 ### Harvester Cluster
 
 - Harvester version 1.3.0 or later
-- Admin access to Harvester dashboard
-- Network connectivity from Butler management cluster to Harvester API
+- Admin access to the Harvester dashboard or API
+- Network connectivity from the bootstrap machine (your laptop/workstation) to the Harvester API
 
-### Required Resources
+### VM Image
 
-| Resource | Purpose |
-|----------|---------|
-| VM Network | Network for cluster nodes (VLAN-backed recommended) |
-| VM Image | OS image (Talos Linux for management, Rocky Linux for workers) |
-| SSH Key | For node access (Rocky Linux workers) |
-| Kubeconfig | Harvester API access |
+Upload a Talos Linux raw image to Harvester. The image must include the `iscsi-tools` and `qemu-guest-agent` extensions for Longhorn storage and IP reporting.
+
+Download from the Talos Image Factory:
+
+```
+https://factory.talos.dev/image/dc7b152cb3ea99b821fcb7340ce7168313ce393d663740b791c36f6e95fc8586/v1.12.1/metal-amd64.raw.xz
+```
+
+- **Schematic ID:** `dc7b152cb3ea99b821fcb7340ce7168313ce393d663740b791c36f6e95fc8586`
+- **Extensions included:** iscsi-tools, qemu-guest-agent
+
+Upload via Harvester Dashboard (Images > Create) or the Harvester API. Note the `namespace/name` after upload (e.g., `default/image-5rs6d`).
+
+### VM Network
+
+A VLAN-backed network configured in Harvester. The network must:
+- Provide DHCP or have static IP assignment
+- Allow outbound internet access (Talos pulls images, Helm fetches charts)
+- Support L2 ARP for kube-vip and MetalLB
+
+Note the `namespace/name` format (e.g., `default/vlan40-workloads`).
+
+### Harvester Kubeconfig
+
+Download from Harvester Dashboard > Support > Download Kubeconfig. Save to `~/.butler/harvester-kubeconfig`.
+
+Update the `server` URL in the kubeconfig to the external Harvester API address if needed.
+
+### IP Planning
+
+Reserve the following IPs on your VLAN. These must not overlap with DHCP ranges, existing VIPs, or other clusters:
+
+| Purpose | Example | Notes |
+|---------|---------|-------|
+| Control plane VIP | 10.40.0.200 | Single IP, used by kube-vip for API HA |
+| MetalLB pool | 10.40.0.210-10.40.0.220 | Range for LoadBalancer services (Traefik, tenant endpoints) |
 
 ---
 
@@ -58,91 +94,234 @@ flowchart LR
 
 ### 1. Create VM Network
 
-In Harvester Dashboard -> Networks -> Create:
+In Harvester Dashboard > Networks > Create:
 
-```yaml
-# Example VLAN network
-Name: workloads
-Namespace: default
-VLAN ID: 40
-Cluster Network: mgmt
-```
+| Field | Value |
+|-------|-------|
+| Name | workloads |
+| Namespace | default |
+| VLAN ID | 40 |
+| Cluster Network | mgmt |
 
-**Result:** `default/workloads` network name
+**Result:** `default/workloads` network name.
 
-### 2. Upload VM Images
+### 2. Upload Talos Image
 
-#### Talos Linux (Management Cluster)
+In Harvester Dashboard > Images > Create:
 
-Download the KubeVirt image from [Talos releases](https://github.com/siderolabs/talos/releases):
+| Field | Value |
+|-------|-------|
+| Name | talos-v1-12-1 |
+| Namespace | default |
+| Source | URL or File upload |
+| URL | `https://factory.talos.dev/image/dc7b152.../v1.12.1/metal-amd64.raw.xz` |
 
-```bash
-# Download Talos KubeVirt image
-curl -LO https://github.com/siderolabs/talos/releases/download/v1.9.0/nocloud-amd64.raw.xz
-xz -d nocloud-amd64.raw.xz
-```
+**Result:** `default/talos-v1-12-1` (or whatever the resulting `namespace/name` is).
 
-In Harvester Dashboard -> Images -> Create:
-- Name: `talos-1.9`
-- URL or upload the raw file
-- Namespace: `default`
-
-**Result:** `default/talos-1.9` image name
-
-#### Rocky Linux (Tenant Workers)
-
-Download Rocky Linux cloud image:
+### 3. Export Kubeconfig
 
 ```bash
-curl -LO https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2
+# Save to standard Butler location
+cp /path/to/harvester-kubeconfig ~/.butler/harvester-kubeconfig
+
+# Verify access
+kubectl --kubeconfig ~/.butler/harvester-kubeconfig get nodes
 ```
-
-Upload to Harvester:
-- Name: `rocky-9-cloud`
-- Namespace: `default`
-
-**Result:** `default/rocky-9-cloud` image name
-
-### 3. Create SSH Key
-
-In Harvester Dashboard -> SSH Keys -> Create:
-
-```bash
-# Generate key pair (if needed)
-ssh-keygen -t ed25519 -f ~/.ssh/butler-ssh -N ""
-```
-
-Upload public key:
-- Name: `butler-ssh`
-- Namespace: `default`
-
-**Result:** `default/butler-ssh` SSH key name
-
-### 4. Export Kubeconfig
-
-In Harvester Dashboard -> Support -> Download Kubeconfig
-
-Or via CLI:
-```bash
-# From Harvester node
-cat /etc/rancher/rke2/rke2.yaml
-```
-
-Save as `harvester-kubeconfig.yaml` and update the server URL to the external address.
 
 ---
 
-## Butler Configuration
+## Bootstrap Configuration
 
-### 1. Create ProviderConfig Secret
+Create a config file at `~/.butler/bootstrap-harvester.yaml`:
 
-```bash
-kubectl create secret generic harvester-kubeconfig \
-  --from-file=kubeconfig=harvester-kubeconfig.yaml \
-  -n butler-system
+### Single-Node (Development)
+
+```yaml
+provider: harvester
+
+cluster:
+  name: butler-mgmt
+  topology: single-node       # Single CP node that also runs workloads
+  controlPlane:
+    replicas: 1
+    cpu: 4                    # vCPUs per node
+    memoryMB: 8192            # Memory in MB (8 GB)
+    diskGB: 50                # Boot disk size in GB
+    extraDisks:
+      - sizeGB: 50            # Additional disk for Longhorn storage
+
+network:
+  podCIDR: 10.244.0.0/16     # Pod network CIDR (default)
+  serviceCIDR: 10.96.0.0/12  # Service network CIDR (default)
+  vip: 10.40.0.200           # Control plane VIP address
+  loadBalancerPool:           # MetalLB IP range for LoadBalancer services
+    start: 10.40.0.210
+    end: 10.40.0.220
+
+talos:
+  version: v1.12.1
+  schematic: dc7b152cb3ea99b821fcb7340ce7168313ce393d663740b791c36f6e95fc8586
+
+addons:
+  cni:
+    type: cilium              # CNI with kube-proxy replacement
+  storage:
+    type: longhorn            # Distributed persistent storage
+  loadBalancer:
+    type: metallb             # L2 LoadBalancer for on-prem
+  console:
+    enabled: true
+    ingress:
+      enabled: true
+      className: traefik
+
+providerConfig:
+  harvester:
+    kubeconfigPath: ~/.butler/harvester-kubeconfig  # Path to Harvester kubeconfig
+    namespace: default                                # Harvester namespace for VMs
+    networkName: default/workloads                    # VLAN network (namespace/name)
+    imageName: default/talos-v1-12-1                  # Talos image (namespace/name)
 ```
 
-### 2. Create ProviderConfig Resource
+### HA (Production)
+
+```yaml
+provider: harvester
+
+cluster:
+  name: butler-mgmt
+  topology: ha
+  controlPlane:
+    replicas: 3               # 3 control plane nodes for HA
+    cpu: 4
+    memoryMB: 8192
+    diskGB: 50
+  workers:
+    replicas: 2               # Separate worker nodes
+    cpu: 4
+    memoryMB: 8192
+    diskGB: 50
+    extraDisks:
+      - sizeGB: 50            # Longhorn storage disk on workers
+
+network:
+  podCIDR: 10.244.0.0/16
+  serviceCIDR: 10.96.0.0/12
+  vip: 10.40.0.200
+  loadBalancerPool:
+    start: 10.40.0.210
+    end: 10.40.0.220
+
+talos:
+  version: v1.12.1
+  schematic: dc7b152cb3ea99b821fcb7340ce7168313ce393d663740b791c36f6e95fc8586
+
+addons:
+  cni:
+    type: cilium
+  storage:
+    type: longhorn
+  loadBalancer:
+    type: metallb
+  console:
+    enabled: true
+    ingress:
+      enabled: true
+      className: traefik
+
+providerConfig:
+  harvester:
+    kubeconfigPath: ~/.butler/harvester-kubeconfig
+    namespace: default
+    networkName: default/workloads
+    imageName: default/talos-v1-12-1
+```
+
+---
+
+## Run Bootstrap
+
+```bash
+butleradm bootstrap harvester --config ~/.butler/bootstrap-harvester.yaml
+```
+
+For development with local controller builds:
+
+```bash
+butleradm bootstrap harvester \
+  --config ~/.butler/bootstrap-harvester.yaml \
+  --local \
+  --no-tui \
+  --skip-cleanup
+```
+
+---
+
+## Validation
+
+After bootstrap completes, verify the management cluster:
+
+```bash
+export KUBECONFIG=~/.butler/butler-mgmt-kubeconfig
+
+# All nodes should be Ready
+kubectl get nodes
+
+# Cilium CNI running
+kubectl get pods -n kube-system -l app.kubernetes.io/name=cilium
+
+# Longhorn storage healthy
+kubectl get pods -n longhorn-system
+
+# cert-manager running
+kubectl get pods -n cert-manager
+
+# Steward (hosted control planes) running
+kubectl get pods -n steward-system
+
+# Butler CRDs installed
+kubectl get crd | grep butler
+
+# kube-vip responding on VIP
+ping 10.40.0.200
+
+# MetalLB pool active, Traefik has a LoadBalancer IP
+kubectl get svc -n traefik-system
+
+# Console accessible
+kubectl get svc butler-console-frontend -n butler-system
+```
+
+### Console Credentials
+
+```bash
+# Get the admin password
+kubectl get secret butler-console-admin -n butler-system \
+  -o jsonpath='{.data.admin-password}' | base64 -d && echo
+# Username: admin
+```
+
+---
+
+## Cleanup
+
+To tear down a bootstrapped cluster:
+
+```bash
+# Delete the KIND bootstrap cluster (if --skip-cleanup was used)
+kind delete cluster --name butler-bootstrap
+
+# Delete Harvester VMs via the Harvester Dashboard or API
+# Navigate to Virtual Machines, select the VMs named <cluster>-cp-* and <cluster>-w-*, delete them
+```
+
+---
+
+## Tenant Clusters on Harvester
+
+After bootstrap, configure Harvester as a provider for tenant clusters:
+
+### Create ProviderConfig
 
 ```yaml
 apiVersion: butler.butlerlabs.dev/v1alpha1
@@ -151,169 +330,91 @@ metadata:
   name: harvester-prod
   namespace: butler-system
 spec:
-  type: harvester
+  provider: harvester
+  credentialsRef:
+    name: harvester-kubeconfig
+    namespace: butler-system
+  network:
+    mode: ipam
   harvester:
-    credentialsRef:
-      name: harvester-kubeconfig
-      key: kubeconfig
     namespace: default
     networkName: default/workloads
-    imageName: default/talos-1.9
+    imageName: default/talos-v1-12-1
     storageClassName: harvester-longhorn
 ```
 
-### 3. Set as Default Provider
+### Create Credentials Secret
 
-Update ButlerConfig:
-
-```yaml
-apiVersion: butler.butlerlabs.dev/v1alpha1
-kind: ButlerConfig
-metadata:
-  name: butler
-spec:
-  defaultProviderConfigRef:
-    name: harvester-prod
-```
-
----
-
-## Network Configuration
-
-### Recommended VLAN Layout
-
-| VLAN | Name | Subnet | Purpose |
-|------|------|--------|---------|
-| 20 | Management | 10.20.0.0/16 | Harvester management, infrastructure |
-| 30 | Storage | 10.30.0.0/16 | Storage traffic (iSCSI, NFS) |
-| 40 | Workloads | 10.40.0.0/16 | Kubernetes clusters |
-| 50 | External | 10.50.0.0/16 | External-facing services |
-
-### MetalLB Integration
-
-For tenant clusters to get LoadBalancer IPs, allocate pools from the workload VLAN:
-
-```yaml
-# In TenantCluster spec
-spec:
-  addons:
-    loadBalancer:
-      provider: metallb
-      addressPool: "10.40.1.0-10.40.1.50"
-```
-
-### Control Plane Endpoint
-
-For management cluster:
-- Reserve a VIP (e.g., `10.40.0.200`) 
-- kube-vip provides HA for control plane
-- MetalLB provides LoadBalancer for services
-
-For tenant clusters:
-- Steward creates LoadBalancer service per cluster
-- MetalLB assigns IPs from management cluster pool
-
----
-
-## Resource Specifications
-
-### Management Cluster Recommendations
-
-| Role | CPU | Memory | Disk | Count |
-|------|-----|--------|------|-------|
-| Control Plane | 4 | 16Gi | 100Gi | 3 (HA) or 1 (single-node) |
-| Worker | 8 | 32Gi | 200Gi | 0-3 |
-
-### Tenant Cluster Defaults
-
-| Role | CPU | Memory | Disk |
-|------|-----|--------|------|
-| Worker | 4 | 8Gi | 40Gi |
-
-Override in TenantCluster spec:
-
-```yaml
-spec:
-  workers:
-    replicas: 3
-    machineTemplate:
-      cpu: 8
-      memory: 16Gi
-      diskSize: 100Gi
+```bash
+kubectl create secret generic harvester-kubeconfig \
+  --from-file=kubeconfig=~/.butler/harvester-kubeconfig \
+  -n butler-system
 ```
 
 ---
 
 ## Troubleshooting
 
-### VM Not Starting
+### VMs Not Provisioning
 
-**Check Harvester logs:**
+**Symptom**: MachineRequest stuck in `Pending` or `Creating`.
+
+**Check:**
 ```bash
-kubectl logs -n harvester-system deploy/harvester-harvester -f
+# From KIND context (if --skip-cleanup was used)
+kubectl --context kind-butler-bootstrap logs -n butler-system deploy/butler-provider-harvester
+kubectl --context kind-butler-bootstrap get machinerequest -n butler-system
 ```
 
-**Check VM status:**
-```bash
-kubectl get virtualmachine -A
-kubectl describe virtualmachine <name> -n <namespace>
-```
+**Common causes:**
+- Harvester kubeconfig server URL is wrong (internal vs external address)
+- Image name doesn't match (wrong `namespace/name` format)
+- Network name doesn't match
+- Insufficient resources on Harvester cluster
 
-### Network Connectivity Issues
+### VIP Not Responding
 
-**Verify VLAN configuration:**
-- Ensure VLAN is created in Harvester
-- Check physical switch VLAN trunking
-- Verify cluster network attachment
+**Symptom**: Cannot reach the Kubernetes API on the VIP address after bootstrap.
 
-**Test from within VM:**
-```bash
-# SSH to Rocky Linux worker
-ssh -i ~/.ssh/butler-ssh rocky@<vm-ip>
-ping <gateway-ip>
-ping <api-server-ip>
-```
+**Check:**
+- Verify the VIP is not already in use (`arping -D <VIP>`)
+- Confirm kube-vip is running: `kubectl get pods -n kube-system -l app.kubernetes.io/name=kube-vip`
+- Verify the VIP is on the same VLAN/subnet as the VM network
+- Check that the network supports gratuitous ARP (some virtual switches filter it)
 
-### Image Issues
+### MetalLB Pool Conflict
 
-**Verify image exists:**
-```bash
-kubectl get virtualmachineimage -n default
-```
+**Symptom**: Traefik service stuck on `<pending>`, no external IP assigned.
 
-**Check image import status:**
-```bash
-kubectl describe virtualmachineimage <name> -n default
-```
+**Check:**
+- Verify the pool range doesn't overlap with the VIP
+- Verify the pool IPs are not already in use by another cluster
+- Check MetalLB speaker pods: `kubectl get pods -n metallb-system`
+- Confirm the pool range is on the same L2 segment as the nodes
+
+### Image Format Wrong
+
+**Symptom**: VMs start but Talos never boots.
+
+The Harvester image must be the `metal-amd64.raw.xz` format from the Talos Image Factory, not the ISO or `nocloud` variant. Verify the schematic ID includes the `qemu-guest-agent` extension (required for Harvester to report VM IPs).
 
 ### Kubeconfig Issues
 
-**Test Harvester API access:**
 ```bash
-kubectl --kubeconfig=harvester-kubeconfig.yaml get nodes
+# Verify Harvester API access
+kubectl --kubeconfig ~/.butler/harvester-kubeconfig get nodes
 ```
 
-**Common issues:**
-- Wrong server URL (use external address)
-- Certificate validation (may need `insecure-skip-tls-verify: true` initially)
-- Firewall blocking port 6443
-
-### MachineRequest Stuck
-
-**Check provider controller logs:**
-```bash
-kubectl logs -n butler-system deploy/butler-provider-harvester -f
-```
-
-**Check MachineRequest status:**
-```bash
-kubectl describe machinerequest <name> -n <namespace>
-```
+Common issues:
+- Server URL points to internal cluster IP (use the external address)
+- Certificate verification fails (try `insecure-skip-tls-verify: true` for testing)
+- Firewall blocking port 6443 between your machine and Harvester
 
 ---
 
 ## See Also
 
-- [Getting Started](../getting-started/) - Bootstrap guide
-- [Architecture](../architecture/) - System design
-- [Nutanix Provider](nutanix.md) - Alternative provider
+- [Getting Started](../getting-started/) - Quick start guide
+- [Bootstrap Flow](../architecture/bootstrap-flow.md) - End-to-end bootstrap sequence
+- [Bootstrap Config Reference](../reference/bootstrap-config.md) - Every config field documented
+- [Nutanix Provider](nutanix.md) - Alternative on-prem provider

--- a/docs/providers/harvester.md
+++ b/docs/providers/harvester.md
@@ -100,12 +100,12 @@ In Harvester Dashboard > Networks > Create:
 
 | Field | Value |
 |-------|-------|
-| Name | workloads |
+| Name | vlan40-workloads |
 | Namespace | default |
 | VLAN ID | 40 |
 | Cluster Network | mgmt |
 
-**Result:** `default/workloads` network name.
+**Result:** `default/vlan40-workloads` network name.
 
 ### 2. Upload Talos Image
 
@@ -295,11 +295,22 @@ kubectl get svc butler-console-frontend -n butler-system
 ### Console Credentials
 
 ```bash
-# Get the admin password
 kubectl get secret butler-console-admin -n butler-system \
   -o jsonpath='{.data.admin-password}' | base64 -d && echo
 # Username: admin
 ```
+
+### What You Have Now
+
+A Butler management cluster running on Harvester with:
+- Talos Linux nodes with Cilium CNI
+- kube-vip providing a floating VIP for the Kubernetes API
+- MetalLB and Traefik handling LoadBalancer and Ingress services
+- Longhorn distributed storage
+- Steward for hosted tenant control planes
+- Butler controller, CRDs, and web console
+
+To create your first tenant cluster, go to [Create Your First Tenant Cluster](../getting-started/#create-your-first-tenant-cluster).
 
 ---
 

--- a/docs/providers/nutanix.md
+++ b/docs/providers/nutanix.md
@@ -1,6 +1,8 @@
 # Nutanix Provider Guide
 
-This guide covers bootstrapping a Butler management cluster on [Nutanix AHV](https://www.nutanix.com/products/ahv) and running tenant clusters on Nutanix infrastructure.
+> **Status: Stable.** E2E validated for single-node and HA topologies.
+
+Bootstrap a Butler management cluster on [Nutanix AHV](https://www.nutanix.com/products/ahv).
 
 ## Table of Contents
 
@@ -259,9 +261,7 @@ For development:
 ```bash
 butleradm bootstrap nutanix \
   --config ~/.butler/bootstrap-nutanix.yaml \
-  --local \
-  --no-tui \
-  --skip-cleanup
+  --local --no-tui --skip-cleanup
 ```
 
 ---

--- a/docs/providers/nutanix.md
+++ b/docs/providers/nutanix.md
@@ -1,38 +1,44 @@
 # Nutanix Provider Guide
 
-This guide covers setting up Butler with [Nutanix AHV](https://www.nutanix.com/products/ahv) as the infrastructure provider.
+This guide covers bootstrapping a Butler management cluster on [Nutanix AHV](https://www.nutanix.com/products/ahv) and running tenant clusters on Nutanix infrastructure.
 
 ## Table of Contents
 
 - [Overview](#overview)
 - [Prerequisites](#prerequisites)
 - [Nutanix Setup](#nutanix-setup)
-- [Butler Configuration](#butler-configuration)
+- [Bootstrap Configuration](#bootstrap-configuration)
+- [Run Bootstrap](#run-bootstrap)
+- [Validation](#validation)
+- [Cleanup](#cleanup)
+- [Tenant Clusters on Nutanix](#tenant-clusters-on-nutanix)
 - [Troubleshooting](#troubleshooting)
 
 ---
 
 ## Overview
 
-Butler uses [CAPX (Cluster API Provider Nutanix)](https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix) to provision VMs on Nutanix AHV via Prism Central.
+Butler uses a thin provider controller (`butler-provider-nutanix`) during bootstrap to provision VMs on Nutanix AHV via the Prism Central API. After the management cluster is running, the CAPI Nutanix Provider (CAPX) manages tenant cluster worker VM lifecycle.
 
 ```mermaid
 flowchart LR
-    Butler["Butler Controller"] --> CAPI["Cluster API"]
-    CAPI --> CAPX["CAPX Provider"]
-    CAPX --> PC["Prism Central"]
+    CLI["butleradm"] --> KIND["KIND Cluster"]
+    KIND --> Bootstrap["butler-bootstrap"]
+    KIND --> Provider["butler-provider-nutanix"]
+    Bootstrap --> MR["MachineRequest CRs"]
+    Provider --> PC["Prism Central"]
     PC --> PE["Prism Element"]
-    PE --> VMs["Virtual Machines"]
+    PE --> VMs["Talos Linux VMs"]
 ```
 
 ### Key Components
 
 | Component | Purpose |
 |-----------|---------|
-| butler-provider-nutanix | Translates MachineRequests to Nutanix VMs |
-| CAPX | Creates NutanixMachine resources |
-| Prism Central | Nutanix management plane |
-| Prism Element | Per-cluster hypervisor management |
+| butler-provider-nutanix | Provisions Nutanix VMs from MachineRequest CRs during bootstrap |
+| CAPI Nutanix Provider (CAPX) | Manages tenant cluster worker VMs after bootstrap |
+| kube-vip | Floating VIP for control plane HA |
+| MetalLB | LoadBalancer service implementation for on-prem |
 
 ---
 
@@ -43,78 +49,256 @@ flowchart LR
 - Nutanix AOS 5.20+ or 6.x
 - Prism Central 2023.x or later
 - Admin credentials for Prism Central
-- Network connectivity from Butler to Prism Central (port 9440)
+- Network connectivity from the bootstrap machine to Prism Central on port 9440
 
-### Required Resources
+### Required Resource IDs
 
-| Resource | Purpose |
-|----------|---------|
-| Subnet | Network for cluster nodes |
-| VM Image | OS image (uploaded to Prism Central) |
-| Cluster | Target Nutanix cluster for VMs |
-| Categories (optional) | For VM organization |
+Before writing the config, collect these UUIDs from Prism Central:
+
+| Resource | Where to Find | Config Field |
+|----------|---------------|-------------|
+| Cluster UUID | Compute & Storage > Clusters > select cluster > URL contains UUID | `clusterUUID` |
+| Subnet UUID | Network & Security > Subnets > select subnet > URL contains UUID | `subnetUUID` |
+| Image UUID | Compute & Storage > Images > select image > URL contains UUID | `imageUUID` |
+| Storage Container UUID (optional) | Storage > Storage Containers | `storageContainerUUID` |
+
+### VM Image
+
+Upload a Talos Linux qcow2 image to Prism Central. The image must include the `iscsi-tools` extension for Longhorn storage.
+
+Download from the Talos Image Factory:
+
+```
+https://factory.talos.dev/image/dc7b152cb3ea99b821fcb7340ce7168313ce393d663740b791c36f6e95fc8586/v1.12.1/nutanix-amd64.qcow2
+```
+
+Upload via Prism Central > Compute & Storage > Images > Add Image.
+
+### Network
+
+The subnet must provide connectivity for:
+- Outbound internet (Talos image pulls, Helm chart downloads)
+- L2 ARP (kube-vip and MetalLB require it)
+- DHCP or static IP assignment
+
+### IP Planning
+
+| Purpose | Example | Notes |
+|---------|---------|-------|
+| Control plane VIP | 10.127.14.29 | Single IP, used by kube-vip for API HA |
+| MetalLB pool | 10.127.14.30-10.127.14.50 | Range for LoadBalancer services |
+
+These must not overlap with DHCP ranges or other cluster allocations.
 
 ---
 
 ## Nutanix Setup
 
-### 1. Upload VM Image
+### 1. Upload Talos Image
 
-#### Via Prism Central UI
+In Prism Central > Compute & Storage > Images > Add Image:
 
-1. Navigate to Compute & Storage -> Images
-2. Click "Add Image"
-3. Select image source:
-   - URL: Direct download link
-   - Upload: Local file
+| Field | Value |
+|-------|-------|
+| Name | talos-v1-12-1 |
+| Image Type | DISK |
+| Source | URL or file upload |
+| URL | `https://factory.talos.dev/.../v1.12.1/nutanix-amd64.qcow2` |
 
-#### Talos Linux Image
-
-```bash
-# Download Talos Nutanix image
-curl -LO https://github.com/siderolabs/talos/releases/download/v1.9.0/nutanix-amd64.qcow2
-```
-
-Upload with name: `talos-1.9`
-
-#### Rocky Linux Image
-
-Download Rocky Linux cloud image:
-```bash
-curl -LO https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2
-```
-
-Upload with name: `rocky-9-cloud`
+Note the image UUID from the URL after creation.
 
 ### 2. Identify Subnet
 
-In Prism Central -> Network & Security -> Subnets
+In Prism Central > Network & Security > Subnets.
 
 Note the subnet name and UUID for your workload network.
 
 ### 3. Identify Cluster
 
-In Prism Central -> Compute & Storage -> Clusters
+In Prism Central > Compute & Storage > Clusters.
 
-Note the cluster name and UUID where VMs will be created.
+Note the cluster UUID where VMs will be created.
 
 ### 4. Create Service Account (Recommended)
 
-For production, create a dedicated service account:
+For production, create a dedicated Prism Central user with appropriate roles:
 
-1. Prism Central -> Administration -> Users
-2. Create local user with appropriate roles
-3. Or configure AD/LDAP integration
-
-Required roles:
-- Cluster Admin (for target clusters)
-- Or custom role with VM create/delete permissions
+1. Prism Central > Administration > Users > Create Local User
+2. Assign Cluster Admin role for the target clusters
 
 ---
 
-## Butler Configuration
+## Bootstrap Configuration
 
-### 1. Create Credentials Secret
+Create a config file at `~/.butler/bootstrap-nutanix.yaml`:
+
+### Single-Node (Development)
+
+```yaml
+provider: nutanix
+
+cluster:
+  name: butler-mgmt
+  topology: single-node
+  controlPlane:
+    replicas: 1
+    cpu: 4                    # vCPUs per node
+    memoryMB: 8192            # Memory in MB (8 GB)
+    diskGB: 50                # Boot disk size in GB
+    extraDisks:
+      - sizeGB: 100           # Additional disk for Longhorn storage
+
+network:
+  podCIDR: 10.244.0.0/16
+  serviceCIDR: 10.96.0.0/12
+  vip: 10.127.14.29           # Control plane VIP
+  loadBalancerPool:            # MetalLB IP range
+    start: 10.127.14.30
+    end: 10.127.14.50
+
+talos:
+  version: v1.12.1
+  schematic: dc7b152cb3ea99b821fcb7340ce7168313ce393d663740b791c36f6e95fc8586
+
+addons:
+  cni:
+    type: cilium
+  storage:
+    type: longhorn
+  loadBalancer:
+    type: metallb
+  console:
+    enabled: true
+    ingress:
+      enabled: true
+      className: traefik
+
+providerConfig:
+  nutanix:
+    endpoint: https://prism-central.example.com   # Prism Central URL
+    port: 9440                                      # API port (default: 9440)
+    insecure: false                                 # Set true for self-signed certs
+    username: butler-admin                          # Prism Central username
+    password: your-password                         # Prism Central password
+    clusterUUID: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"  # Target Nutanix cluster
+    subnetUUID: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"   # VM network subnet
+    imageUUID: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"    # Talos image UUID
+    # storageContainerUUID: "..."                   # Optional: storage container for disks
+    # hostAliases:                                  # Optional: /etc/hosts entries for KIND
+    #   - "10.0.0.1 prism-central.internal"         # Useful for corporate DNS/Zscaler
+```
+
+### HA (Production)
+
+```yaml
+provider: nutanix
+
+cluster:
+  name: butler-mgmt
+  topology: ha
+  controlPlane:
+    replicas: 3
+    cpu: 4
+    memoryMB: 8192
+    diskGB: 50
+  workers:
+    replicas: 2
+    cpu: 8
+    memoryMB: 8192
+    diskGB: 100
+    extraDisks:
+      - sizeGB: 200
+
+network:
+  podCIDR: 10.244.0.0/16
+  serviceCIDR: 10.96.0.0/12
+  vip: 10.127.14.29
+  loadBalancerPool:
+    start: 10.127.14.30
+    end: 10.127.14.50
+
+talos:
+  version: v1.12.1
+  schematic: dc7b152cb3ea99b821fcb7340ce7168313ce393d663740b791c36f6e95fc8586
+
+addons:
+  cni:
+    type: cilium
+  storage:
+    type: longhorn
+  loadBalancer:
+    type: metallb
+  console:
+    enabled: true
+    ingress:
+      enabled: true
+      className: traefik
+
+providerConfig:
+  nutanix:
+    endpoint: https://prism-central.example.com
+    port: 9440
+    insecure: false
+    username: butler-admin
+    password: your-password
+    clusterUUID: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    subnetUUID: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    imageUUID: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+```
+
+---
+
+## Run Bootstrap
+
+```bash
+butleradm bootstrap nutanix --config ~/.butler/bootstrap-nutanix.yaml
+```
+
+For development:
+
+```bash
+butleradm bootstrap nutanix \
+  --config ~/.butler/bootstrap-nutanix.yaml \
+  --local \
+  --no-tui \
+  --skip-cleanup
+```
+
+---
+
+## Validation
+
+```bash
+export KUBECONFIG=~/.butler/butler-mgmt-kubeconfig
+
+kubectl get nodes                                    # All nodes Ready
+kubectl get pods -n kube-system -l app.kubernetes.io/name=cilium
+kubectl get pods -n longhorn-system
+kubectl get pods -n cert-manager
+kubectl get pods -n steward-system
+kubectl get crd | grep butler
+ping 10.127.14.29                                    # VIP responds
+kubectl get svc -n traefik-system                    # LB IP assigned
+```
+
+---
+
+## Cleanup
+
+```bash
+kind delete cluster --name butler-bootstrap
+
+# Delete VMs via Prism Central UI:
+# Compute & Storage > VMs > select butler-mgmt-* VMs > Actions > Delete
+```
+
+---
+
+## Tenant Clusters on Nutanix
+
+After bootstrap, configure Nutanix as a provider for tenant clusters:
+
+### Create Credentials Secret
 
 ```bash
 kubectl create secret generic nutanix-credentials \
@@ -126,7 +310,7 @@ kubectl create secret generic nutanix-credentials \
   -n butler-system
 ```
 
-### 2. Create ProviderConfig Resource
+### Create ProviderConfig
 
 ```yaml
 apiVersion: butler.butlerlabs.dev/v1alpha1
@@ -135,95 +319,23 @@ metadata:
   name: nutanix-prod
   namespace: butler-system
 spec:
-  type: nutanix
+  provider: nutanix
+  credentialsRef:
+    name: nutanix-credentials
+    namespace: butler-system
+  network:
+    mode: ipam
   nutanix:
-    credentialsRef:
-      name: nutanix-credentials
     prismCentral:
       address: prism-central.example.com
       port: 9440
       insecure: false
     cluster:
       name: cluster-01
-      # Or use UUID:
-      # uuid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
     subnet:
       name: workload-subnet
-      # Or use UUID:
-      # uuid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
     image:
-      name: talos-1.9
-```
-
-### 3. Set as Default Provider
-
-Update ButlerConfig:
-
-```yaml
-apiVersion: butler.butlerlabs.dev/v1alpha1
-kind: ButlerConfig
-metadata:
-  name: butler
-spec:
-  defaultProviderConfigRef:
-    name: nutanix-prod
-```
-
----
-
-## Network Configuration
-
-### VIP for Control Plane
-
-Reserve a static IP for the control plane VIP:
-
-```yaml
-# In ClusterBootstrap for management cluster
-spec:
-  cluster:
-    controlPlaneEndpoint: 10.127.14.29
-```
-
-kube-vip uses the `ens3` interface for Nutanix VMs.
-
-### MetalLB Pool
-
-Allocate IPs for LoadBalancer services:
-
-```yaml
-# ButlerConfig or per-cluster
-spec:
-  platform:
-    metalLBPool: "10.127.14.30-10.127.14.50"
-```
-
----
-
-## Resource Specifications
-
-### Management Cluster Recommendations
-
-| Role | vCPUs | Memory | Disk | Count |
-|------|-------|--------|------|-------|
-| Control Plane | 4 | 16GB | 100GB | 3 (HA) |
-| Worker | 8 | 32GB | 200GB | 0-3 |
-
-### Tenant Cluster Defaults
-
-| Role | vCPUs | Memory | Disk |
-|------|-------|--------|------|
-| Worker | 4 | 8GB | 40GB |
-
-Override in TenantCluster spec:
-
-```yaml
-spec:
-  workers:
-    replicas: 3
-    machineTemplate:
-      cpu: 8
-      memory: 16Gi
-      disk: 100Gi
+      name: talos-v1-12-1
 ```
 
 ---
@@ -232,86 +344,61 @@ spec:
 
 ### Authentication Failures
 
-**Verify credentials:**
+**Symptom**: Provider controller logs show 401 or authentication errors.
+
 ```bash
-# Test Prism Central API
-curl -k -u admin:password https://prism-central.example.com:9440/api/nutanix/v3/clusters/list \
+# Test Prism Central API directly
+curl -k -u admin:password \
+  https://prism-central.example.com:9440/api/nutanix/v3/clusters/list \
   -H "Content-Type: application/json" \
   -d '{"length": 10}'
 ```
 
-**Check secret:**
-```bash
-kubectl get secret nutanix-credentials -n butler-system -o yaml
-```
-
-### VM Not Creating
-
-**Check CAPX controller logs:**
-```bash
-kubectl logs -n capx-system deploy/capx-controller-manager -f
-```
-
-**Check NutanixMachine status:**
-```bash
-kubectl get nutanixmachine -A
-kubectl describe nutanixmachine <n> -n <namespace>
-```
-
-### Network Issues
-
-**Verify subnet exists:**
-```bash
-# Via API
-curl -k -u admin:password https://prism-central.example.com:9440/api/nutanix/v3/subnets/list \
-  -H "Content-Type: application/json" \
-  -d '{"length": 100}'
-```
-
-**Check VM network config:**
-- Verify DHCP is configured on subnet
-- Or use static IP assignment in machine config
-
-### Image Issues
-
-**Verify image exists:**
-```bash
-# Via API
-curl -k -u admin:password https://prism-central.example.com:9440/api/nutanix/v3/images/list \
-  -H "Content-Type: application/json" \
-  -d '{"length": 100}'
-```
-
-**Check image type:**
-- Must be DISK image, not ISO
-- qcow2 or raw format
-
 ### Certificate Issues
 
-If using self-signed certificates:
+**Symptom**: TLS handshake errors in provider controller logs.
+
+For self-signed certificates, set `insecure: true` in the config. For production, add the CA certificate to the trust chain.
+
+### DNS Resolution / Zscaler
+
+**Symptom**: KIND container cannot resolve Prism Central hostname.
+
+The KIND bootstrap cluster runs inside a Docker container and may not have access to corporate DNS servers or Zscaler-proxied endpoints. Use the `hostAliases` field to inject `/etc/hosts` entries into the KIND node:
 
 ```yaml
-spec:
+providerConfig:
   nutanix:
-    prismCentral:
-      insecure: true  # For testing only
+    hostAliases:
+      - "10.0.0.1 prism-central.internal.corp.com"
 ```
 
-For production, add CA certificate to trust store.
+### VMs Not Creating
 
----
+**Check:**
+```bash
+kubectl --context kind-butler-bootstrap logs -n butler-system deploy/butler-provider-nutanix
+kubectl --context kind-butler-bootstrap get machinerequest -n butler-system
+```
 
-## CAPX Version Compatibility
+**Common causes:**
+- Wrong cluster UUID, subnet UUID, or image UUID
+- Image type is ISO instead of DISK (must be qcow2 or raw)
+- Insufficient resources on the Nutanix cluster
+- Subnet does not have IP addresses available
+
+### CAPX Version Compatibility
 
 | Butler Version | CAPX Version | Nutanix AOS |
 |----------------|--------------|-------------|
-| 0.1.x | 1.4.x | 5.20+, 6.x |
+| 0.1.x+ | 1.4.x | 5.20+, 6.x |
 
 ---
 
 ## See Also
 
-- [Getting Started](../getting-started/) - Bootstrap guide
-- [Architecture](../architecture/) - System design
-- [Harvester Provider](harvester.md) - Alternative provider
+- [Getting Started](../getting-started/) - Quick start guide
+- [Bootstrap Flow](../architecture/bootstrap-flow.md) - End-to-end bootstrap sequence
+- [Bootstrap Config Reference](../reference/bootstrap-config.md) - Every config field documented
+- [Harvester Provider](harvester.md) - Alternative on-prem provider
 - [CAPX Documentation](https://opendocs.nutanix.com/capx/latest/)

--- a/docs/providers/nutanix.md
+++ b/docs/providers/nutanix.md
@@ -271,15 +271,27 @@ butleradm bootstrap nutanix \
 ```bash
 export KUBECONFIG=~/.butler/butler-mgmt-kubeconfig
 
-kubectl get nodes                                    # All nodes Ready
+kubectl get nodes
 kubectl get pods -n kube-system -l app.kubernetes.io/name=cilium
 kubectl get pods -n longhorn-system
 kubectl get pods -n cert-manager
 kubectl get pods -n steward-system
 kubectl get crd | grep butler
-ping 10.127.14.29                                    # VIP responds
-kubectl get svc -n traefik-system                    # LB IP assigned
+ping 10.127.14.29
+kubectl get svc -n traefik-system
 ```
+
+### What You Have Now
+
+A Butler management cluster running on Nutanix with:
+- Talos Linux VMs with Cilium CNI
+- kube-vip providing a floating VIP for the Kubernetes API
+- MetalLB and Traefik handling LoadBalancer and Ingress services
+- Longhorn distributed storage
+- Steward for hosted tenant control planes
+- Butler controller, CRDs, and web console
+
+To create your first tenant cluster, go to [Create Your First Tenant Cluster](../getting-started/#create-your-first-tenant-cluster).
 
 ---
 

--- a/docs/reference/bootstrap-config.md
+++ b/docs/reference/bootstrap-config.md
@@ -15,6 +15,7 @@ The config is a plain YAML file passed to `butleradm bootstrap <provider> --conf
 | `network` | object | No | See defaults | Network configuration |
 | `talos` | object | No | See defaults | Talos Linux configuration |
 | `addons` | object | No | See defaults | Addon configuration |
+| `controlPlaneExposure` | object | No | `LoadBalancer` | How tenant control planes are exposed (LoadBalancer, Ingress, or Gateway) |
 | `providerConfig` | object | Yes | -- | Provider-specific settings (must match `provider` field) |
 
 ---
@@ -92,6 +93,56 @@ The config is a plain YAML file passed to `butleradm bootstrap <provider> --conf
 | `addons.console.ingress.tlsSecretName` | string | No | -- | TLS secret name (auto-generated if TLS enabled) |
 | `addons.console.auth.adminPassword` | string | No | `admin` | Initial admin password |
 | `addons.console.auth.jwtSecret` | string | No | (random) | JWT signing secret |
+
+---
+
+## controlPlaneExposure
+
+Configures how tenant control planes are exposed after bootstrap. This is a platform-level setting written to `ButlerConfig` during addon installation (step 11.5). If omitted, defaults to `LoadBalancer` mode.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `controlPlaneExposure.mode` | string | No | `LoadBalancer` | Exposure mode: `LoadBalancer`, `Ingress`, or `Gateway` |
+| `controlPlaneExposure.hostname` | string | Ingress/Gateway | -- | Wildcard domain for tenant API servers (e.g., `*.k8s.platform.example.com`) |
+| `controlPlaneExposure.ingressClassName` | string | No | -- | Ingress class when mode is `Ingress` (e.g., `haproxy`, `nginx`) |
+| `controlPlaneExposure.controllerType` | string | No | -- | Ingress controller type for TLS passthrough: `haproxy`, `nginx`, `traefik`, `generic` |
+| `controlPlaneExposure.gatewayRef` | string | Gateway | -- | Gateway resource reference when mode is `Gateway` (format: `namespace/name`) |
+
+### Exposure Modes
+
+**LoadBalancer** (default): Each tenant API server gets a dedicated LoadBalancer IP. Direct TCP access on port 6443. No SNI routing. Requires 1 IP per tenant from MetalLB (on-prem) or cloud LB. tcp-proxy is not required.
+
+**Ingress**: Multiple tenants share a single IP via an Ingress controller with TLS passthrough. SNI-based routing using `{cluster}.{namespace}.{hostname}` hostnames. Requires an Ingress controller that supports TLS passthrough (HAProxy, NGINX, or Traefik). tcp-proxy is auto-enabled to rewrite in-cluster `kubernetes.default.svc` endpoints.
+
+**Gateway**: Multiple tenants share a single IP via Gateway API TLSRoute. SNI-based routing like Ingress mode, but uses the Gateway API instead of Ingress resources. Requires a Gateway controller that supports TLSRoute. tcp-proxy is auto-enabled.
+
+### Examples
+
+LoadBalancer mode (default, can be omitted entirely):
+
+```yaml
+controlPlaneExposure:
+  mode: LoadBalancer
+```
+
+Ingress mode with HAProxy:
+
+```yaml
+controlPlaneExposure:
+  mode: Ingress
+  hostname: "*.k8s.butlerlabs.dev"
+  ingressClassName: haproxy
+  controllerType: haproxy
+```
+
+Gateway mode:
+
+```yaml
+controlPlaneExposure:
+  mode: Gateway
+  hostname: "*.k8s.butlerlabs.dev"
+  gatewayRef: "butler-system/tenant-gateway"
+```
 
 ---
 

--- a/docs/reference/bootstrap-config.md
+++ b/docs/reference/bootstrap-config.md
@@ -1,0 +1,201 @@
+# Bootstrap Config Reference
+
+Complete field reference for `butleradm bootstrap` configuration files.
+
+The bootstrap config is a plain YAML file passed to `butleradm bootstrap <provider> --config <path>`. The CLI parses it via Viper into Go structs defined in `butler-cli/internal/adm/bootstrap/orchestrator/config.go`.
+
+---
+
+## Top-Level Fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `provider` | string | Yes | -- | Infrastructure provider: `harvester`, `nutanix`, `proxmox`, `aws`, `gcp`, `azure` |
+| `cluster` | object | Yes | -- | Cluster specification |
+| `network` | object | No | See defaults | Network configuration |
+| `talos` | object | No | See defaults | Talos Linux configuration |
+| `addons` | object | No | See defaults | Addon configuration |
+| `providerConfig` | object | Yes | -- | Provider-specific settings (must match `provider` field) |
+
+---
+
+## cluster
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `cluster.name` | string | Yes | -- | Cluster name. Used for VM names, kubeconfig context, and resource naming. |
+| `cluster.topology` | string | No | `ha` | Cluster topology: `single-node` or `ha`. Single-node forces `controlPlane.replicas=1` and skips worker nodes. |
+| `cluster.controlPlane` | object | Yes | -- | Control plane node pool |
+| `cluster.workers` | object | No | -- | Worker node pool. Ignored when topology is `single-node`. |
+
+### Node Pool (controlPlane / workers)
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `replicas` | int | Yes | -- | Number of nodes. Control plane must be 1 (single-node) or 3 (HA). |
+| `cpu` | int | Yes | -- | vCPUs per node |
+| `memoryMB` | int | Yes | -- | Memory per node in megabytes (e.g., 8192 = 8 GB) |
+| `diskGB` | int | Yes | -- | Boot disk size in gigabytes |
+| `extraDisks` | array | No | -- | Additional disks (for Longhorn storage) |
+| `extraDisks[].sizeGB` | int | Yes | -- | Disk size in gigabytes |
+| `extraDisks[].storageClass` | string | No | -- | Optional storage class |
+
+---
+
+## network
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `network.podCIDR` | string | No | `10.244.0.0/16` | Pod network CIDR |
+| `network.serviceCIDR` | string | No | `10.96.0.0/12` | Service network CIDR |
+| `network.vip` | string | On-prem only | -- | Control plane VIP address. Used by kube-vip. Not applicable for cloud providers. |
+| `network.loadBalancerPool` | object | On-prem only | -- | MetalLB IP address range. Not applicable for cloud providers. |
+| `network.loadBalancerPool.start` | string | Yes (if pool set) | -- | First IP in the pool (inclusive) |
+| `network.loadBalancerPool.end` | string | Yes (if pool set) | -- | Last IP in the pool (inclusive) |
+
+### On-Prem vs Cloud
+
+- **On-prem** (Harvester, Nutanix, Proxmox): Set `vip` and `loadBalancerPool`. kube-vip provides control plane HA, MetalLB provides LoadBalancer services.
+- **Cloud** (AWS, GCP, Azure): Do not set `vip` or `loadBalancerPool`. The provider creates a cloud load balancer for control plane HA. The CCM handles LoadBalancer services natively.
+
+---
+
+## talos
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `talos.version` | string | No | `v1.9.0` | Talos Linux version |
+| `talos.schematic` | string | No | -- | Talos Image Factory schematic ID. Determines which extensions are included in the image (e.g., iscsi-tools, qemu-guest-agent). |
+
+---
+
+## addons
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `addons.cni.type` | string | No | `cilium` | CNI plugin type |
+| `addons.storage.type` | string | No | `longhorn` | Storage provider type |
+| `addons.loadBalancer.type` | string | No | `metallb` | Load balancer type (on-prem only) |
+| `addons.loadBalancer.addressPool` | string | No | -- | **Deprecated.** Use `network.loadBalancerPool` instead. Legacy IP range string (e.g., `10.40.0.200-10.40.0.250`). |
+| `addons.gitOps.type` | string | No | -- | GitOps controller type (e.g., `flux`). Not installed during bootstrap by default. |
+| `addons.capi.enabled` | bool | No | `false` | Install Cluster API |
+| `addons.capi.version` | string | No | -- | CAPI version |
+| `addons.butlerController.enabled` | bool | No | `false` | Install Butler controller |
+| `addons.butlerController.version` | string | No | -- | Butler controller version |
+| `addons.butlerController.image` | string | No | -- | Butler controller container image |
+| `addons.console.enabled` | bool | No | `false` | Install Butler Console |
+| `addons.console.version` | string | No | `latest` | Console chart/image version |
+| `addons.console.ingress.enabled` | bool | No | `false` | Create Ingress for console (on-prem) |
+| `addons.console.ingress.host` | string | No | `butler.<cluster>.local` | Ingress hostname |
+| `addons.console.ingress.className` | string | No | -- | Ingress class (e.g., `traefik`) |
+| `addons.console.ingress.tls` | bool | No | `false` | Enable TLS on ingress |
+| `addons.console.ingress.tlsSecretName` | string | No | -- | TLS secret name (auto-generated if TLS enabled) |
+| `addons.console.auth.adminPassword` | string | No | `admin` | Initial admin password |
+| `addons.console.auth.jwtSecret` | string | No | (random) | JWT signing secret |
+
+---
+
+## providerConfig
+
+Only one provider block should be set, matching the top-level `provider` field.
+
+### providerConfig.harvester
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `kubeconfigPath` | string | Yes | Path to the Harvester kubeconfig file. Supports `~` expansion. |
+| `namespace` | string | Yes | Harvester namespace for VMs (e.g., `default`) |
+| `networkName` | string | Yes | VM network in `namespace/name` format (e.g., `default/vlan40-workloads`) |
+| `imageName` | string | Yes | Talos image in `namespace/name` format (e.g., `default/talos-v1-12-1`) |
+
+### providerConfig.nutanix
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `endpoint` | string | Yes | -- | Prism Central URL (e.g., `https://prism.example.com`) |
+| `port` | int | No | `9440` | Prism Central API port |
+| `insecure` | bool | No | `false` | Allow insecure TLS (self-signed certs) |
+| `username` | string | Yes | -- | Prism Central username |
+| `password` | string | Yes | -- | Prism Central password |
+| `clusterUUID` | string | Yes | -- | Target Nutanix cluster UUID |
+| `subnetUUID` | string | Yes | -- | VM network subnet UUID |
+| `imageUUID` | string | Yes | -- | Talos image UUID in Prism Central |
+| `storageContainerUUID` | string | No | -- | Storage container for VM disks |
+| `hostAliases` | array | No | -- | `/etc/hosts` entries for the KIND node (e.g., `["10.0.0.1 prism.internal"]`). Useful for corporate DNS/Zscaler. |
+
+### providerConfig.proxmox
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `endpoint` | string | Yes | -- | Proxmox API URL |
+| `insecure` | bool | No | `false` | Allow insecure TLS |
+| `username` | string | Yes | -- | Proxmox username |
+| `password` | string | Yes | -- | Proxmox password |
+| `nodes` | array | Yes | -- | List of Proxmox node names for VM placement |
+| `storage` | string | Yes | -- | Storage location for VM disks |
+| `templateID` | int | No | -- | VM template ID to clone |
+| `vmidStart` | int | No | -- | Start of VM ID range |
+| `vmidEnd` | int | No | -- | End of VM ID range |
+| `hostAliases` | array | No | -- | `/etc/hosts` entries for KIND node |
+
+### providerConfig.aws
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `accessKeyID` | string | Yes | -- | IAM access key ID |
+| `secretAccessKey` | string | Yes | -- | IAM secret access key |
+| `region` | string | Yes | -- | AWS region (e.g., `us-east-1`) |
+| `vpcID` | string | No | -- | VPC ID |
+| `subnetID` | string | No | -- | Subnet ID for VM placement |
+| `securityGroupID` | string | No | -- | Security group ID |
+| `instanceType` | string | No | `m5.xlarge` | EC2 instance type |
+| `ami` | string | No | (per-region default) | Custom AMI ID. If not set, uses built-in Talos AMI for the region. |
+
+### providerConfig.gcp
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `serviceAccountKeyPath` | string | Yes | -- | Path to GCP service account key JSON file. Supports `~` expansion. |
+| `projectID` | string | Yes | -- | GCP project ID |
+| `region` | string | Yes | -- | GCP region (e.g., `us-central1`) |
+| `zone` | string | No | `{region}-a` | GCP zone |
+| `network` | string | Yes | -- | VPC network name |
+| `subnetwork` | string | No | -- | Subnet name |
+| `machineType` | string | No | -- | GCE machine type (e.g., `n2-standard-4`) |
+| `imageProject` | string | No | -- | GCP project containing the Talos image |
+| `imageFamily` | string | No | -- | Image family (e.g., `talos-v1-12`). Used if `image` is not set. |
+| `image` | string | No | -- | Specific GCE image name. Takes precedence over `imageFamily`. |
+
+### providerConfig.azure
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `clientID` | string | Yes | -- | Service principal app ID |
+| `clientSecret` | string | Yes | -- | Service principal password |
+| `tenantID` | string | Yes | -- | Azure AD tenant ID |
+| `subscriptionID` | string | Yes | -- | Azure subscription ID |
+| `resourceGroup` | string | Yes | -- | Pre-existing resource group name |
+| `location` | string | Yes | -- | Azure region (e.g., `eastus`) |
+| `vnetName` | string | No | -- | Pre-existing VNet name |
+| `subnetName` | string | No | -- | Subnet within the VNet |
+| `securityGroupName` | string | No | -- | Pre-existing NSG name. **Required for CCM to create LB NSG rules.** |
+| `vmSize` | string | No | -- | Azure VM size (e.g., `Standard_D4s_v3`) |
+| `imageURN` | string | No | -- | Full ARM resource ID for the Talos image (managed image or gallery image version) |
+
+---
+
+## Defaults
+
+When a field is omitted, these defaults are applied:
+
+| Field | Default Value |
+|-------|---------------|
+| `cluster.topology` | `ha` |
+| `network.podCIDR` | `10.244.0.0/16` |
+| `network.serviceCIDR` | `10.96.0.0/12` |
+| `talos.version` | `v1.9.0` |
+| `addons.cni.type` | `cilium` |
+| `addons.storage.type` | `longhorn` |
+| `addons.loadBalancer.type` | `metallb` |
+| `providerConfig.nutanix.port` | `9440` |
+| `providerConfig.gcp.zone` | `{region}-a` |

--- a/docs/reference/bootstrap-config.md
+++ b/docs/reference/bootstrap-config.md
@@ -1,8 +1,8 @@
 # Bootstrap Config Reference
 
-Complete field reference for `butleradm bootstrap` configuration files.
+Field reference for `butleradm bootstrap` configuration files.
 
-The bootstrap config is a plain YAML file passed to `butleradm bootstrap <provider> --config <path>`. The CLI parses it via Viper into Go structs defined in `butler-cli/internal/adm/bootstrap/orchestrator/config.go`.
+The config is a plain YAML file passed to `butleradm bootstrap <provider> --config <path>`. The CLI parses it into Go structs defined in `butler-cli/internal/adm/bootstrap/orchestrator/config.go`.
 
 ---
 
@@ -64,7 +64,7 @@ The bootstrap config is a plain YAML file passed to `butleradm bootstrap <provid
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `talos.version` | string | No | `v1.9.0` | Talos Linux version |
+| `talos.version` | string | No | `v1.12.1` | Talos Linux version |
 | `talos.schematic` | string | No | -- | Talos Image Factory schematic ID. Determines which extensions are included in the image (e.g., iscsi-tools, qemu-guest-agent). |
 
 ---
@@ -193,7 +193,7 @@ When a field is omitted, these defaults are applied:
 | `cluster.topology` | `ha` |
 | `network.podCIDR` | `10.244.0.0/16` |
 | `network.serviceCIDR` | `10.96.0.0/12` |
-| `talos.version` | `v1.9.0` |
+| `talos.version` | `v1.12.1` |
 | `addons.cni.type` | `cilium` |
 | `addons.storage.type` | `longhorn` |
 | `addons.loadBalancer.type` | `metallb` |


### PR DESCRIPTION
## Summary

- Rewrites all 5 provider guides (Harvester, Nutanix, AWS, GCP, Azure) with correct `butleradm` config format
- Replaces stale ClusterBootstrap CRD YAML with plain YAML config matching `config.go` structs
- Adds bootstrap config reference page documenting every field across all 6 providers
- Updates bootstrap-flow addon table with complete installation order (17 steps including CCM, providerID patching, Gateway API CRDs, Butler CRDs)
- Expands troubleshooting with real failure modes from E2E testing (CCM deadlock, Azure quota, backend pool bug, GCP nodeipam, Zscaler)
- Updates provider status: AWS In Progress -> Stable, Azure In Progress -> Stable
- Fixes getting-started guide with correct CLI flags and config format
- Adds Cilium ports (TCP 4240, UDP 8472) to all security group/firewall rule docs
- Adds controlPlaneExposure section to bootstrap config reference
- Fixes cleanup command cluster name filters to match example configs

## Test plan

- [x] Verify every YAML field name matches a `mapstructure` tag in `butler-cli/internal/adm/bootstrap/orchestrator/config.go`
- [x] Verify AMI IDs match `butler-provider-aws/internal/awsclient/types.go`
- [x] Verify addon order table matches `butler-bootstrap/internal/controller/clusterbootstrap_controller.go`
- [x] Verify security group/firewall port lists include all required ports
- [ ] Run markdownlint on all changed files