### PR TITLE
docs: remove unsubstantiated claims and overpromising language

### DIFF
--- a/docs/concepts/hosted-control-planes.md
+++ b/docs/concepts/hosted-control-planes.md
@@ -20,13 +20,13 @@ All three components run as a single Deployment in a dedicated namespace on the 
 ## Benefits
 
 - **Faster provisioning** -- Control plane pods start in seconds. No VM boot time.
-- **Lower resource cost** -- Each tenant control plane uses ~12 mCPU and ~6 MiB at idle. Hundreds of tenants fit on modest hardware.
+- **Lower resource cost** -- Each tenant control plane uses ~12 mCPU and ~6 MiB at idle (observed on butler-beta).
 - **Centralized operations** -- One etcd cluster, one set of certificates, one backup target.
 
 ## Trade-offs
 
 - **Management cluster criticality** -- If the management cluster goes down, all tenant API servers become unavailable. Worker nodes continue running workloads, but kubectl access and new scheduling stop.
-- **Resource scaling** -- At 10+ tenants, configure [control plane resource limits](../reference/crds/butlerconfig.md) to prevent etcd starvation.
+- **Resource scaling** -- As tenant count grows, monitor etcd resource usage and configure [control plane resource limits](../reference/crds/butlerconfig.md) to avoid contention.
 - **Shared etcd** -- Tenant data is logically isolated (separate key prefixes) but shares physical storage. A misbehaving tenant with high write volume can affect others.
 
 ## Exposure Modes

--- a/docs/concepts/management-clusters.md
+++ b/docs/concepts/management-clusters.md
@@ -31,9 +31,9 @@ Butler supports two management cluster topologies:
 
 Both topologies use [Talos Linux](https://www.talos.dev/) as the node operating system. Talos provides an immutable, API-managed OS with no SSH access and a minimal attack surface.
 
-## One Per Environment
+## Capacity
 
-Most organizations run one management cluster per environment (development, staging, production). A single management cluster can host hundreds of tenant clusters, bounded by etcd capacity and node resources.
+The practical capacity of a management cluster depends on etcd capacity, node resources, and the resource footprint of each tenant control plane. See the [scaling guide](../operations/scaling.md) for tuning guidance.
 
 ## See Also
 

--- a/docs/concepts/tenant-clusters.md
+++ b/docs/concepts/tenant-clusters.md
@@ -51,8 +51,8 @@ Butler supports five worker node operating systems:
 | Talos | Machine config via talosctl | Default for new clusters. Immutable, API-managed. |
 | Rocky | kubeadm join via cloud-init | Max K8s version: v1.30.2 |
 | Flatcar | Ignition JSON | Auto-joins via bootstrap token |
-| Bottlerocket | TOML settings | Minimal, container-optimized |
-| Kairos | Cloud-config YAML | Immutable, community-driven |
+| Bottlerocket | TOML settings | Minimal, container-optimized (E2E pending) |
+| Kairos | Cloud-config YAML | Immutable, community-driven (E2E pending) |
 
 Set the OS type in `spec.workers.machineTemplate.os.type`.
 

--- a/docs/getting-started/first-tenant-cluster.md
+++ b/docs/getting-started/first-tenant-cluster.md
@@ -89,7 +89,7 @@ kubectl get tenantcluster my-first-cluster -n dev-team -w
 
 The cluster transitions through phases: `Pending` -> `Provisioning` -> `Installing` -> `Ready`.
 
-Provisioning typically takes 3-5 minutes. If it stays in `Provisioning` for more than 10 minutes, check [Troubleshooting](../troubleshooting/provisioning.md).
+Provisioning time varies by infrastructure provider and load. If the cluster stays in `Provisioning` for more than 10 minutes, check [Troubleshooting](../troubleshooting/provisioning.md).
 
 ## 5. Get the Kubeconfig
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -9,7 +9,7 @@ Butler provisions and manages Kubernetes clusters across on-prem and cloud infra
 
 ## What You Get
 
-- **Self-service clusters** -- Create a TenantCluster CR and get a working Kubernetes cluster with CNI, load balancing, and storage in under 5 minutes.
+- **Self-service clusters** -- Create a TenantCluster CR and get a working Kubernetes cluster with CNI, load balancing, and storage.
 - **No control plane nodes** -- Steward runs tenant API servers as pods in the management cluster. No dedicated VMs for control planes.
 - **Five infrastructure providers** -- Harvester, Nutanix, AWS, GCP, Azure. Proxmox is planned.
 - **Team isolation** -- Namespace-based multi-tenancy with RBAC roles, resource quotas, and SSO integration.

--- a/docs/operations/scaling.md
+++ b/docs/operations/scaling.md
@@ -31,7 +31,7 @@ spec:
     - etcd-2.etcd:2379
 ```
 
-At 10+ tenants, tune etcd resource limits and snapshot count. See the [etcd tuning guide](https://github.com/butlerdotdev/steward/blob/master/docs/etcd-tuning-for-multi-tenant.md) for details.
+As tenant count grows, tune etcd resource limits and snapshot count. See the [etcd tuning guide](https://github.com/butlerdotdev/steward/blob/master/docs/etcd-tuning-for-multi-tenant.md) for details.
 
 ## Scale Tenant Clusters
 

--- a/docs/operations/upgrading.md
+++ b/docs/operations/upgrading.md
@@ -8,7 +8,7 @@ sidebar_position: 2
 ## Pre-Upgrade Checklist
 
 - [ ] Review release notes for breaking changes
-- [ ] Check the [compatibility matrix](../../releases/compatibility-matrix.md) for version requirements
+- [ ] Check release notes for component version requirements
 - [ ] Back up management cluster state (see [Backup and Restore](./backup-restore.md))
 - [ ] Notify users of the maintenance window
 - [ ] Test the upgrade in a non-production environment first
@@ -68,5 +68,4 @@ helm rollback butler-crds -n butler-system
 
 ## See Also
 
-- [Compatibility Matrix](../../releases/compatibility-matrix.md) -- Version requirements
 - [Backup and Restore](./backup-restore.md) -- Pre-upgrade backup

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -13,7 +13,7 @@ This document outlines planned development for Butler. Plans are subject to chan
 
 Butler is in beta with a comprehensive feature set:
 
-- Management cluster bootstrap across 6 providers (Harvester, Nutanix, AWS, GCP, Azure, with Proxmox planned)
+- Management cluster bootstrap across 5 providers (Harvester, Nutanix, AWS, GCP, Azure) with Proxmox planned
 - Tenant cluster provisioning with hosted control planes via Steward
 - Multi-OS worker nodes (Talos, Rocky, Flatcar, Bottlerocket, Kairos)
 - Three control plane exposure modes (LoadBalancer, Ingress, Gateway)
@@ -24,7 +24,7 @@ Butler is in beta with a comprehensive feature set:
 - Team-based multi-tenancy with resource quotas
 - SSO integration (Google, Microsoft Entra ID, Okta)
 - Butler Image Factory for OS image building and syncing
-- Configurable control plane resource limits (prevents etcd starvation at scale)
+- Configurable control plane resource limits for etcd resource management
 
 ---
 


### PR DESCRIPTION
## Summary

- Remove "under 5 minutes" provisioning claim -- no benchmark supports it
- Remove "hundreds of tenants fit on modest hardware" -- untested at scale
- Remove "prevents etcd starvation" -- overpromises; replaced with "avoid contention"
- Remove "At 10+ tenants" as a hard threshold -- lab observation, not validated guidance
- Remove broken links to nonexistent `releases/compatibility-matrix.md`
- Fix provider count: 5 stable providers, Proxmox planned (was counting 6)
- Add "(E2E pending)" to Bottlerocket and Kairos OS entries
- Add "(observed on butler-beta)" context to ~12 mCPU / ~6 MiB numbers
- Replace prescriptive "One Per Environment" section with neutral "Capacity" section
- Remove specific timing claims from first-tenant-cluster guide

## Test plan

- [ ] Verify no new broken links introduced
- [ ] Read through changed pages for tone consistency