### PR TITLE
docs(getting-started): add post-bootstrap operator checklist

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -63,8 +63,9 @@ Bootstrap takes 15-30 minutes and produces a Kubernetes cluster running Talos Li
 
 Once your management cluster passes the validation checklist in the provider guide:
 
-1. **[Create your first tenant cluster](./first-tenant-cluster.md)** -- Define a Team, create a TenantCluster, and get a kubeconfig.
-2. **[Explore the Console](./console.md)** -- Open the web UI to view clusters, manage addons, and access terminals.
+1. **[Complete post-bootstrap configuration](./post-bootstrap.md)** -- Expose the console with DNS + TLS, configure SSO, create your admin user, and tune `ButlerConfig`. Do this before inviting users or creating tenant clusters.
+2. **[Create your first tenant cluster](./first-tenant-cluster.md)** -- Define a Team, create a TenantCluster, and get a kubeconfig.
+3. **[Explore the Console](./console.md)** -- Open the web UI to view clusters, manage addons, and access terminals.
 
 ## Troubleshooting
 

--- a/docs/getting-started/console.md
+++ b/docs/getting-started/console.md
@@ -1,6 +1,6 @@
 ---
 title: Butler Console
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Butler Console

--- a/docs/getting-started/first-tenant-cluster.md
+++ b/docs/getting-started/first-tenant-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Create Your First Tenant Cluster
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Create Your First Tenant Cluster

--- a/docs/getting-started/post-bootstrap.md
+++ b/docs/getting-started/post-bootstrap.md
@@ -14,6 +14,27 @@ export KUBECONFIG=~/.butler/<cluster-name>-kubeconfig
 kubectl get nodes
 ```
 
+## Three Ways to Apply These Changes
+
+Each step produces the same Kubernetes state; the paths differ only in how the change lands. Pick based on how your team operates:
+
+- **kubectl**. Shortest path, no prerequisite setup. Right for first-time configuration, dev clusters, and verifying something works. This guide's primary examples use kubectl because it works for every step.
+- **Console UI**. Right for ongoing administration once the console is reachable. Requires steps 1 and 2 to be complete first. Some steps (infrastructure like ingress and TLS, or server env vars) are not surfaced in the UI because they are not platform state; those are called out per step.
+- **GitOps**. Right when the cluster is managed declaratively and all changes go through PR review. Requires Flux to be bootstrapped on the management cluster first (separate operations guide). Adds a review step to every change; drift goes down over time.
+
+Which paths each step supports:
+
+| Step | kubectl | Console UI | GitOps |
+|---|---|---|---|
+| 1. Expose the console | yes | no (infrastructure, not platform state) | yes |
+| 2. Configure `butler-server` env | yes | no (server config, not a CRD) | yes, via Helm values |
+| 3. Configure SSO | yes | yes (`Admin → Identity Providers`) | yes |
+| 4. Create admin user + invite | yes | yes (`Admin → Users → Regenerate invite`) | partial, see step 4 |
+| 5. Tune `ButlerConfig` | yes | yes (`Admin → Settings`) | yes |
+| 6. Verify | `butlerctl login` + curl | browser to `https://console.yourdomain` | not applicable |
+
+The numbered walkthrough below uses kubectl as the primary path. Callouts on each step show the Console UI and GitOps equivalents.
+
 ## 1. Expose the Console
 
 Bootstrap already installs an Ingress for the console. You change its host to one you own, add TLS, and create a DNS record pointing at the ingress controller's LoadBalancer IP.
@@ -93,6 +114,14 @@ kubectl -n butler-system get certificate butler-console-tls -w
 
 If you manage the install with Helm, set `ingress.hosts[0].host`, `ingress.tls`, and `ingress.annotations` in the chart values instead of patching the Ingress directly.
 
+:::tip GitOps path
+Commit the `ClusterIssuer` YAML and a `HelmRelease` (or direct `Ingress` override) to your Flux repo. The patch above is not idempotent in a GitOps workflow because Flux would fight a live `kubectl patch`; manage the Ingress fields through the chart values or a dedicated Ingress manifest instead.
+:::
+
+:::note No UI path
+Ingress and TLS are cluster infrastructure, not Butler platform state. The Console UI does not surface them. Do this step from kubectl or GitOps.
+:::
+
 ## 2. Configure `butler-server` for the Public URL
 
 The server emits its public URL in several places: the CLI device-flow verification link, invite emails, and OIDC callback hints. By default the server derives this URL from the incoming request, but you must still tell it to trust the ingress-supplied forwarded headers.
@@ -121,6 +150,14 @@ kubectl rollout status deployment/butler-console-server -n butler-system
 
 :::warning
 Only set `BUTLER_TRUST_PROXY_HEADERS=true` when you are confident the ingress strips client-supplied `X-Forwarded-*` headers and sets its own. Traefik, nginx-ingress, and Envoy do this by default. Verify by curling the ingress from outside the cluster with a spoofed `X-Forwarded-Host` header and checking the access log on the ingress pod.
+:::
+
+:::tip GitOps path
+These are env vars on the `butler-console-server` Deployment, which is Helm-managed. In a GitOps flow, set them in the chart values committed to your Flux repo (`server.env` or the equivalent values key for your chart version) rather than editing the live Deployment. A live `kubectl set env` will be reverted on the next Flux reconcile.
+:::
+
+:::note No UI path
+`butler-server` env vars are not platform state; the console does not expose them. Use kubectl (one-shot clusters) or GitOps (everything else).
 :::
 
 ## 3. Configure SSO
@@ -174,6 +211,14 @@ spec:
 ```
 
 `spec.oidc.redirectURL` is required and must match the callback URL registered with your IdP exactly. `spec.oidc.clientSecretRef.namespace` is optional and defaults to `butler-system`.
+
+:::tip Console UI path
+`Admin → Identity Providers → Create`. The form accepts the same fields shown above (type, issuer URL, client ID, client secret, redirect URL, scopes, claim mappings). The console writes the same `IdentityProvider` CRD. Use this path for ongoing changes once the console is reachable.
+:::
+
+:::tip GitOps path
+Commit both the `Secret` and the `IdentityProvider` YAML to your Flux repo (for example `platform/identity-providers/company-sso.yaml`). Run the `client-secret` value through SOPS or your secret-management layer before commit. Flux reconciles the CRD exactly as `kubectl apply` would.
+:::
 
 After applying, confirm the resource is accepted:
 
@@ -247,6 +292,18 @@ kubectl -n butler-system rollout restart deployment/butler-console-server
 
 The `User` CRD named `admin` remains; delete it separately if you don't want to keep it as a break-glass internal account.
 
+:::tip Console UI path
+`Admin → Users → Create`. The form produces the same `User` CRD that `butleradm user create` does. Each user row has a `Regenerate invite` action that calls `POST /api/admin/users/{name}/invite` and shows the one-time URL in the UI; no curl or cookie juggling required. For SSO users, the same page offers a toggle for `isPlatformAdmin`.
+:::
+
+:::tip GitOps path (partial)
+You can commit `User` CRDs to your Flux repo and let Flux create them, but the invite URL is minted at claim time by `butler-server` and is not part of CRD state. For password-based users the workflow stays: Flux creates the `User`, then an operator regenerates the invite URL via the UI or API and delivers it to the user. SSO users bypass this entirely; they're auto-created on first login.
+:::
+
+:::note
+The invite URL is constructed from `BUTLER_BASE_URL` captured by the server at startup. This predates the device-flow request-based URL derivation and is a known structural pattern that will migrate to per-request derivation in a future change.
+:::
+
 ## 5. Tune `ButlerConfig`
 
 `ButlerConfig` is the cluster-scoped singleton that controls platform-wide defaults. Bootstrap creates it with sensible defaults, but review the values before onboarding teams.
@@ -268,7 +325,17 @@ Fields worth reviewing:
 
 Apply changes with `kubectl apply` or `kubectl edit`; the controller reconciles in seconds.
 
+:::tip Console UI path
+`Admin → Settings`. The page has sections for general settings (multi-tenancy mode, default namespace, default provider), control plane exposure, default addon versions, default team limits, default control plane resources, image factory, audit log, notifications, and the platform SSH authorized key. The console writes back to the same `ButlerConfig` singleton; there's no drift between the two paths.
+:::
+
+:::tip GitOps path
+The `ButlerConfig` resource is cluster-scoped and named `butler`. Commit the full resource to your Flux repo (for example `platform/butlerconfig.yaml`). Flux reconciles it in place. Because this is a singleton, avoid `kubectl edit` on live clusters under Flux management; the edit will be reverted on reconcile.
+:::
+
 ## 6. Verify
+
+The verification step is a check, not an apply, so there's no GitOps variant. Exercise both the Console UI and the CLI flow:
 
 ### Web console
 

--- a/docs/getting-started/post-bootstrap.md
+++ b/docs/getting-started/post-bootstrap.md
@@ -67,7 +67,7 @@ kubectl -n traefik get svc traefik -o jsonpath='{.status.loadBalancer.ingress[0]
 
 Create an A or CNAME record pointing `console.yourdomain` at that IP. If you plan to expose tenant-cluster API servers via shared ingress later (the `Ingress` mode of `ButlerConfig.spec.controlPlaneExposure`), also create a wildcard `*.k8s.yourdomain` pointing at the same IP.
 
-Bootstrap installs Traefik unconditionally today; the ingress controller is not configurable from the bootstrap config. Swapping to a different controller post-install is possible but out of scope for this guide.
+As of butler-cli v0.7.4, bootstrap installs Traefik unconditionally; the ingress controller is not configurable from the bootstrap config (`butler-bootstrap/internal/addons/installer.go` hardcodes the chart). Swapping to a different controller post-install is possible but out of scope for this guide.
 
 ### TLS certificate
 
@@ -94,7 +94,41 @@ For air-gapped or internal-only deployments, replace the `ClusterIssuer` body wi
 
 ### Update the Ingress host and TLS
 
-Patch the bootstrap-created Ingress to use your real hostname and reference the `ClusterIssuer`. This preserves the `/api`, `/ws`, and `/` path rules:
+The Ingress is managed by the `butler-console` Helm chart. Update the chart values and re-apply the release; the chart regenerates the Ingress with the `/api`, `/ws`, and `/` path rules intact.
+
+```yaml
+# values.yaml override
+ingress:
+  enabled: true
+  className: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: console.yourdomain
+      paths:
+        - path: /api
+          pathType: Prefix
+          service: server
+        - path: /ws
+          pathType: Prefix
+          service: server
+        - path: /
+          pathType: Prefix
+          service: frontend
+  tls:
+    - hosts:
+        - console.yourdomain
+      secretName: butler-console-tls
+```
+
+Apply with `helm upgrade` (or let Flux reconcile, under GitOps). Wait for the certificate to issue:
+
+```bash
+kubectl -n butler-system get certificate butler-console-tls -w
+```
+
+:::tip Break-glass: kubectl patch
+For one-off clusters where you do not want to touch Helm values, patch the live Ingress directly:
 
 ```bash
 kubectl -n butler-system annotate ingress butler-console \
@@ -106,66 +140,71 @@ kubectl -n butler-system patch ingress butler-console --type=json -p='[
 ]'
 ```
 
-Wait for the certificate to issue before continuing:
-
-```bash
-kubectl -n butler-system get certificate butler-console-tls -w
-```
-
-If you manage the install with Helm, set `ingress.hosts[0].host`, `ingress.tls`, and `ingress.annotations` in the chart values instead of patching the Ingress directly.
-
-:::tip GitOps path
-Commit the `ClusterIssuer` YAML and a `HelmRelease` (or direct `Ingress` override) to your Flux repo. The patch above is not idempotent in a GitOps workflow because Flux would fight a live `kubectl patch`; manage the Ingress fields through the chart values or a dedicated Ingress manifest instead.
-:::
-
-:::note No UI path
-Ingress and TLS are cluster infrastructure, not Butler platform state. The Console UI does not surface them. Do this step from kubectl or GitOps.
+**This patch is ephemeral.** The next `helm upgrade` or Flux reconcile of the `butler-console` chart will revert it. Use only when you are not running Helm-managed upgrades.
 :::
 
 ## 2. Configure `butler-server` for the Public URL
 
-The server emits its public URL in several places: the CLI device-flow verification link, invite emails, and OIDC callback hints. By default the server derives this URL from the incoming request, but you must still tell it to trust the ingress-supplied forwarded headers.
+The server emits its public URL in several places: the CLI device-flow verification link and invite emails. By default the server derives this URL from the incoming request, but you must still tell it to trust the ingress-supplied forwarded headers.
 
-Set three environment variables on the `butler-console-server` Deployment. If you are managing the install with Helm, set them in the chart values; otherwise edit the Deployment directly:
+Set these in the `butler-console` Helm chart values:
 
-```bash
-kubectl set env deployment/butler-console-server -n butler-system \
-  BUTLER_BASE_URL=https://console.yourdomain \
-  BUTLER_TRUST_PROXY_HEADERS=true \
-  BUTLER_SECURE_COOKIES=true
+```yaml
+# values.yaml override
+server:
+  config:
+    baseURL: https://console.yourdomain
+  auth:
+    secureCookies: true
 ```
 
-| Variable | Value | Reason |
+| Chart value | Env var | Reason |
 |---|---|---|
-| `BUTLER_BASE_URL` | `https://console.yourdomain` | Canonical public URL. Used for invite links and as the fallback when request derivation is not possible. |
-| `BUTLER_TRUST_PROXY_HEADERS` | `true` | Tells the server to honor `X-Forwarded-Proto` and `X-Forwarded-Host` set by the ingress. Without this, `https` flows show up as `http` in emitted URLs. |
-| `BUTLER_SECURE_COOKIES` | `true` | Sets the `Secure` flag on session cookies. Required once TLS is active. |
+| `server.config.baseURL` | `BUTLER_BASE_URL` | Canonical public URL. Used for invite links and as the fallback when request derivation is not possible. |
+| `server.auth.secureCookies` | `BUTLER_SECURE_COOKIES` | Sets the `Secure` flag on session cookies. Required once TLS is active. |
 
-Restart to pick up the new values:
+Apply with `helm upgrade` (or let Flux reconcile).
+
+#### `BUTLER_TRUST_PROXY_HEADERS` chart gap
+
+The third env var you want set is `BUTLER_TRUST_PROXY_HEADERS=true`, which tells the server to honor `X-Forwarded-Proto` and `X-Forwarded-Host` from the ingress. Without it, `https` flows show up as `http` in emitted URLs. As of `butler-console` chart 0.4.1, this env var is not yet exposed through chart values; until the chart catches up, set it via `kubectl set env`:
 
 ```bash
-kubectl rollout restart deployment/butler-console-server -n butler-system
-kubectl rollout status deployment/butler-console-server -n butler-system
+kubectl -n butler-system set env deployment/butler-console-server \
+  BUTLER_TRUST_PROXY_HEADERS=true
+kubectl -n butler-system rollout status deployment/butler-console-server
 ```
+
+This patch will be reverted on the next `helm upgrade` of the chart until the values key lands. Track the chart update and re-apply on each upgrade.
 
 :::warning
 Only set `BUTLER_TRUST_PROXY_HEADERS=true` when you are confident the ingress strips client-supplied `X-Forwarded-*` headers and sets its own. Traefik, nginx-ingress, and Envoy can all be configured to do this; check your deployment's forwarded-headers settings (for example, nginx-ingress `use-forwarded-headers` defaults to `false`, which has the effect of ignoring upstream values and writing its own; Traefik requires explicit trusted-IP configuration on the entrypoint). Verify by curling the ingress from outside the cluster with a spoofed `X-Forwarded-Host` header and checking the access log or the response on the ingress pod.
 :::
 
-:::tip GitOps path
-These are env vars on the `butler-console-server` Deployment, which is Helm-managed. In a GitOps flow, set them in the chart values committed to your Flux repo (`server.env` or the equivalent values key for your chart version) rather than editing the live Deployment. A live `kubectl set env` will be reverted on the next Flux reconcile.
-:::
+:::tip Break-glass: kubectl set env
+For one-off dev clusters where you do not want to touch Helm values, all three env vars can be set directly:
 
-:::note No UI path
-`butler-server` env vars are not platform state; the console does not expose them. Use kubectl (one-shot clusters) or GitOps (everything else).
+```bash
+kubectl -n butler-system set env deployment/butler-console-server \
+  BUTLER_BASE_URL=https://console.yourdomain \
+  BUTLER_TRUST_PROXY_HEADERS=true \
+  BUTLER_SECURE_COOKIES=true
+kubectl -n butler-system rollout status deployment/butler-console-server
+```
+
+Reverted on the next `helm upgrade`.
 :::
 
 ## 3. Configure SSO
 
+:::note Platform direction for this section
+The shape of SSO configuration is mid-migration. Reconciliation of `IdentityProvider` CRDs into the running server is tracked at [butlerdotdev/butler#21](https://github.com/butlerdotdev/butler/issues/21). Today the env var path described below is the supported configuration mechanism; once the tracked decision lands, this section may flip to CRD-primary.
+:::
+
 Butler supports OIDC (Google Workspace, Microsoft Entra, Okta, Keycloak, and any standards-compliant provider). There are two related pieces you may need to configure:
 
 - **`butler-console-server` environment variables**: the server builds its OIDC provider from `BUTLER_OIDC_*` env vars once at startup. These drive the active SSO login flow.
-- **`IdentityProvider` CRD**: a cluster-scoped record used by the Teams handler to validate `identityProvider: <name>` references in group-sync rules, and displayed in the console's admin UI. It is not read by the auth code path today; creating one does not enable SSO on its own.
+- **`IdentityProvider` CRD**: a cluster-scoped record whose `metadata.name` is referenced by `Team` group-sync rules for existence checks, and is displayed in the console admin UI. Its spec fields (`issuerURL`, `clientID`, `clientSecretRef`, `redirectURL`, `scopes`, claim mappings) are not consumed by any active code path today. They exist in the schema and the admin UI for the day reconciliation lands.
 
 Enabling SSO means setting env vars. Creating the CRD is optional and only necessary if you plan to reference a named IdP from `Team.spec.access.groups` group-sync rules.
 
@@ -179,29 +218,37 @@ https://console.yourdomain/api/auth/callback
 
 Note the issuer URL, client ID, and client secret. Google Workspace additionally requires an Admin SDK service account for group fetching (groups are not in Google OIDC tokens).
 
-### Set the OIDC environment variables on `butler-console-server`
+### Set the OIDC configuration on `butler-console-server`
 
-Store the client secret in a Secret and reference it from the Deployment rather than baking it into the env literal. The example below uses a Secret + `envFrom` on the Helm-managed chart; if you are editing the live Deployment, use `kubectl set env --from=secret/...` for the client secret and plain `--env` for the others.
+Use the `butler-console` chart's `server.oidc.*` values. The chart reads OIDC credentials from a referenced Secret (`server.oidc.existingSecret`) with two keys, `client-id` and `client-secret`; the Secret keeps the credentials out of your values file.
+
+Create the Secret:
 
 ```bash
 kubectl -n butler-system create secret generic butler-oidc \
-  --from-literal=BUTLER_OIDC_CLIENT_SECRET='<from-idp>'
-
-kubectl -n butler-system set env deployment/butler-console-server \
-  BUTLER_OIDC_ENABLED=true \
-  BUTLER_OIDC_ISSUER_URL=https://accounts.google.com \
-  BUTLER_OIDC_CLIENT_ID='<from-idp>' \
-  BUTLER_OIDC_REDIRECT_URL=https://console.yourdomain/api/auth/callback \
-  BUTLER_OIDC_GROUPS_CLAIM=groups \
-  BUTLER_OIDC_EMAIL_CLAIM=email
-
-kubectl -n butler-system set env deployment/butler-console-server \
-  --from=secret/butler-oidc
-
-kubectl -n butler-system rollout restart deployment/butler-console-server
+  --from-literal=client-id='<from-idp>' \
+  --from-literal=client-secret='<from-idp>'
 ```
 
-Google Workspace only: add `GOOGLE_SERVICE_ACCOUNT_JSON` (the service account key JSON) and `GOOGLE_ADMIN_EMAIL` (an admin user for domain-wide delegation) so `butler-server` can fetch groups via the Admin SDK.
+Then set the chart values:
+
+```yaml
+# values.yaml override
+server:
+  oidc:
+    enabled: true
+    issuerURL: https://accounts.google.com
+    existingSecret: butler-oidc
+    redirectURL: https://console.yourdomain/api/auth/callback
+    groupsClaim: groups
+    emailClaim: email
+```
+
+`enabled: true` is redundant when `issuerURL` and `clientID` (or `existingSecret`) are set, because `config.go` auto-enables OIDC in that case; it is kept here for explicitness.
+
+Google Workspace only: also set `GOOGLE_SERVICE_ACCOUNT_JSON` (the service account key JSON) and `GOOGLE_ADMIN_EMAIL` (an admin user for domain-wide delegation) so `butler-server` can fetch groups via the Admin SDK. These are not yet exposed as chart values; set them via `kubectl set env --from=secret/...` against a Secret that contains both keys, and track the chart update.
+
+Apply with `helm upgrade` (or let Flux reconcile). The release rolls the `butler-console-server` Deployment and the new OIDC provider is built at startup.
 
 Verify the provider is now advertised:
 
@@ -256,15 +303,15 @@ butleradm idp get company-sso
 ```
 
 :::tip Console UI path
-`Admin → Identity Providers → Create`. The form writes the `IdentityProvider` CRD. **This does not by itself enable SSO**; the env vars above are the switch. Create the CRD here if you want a record for group-sync rules or UI visibility.
+`Admin → Identity Providers → Create` writes the `IdentityProvider` CRD. The env vars above remain the switch that activates SSO.
 :::
 
 :::tip GitOps path
-The env var configuration belongs in the `butler-console` chart values in your Flux repo (`server.env`/`server.envFrom` depending on chart version). The `IdentityProvider` CRD is a separate manifest that Flux reconciles independently. Run the client secret through SOPS or your secret-management layer before commit.
+Chart values block plus the optional `IdentityProvider` manifest, committed to your Flux repo. Run the `client-secret` through SOPS or your secret-management layer before commit.
 :::
 
-:::note Current gap
-The `IdentityProvider` CRD exists as a data model, but `butler-server` does not read it into its running OIDC provider; the provider is built from env vars once at startup. For SSO to be active, env vars are required. Provider-specific reference pages (Google Workspace Admin SDK, Microsoft Entra, Okta) are tracked separately and are not yet published.
+:::note Roadmap
+Reconciliation of `IdentityProvider` CRDs into the running server is tracked at [butlerdotdev/butler#21](https://github.com/butlerdotdev/butler/issues/21). Today the env var path is the supported configuration mechanism. Provider-specific reference pages (Google Workspace Admin SDK, Microsoft Entra, Okta) are tracked separately and are not yet published.
 :::
 
 ## 4. Create Your Admin User
@@ -272,7 +319,7 @@ The `IdentityProvider` CRD exists as a data model, but `butler-server` does not 
 Bootstrap creates two things you can authenticate as:
 
 1. A legacy admin session sourced from `BUTLER_ADMIN_USERNAME` and `BUTLER_ADMIN_PASSWORD` on the `butler-console-server` Deployment. The password is generated and stored in the `butler-console-admin` Secret.
-2. A `User` resource named `admin` with `spec.authType: internal` and `spec.isPlatformAdmin: true`. This is a real CRD record tied to the legacy credentials.
+2. A `User` resource named `admin` with `spec.authType: internal` and `spec.isPlatformAdmin: true`. The CRD mirrors the bootstrap admin's identity (email `admin@localhost`) but does not reference the legacy password Secret; password authentication as `admin` goes through the legacy env-var code path, not through the CRD.
 
 Either way, you should log in once as the bootstrap admin, create a real user for yourself, then retire the legacy credentials.
 
@@ -320,7 +367,13 @@ The response body is `{"inviteUrl":"..."}`. Send the URL to the user; it's one-t
 
 ### Retire the legacy admin
 
-Once your real account works, remove the legacy credentials from the Deployment:
+:::danger Do not run this until your replacement admin works
+Do not strip the legacy credentials until you have signed in successfully as your replacement admin (Option A or Option B above). The `admin` User CRD cannot be authenticated against after env vars are stripped; it has no referenced password Secret, and the `/api/admin/users/admin/invite` endpoint requires an existing session cookie that the stripped admin can no longer mint. If your replacement account does not work, stripping the env vars will lock you out of the cluster with no in-band recovery path.
+
+Confirm the replacement works by signing in fully (console or `butlerctl login`) before running any of the commands below.
+:::
+
+Once your replacement account is verified working, remove the legacy credentials from the Deployment:
 
 ```bash
 kubectl -n butler-system set env deployment/butler-console-server \
@@ -336,15 +389,15 @@ kubectl delete user admin
 ```
 
 :::tip Console UI path
-`Admin → Users` lists users and exposes `Add New User` (which creates the same `User` CRD that `butleradm user create` does) and `Resend Invite` per row (which calls `POST /api/admin/users/{name}/invite` and shows the one-time URL in a modal). No curl or cookie juggling required. Promoting a user to platform admin is not a UI toggle today and requires `kubectl patch` as shown above.
+`Admin → Users`. `Add New User` creates the `User` CRD and opens an invite-URL modal. `Resend Invite` on an existing row calls `POST /api/admin/users/{name}/invite`. Platform-admin promotion is not a UI toggle today; use the `kubectl patch` shown above.
 :::
 
 :::tip GitOps path (partial)
-You can commit `User` CRDs to your Flux repo and let Flux create them, but the invite URL is minted at claim time by `butler-server` and is not part of CRD state. For password-based users the workflow stays: Flux creates the `User`, then an operator regenerates the invite URL via the UI or API and delivers it to the user. SSO users bypass this entirely; they're auto-created on first login.
+Commit `User` CRDs to your Flux repo. The invite URL itself is minted at claim time by `butler-server` and is not part of CRD state; operators still regenerate it via UI or API per user.
 :::
 
 :::note
-The invite URL is constructed from `BUTLER_BASE_URL` captured by the server at startup. This predates the device-flow request-based URL derivation and is a known structural pattern that will migrate to per-request derivation in a future change.
+The invite URL is built from `BUTLER_BASE_URL` captured at server startup. Migrating it to per-request derivation is tracked as a follow-up to the butler-server v0.5.5 device-flow fix.
 :::
 
 ## 5. Tune `ButlerConfig`
@@ -369,11 +422,11 @@ Fields worth reviewing:
 Apply changes with `kubectl apply` or `kubectl edit`; the controller reconciles in seconds.
 
 :::tip Console UI path
-`Admin → Settings`. The page has sections for general settings (multi-tenancy mode, default namespace, default provider), control plane exposure, default addon versions, default team limits, default control plane resources, image factory, audit log, notifications, and the platform SSH authorized key. The console writes back to the same `ButlerConfig` singleton; there's no drift between the two paths.
+`Admin → Settings`. Sections cover general settings, control plane exposure, default addon versions, default team limits, default control plane resources, image factory, audit log, notifications, and the platform SSH authorized key. Writes back to the same singleton.
 :::
 
 :::tip GitOps path
-The `ButlerConfig` resource is cluster-scoped and named `butler`. Commit the full resource to your Flux repo (for example `platform/butlerconfig.yaml`). Flux reconciles it in place. Because this is a singleton, avoid `kubectl edit` on live clusters under Flux management; the edit will be reverted on reconcile.
+Commit the `ButlerConfig` singleton (cluster-scoped, named `butler`) to your Flux repo. Avoid `kubectl edit` on Flux-managed clusters; edits are reverted on reconcile.
 :::
 
 ## 6. Verify

--- a/docs/getting-started/post-bootstrap.md
+++ b/docs/getting-started/post-bootstrap.md
@@ -20,11 +20,13 @@ The bootstrap installs `butler-console-server` with a `Service` of type `Cluster
 
 ### DNS
 
-Create an A or CNAME record that points `console.yourdomain` at the ingress LoadBalancer IP. If you configured `loadBalancerPool` during bootstrap, the ingress controller has already received an IP from that pool:
+Create an A or CNAME record that points `console.yourdomain` at the ingress LoadBalancer IP. If you configured `loadBalancerPool` during bootstrap, the ingress controller has already received an IP from that pool. The ingress installed by default is Traefik, in the `traefik` namespace:
 
 ```bash
-kubectl get svc -n kube-system traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+kubectl get svc -n traefik traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
 ```
+
+If you chose a different ingress controller during bootstrap, substitute the namespace and Service name.
 
 If you plan to expose tenant-cluster API servers on shared ingress later, also create a wildcard record `*.k8s.yourdomain` pointing at the same IP.
 
@@ -137,26 +139,9 @@ Note the issuer URL, client ID, and client secret. Google Workspace additionally
 
 ### Apply the IdentityProvider
 
+The Secret lives in the same namespace as the IdentityProvider (cluster-scoped resources look up referenced Secrets in `butler-system` by default; set `spec.oidc.clientSecretRef.namespace` explicitly if you store it elsewhere). The Secret must have a key named `client-secret`.
+
 ```yaml
-apiVersion: butler.butlerlabs.dev/v1alpha1
-kind: IdentityProvider
-metadata:
-  name: company-sso
-spec:
-  displayName: "Company SSO"
-  issuerURL: https://login.microsoftonline.com/<tenant-id>/v2.0
-  clientID: <from-idp>
-  clientSecretRef:
-    name: company-sso-secret
-    key: client-secret
-  scopes:
-    - openid
-    - profile
-    - email
-    - groups
-  groupsClaim: groups
-  emailClaim: email
----
 apiVersion: v1
 kind: Secret
 metadata:
@@ -165,45 +150,74 @@ metadata:
 type: Opaque
 stringData:
   client-secret: <from-idp>
+---
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: IdentityProvider
+metadata:
+  name: company-sso
+spec:
+  type: oidc
+  displayName: "Company SSO"
+  oidc:
+    issuerURL: https://login.microsoftonline.com/<tenant-id>/v2.0
+    clientID: <from-idp>
+    clientSecretRef:
+      name: company-sso-secret
+    scopes:
+      - openid
+      - profile
+      - email
+      - groups
+    groupsClaim: groups
+    emailClaim: email
 ```
 
-Provider-specific references:
-
-- [Google Workspace (Admin SDK + OIDC)](../reference/sso-google.md)
-- [Microsoft Entra (Azure AD)](../reference/sso-entra.md)
-- [Okta](../reference/sso-okta.md)
-
-After applying, test discovery:
+After applying, confirm the resource is accepted:
 
 ```bash
-butleradm idp test company-sso
+butleradm idp get company-sso
 ```
 
-The server picks up new IdentityProviders without a restart.
+The server picks up new IdentityProviders without a restart. Provider-specific guides (Google Workspace with Admin SDK group fetching, Microsoft Entra, Okta) are tracked as separate reference pages and are not yet published.
 
 ## 4. Create Your Admin User
 
-The bootstrap creates a legacy admin account from `BUTLER_ADMIN_USERNAME` and `BUTLER_ADMIN_PASSWORD`. Use it once to create a real `User` resource for yourself, then rotate or disable the legacy account.
+The bootstrap creates a legacy admin account from `BUTLER_ADMIN_USERNAME` and `BUTLER_ADMIN_PASSWORD`. Use it once to create a real `User` resource for yourself, then retire the legacy account.
 
 ### Option A: SSO user
 
-If you configured SSO in the previous step, log in to the console at `https://console.yourdomain` using SSO. Butler auto-creates a `User` for you on first login. Then grant platform admin:
+If you configured SSO in the previous step, log in to the console at `https://console.yourdomain` using SSO. Butler auto-creates a `User` resource for you on first login (name derived from your email, `spec.authType: sso`). Then promote that user to platform admin with `kubectl`:
 
 ```bash
-butleradm user promote <your-email> --platform-admin
+# Resource names use the email local part plus a hash suffix.
+# List to find yours, then patch it.
+kubectl get users
+kubectl patch user <resource-name> --type=merge \
+  -p '{"spec":{"isPlatformAdmin":true}}'
 ```
+
+A dedicated `butleradm user promote` command is on the roadmap; until it lands, the `kubectl patch` path above is the supported workflow.
 
 ### Option B: Internal user (password)
 
+Create the User CRD via the CLI:
+
 ```bash
-butleradm user invite admin@yourdomain --platform-admin
+butleradm user create --email admin@yourdomain --admin
 ```
 
-The command prints a one-time invite URL. Open it in a browser, set a password, and sign in.
+The CLI creates the resource with `spec.isPlatformAdmin: true`. It does not itself mint the password-set invite URL. To get the invite URL, call the console's admin endpoint with the legacy admin credentials (the console UI exposes this as a "Regenerate invite" action per user):
+
+```bash
+curl -u admin:<legacy-password> \
+  -X POST https://console.yourdomain/api/admin/users/<resource-name>/regenerate-invite
+```
+
+The response body contains the one-time URL. Send it to the user. They open it in a browser, set a password, and sign in.
 
 ### Retire the legacy admin
 
-Once your real account works, remove or rotate the legacy credentials in the Deployment:
+Once your real account works, remove the legacy credentials from the Deployment:
 
 ```bash
 kubectl set env deployment/butler-console-server -n butler-system \
@@ -224,11 +238,12 @@ Fields worth reviewing:
 
 | Field | Default | Notes |
 |---|---|---|
-| `spec.multiTenancyMode` | `Optional` | Set to `Enforced` to require every `TenantCluster` to belong to a `Team` with quota enforcement. |
-| `spec.defaultProvider` | (unset) | Sets the default `ProviderConfig` for new tenant clusters that do not specify one. |
-| `spec.teamLimits` | (unset) | Platform-wide per-team caps on CPU, memory, storage, and cluster count. |
-| `spec.defaultControlPlaneResources` | bootstrap defaults | Default CPU and memory for `TenantControlPlane` apiserver, controller-manager, and scheduler pods. |
-| `spec.controlPlaneExposure` | `LoadBalancer` | How tenant API servers are reached. `Ingress` or `Gateway` modes share a single IP. |
+| `spec.multiTenancy.mode` | `Disabled` | Set to `Optional` to allow `TenantCluster` resources to attach to a `Team` but not require it. Set to `Enforced` to require every cluster to belong to a `Team` with quota enforcement. |
+| `spec.defaultNamespace` | `butler-tenants` | Namespace for TenantClusters in `Disabled` or `Optional` mode when no Team is specified. |
+| `spec.defaultProviderConfigRef` | (unset) | References the default `ProviderConfig` for new tenant clusters that do not specify one. |
+| `spec.defaultTeamLimits` | (unset) | Platform-wide per-Team defaults (`maxClusters`, `maxWorkersPerCluster`). Admins can override per Team. |
+| `spec.defaultControlPlaneResources` | bootstrap defaults | Default CPU and memory for `TenantControlPlane` apiserver, controller-manager, and scheduler pods. If unset, pods run BestEffort QoS. |
+| `spec.controlPlaneExposure` | set by bootstrap | How tenant API servers are reached. `LoadBalancer` gives each tenant its own IP; `Ingress` or `Gateway` share one IP across tenants via SNI. |
 
 Apply changes with `kubectl apply` or `kubectl edit`; the controller reconciles in seconds.
 
@@ -283,6 +298,7 @@ With the platform reachable, authenticated, and tuned:
 | Session cookie not persisted after login | `BUTLER_SECURE_COOKIES` is `true` but the connection to the browser is HTTP. Terminate TLS before the request reaches the server. |
 | OIDC callback returns "invalid redirect URI" | The OAuth client in your IdP is registered with a different callback URL than the server advertises. Must be exactly `https://<BUTLER_BASE_URL>/api/auth/callback`. |
 | Certificate stuck in `Pending` | `kubectl describe certificate butler-console-tls -n butler-system`. Check the cert-manager logs and the `ClusterIssuer` status. |
-| `butleradm user invite` fails with "server misconfigured" | `BUTLER_BASE_URL` is unset and the command runs outside a request context. Set it via step 2 and retry. |
+| `butleradm user create` succeeds but the user has no way to set a password | The CLI only creates the User resource; the invite URL comes from the server's `/api/admin/users/{name}/regenerate-invite` endpoint. See section 4. |
+| `/api/admin/users/.../regenerate-invite` returns `server misconfigured: cannot determine public URL` | `BUTLER_BASE_URL` is unset. Set it in step 2. |
 
 See [Troubleshooting](../troubleshooting/) for broader platform issues.

--- a/docs/getting-started/post-bootstrap.md
+++ b/docs/getting-started/post-bootstrap.md
@@ -5,7 +5,7 @@ sidebar_position: 7
 
 # Post-Bootstrap Configuration
 
-After `butleradm bootstrap` finishes, the management cluster runs but is not yet reachable from outside the cluster network, has no TLS, and has only a legacy admin account. Work through the sections below before inviting users or creating tenant clusters.
+After `butleradm bootstrap` finishes, the management cluster runs but is not yet reachable from outside the cluster network, has no TLS, and has only the bootstrap-generated admin credentials (a legacy admin env pair on `butler-console-server` plus a backing `User` CRD named `admin`). Work through the sections below before inviting users or creating tenant clusters.
 
 Every step on this page runs against the management cluster's kubeconfig:
 
@@ -28,8 +28,8 @@ Which paths each step supports:
 |---|---|---|---|
 | 1. Expose the console | yes | no (infrastructure, not platform state) | yes |
 | 2. Configure `butler-server` env | yes | no (server config, not a CRD) | yes, via Helm values |
-| 3. Configure SSO | yes | yes (`Admin → Identity Providers`) | yes |
-| 4. Create admin user + invite | yes | yes (`Admin → Users → Regenerate invite`) | partial, see step 4 |
+| 3. Configure SSO | yes (env vars on `butler-console-server`) | partial (`Admin → Identity Providers` writes the CRD but does not set env vars; see step 3) | yes (chart values + CRD manifest) |
+| 4. Create admin user + invite | yes | yes (`Admin → Users`, then `Resend Invite` on an existing row or the modal shown on create) | partial, see step 4 |
 | 5. Tune `ButlerConfig` | yes | yes (`Admin → Settings`) | yes |
 | 6. Verify | `butlerctl login` + curl | browser to `https://console.yourdomain` | not applicable |
 
@@ -65,9 +65,9 @@ Bootstrap installs Traefik as the default ingress controller in the `traefik` na
 kubectl -n traefik get svc traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
 ```
 
-Create an A or CNAME record pointing `console.yourdomain` at that IP. If you plan to expose tenant-cluster API servers via shared ingress later, also create a wildcard `*.k8s.yourdomain` pointing at the same IP.
+Create an A or CNAME record pointing `console.yourdomain` at that IP. If you plan to expose tenant-cluster API servers via shared ingress later (the `Ingress` mode of `ButlerConfig.spec.controlPlaneExposure`), also create a wildcard `*.k8s.yourdomain` pointing at the same IP.
 
-If you chose a different ingress controller during bootstrap, substitute its namespace and Service name; the Ingress `ingressClassName` must match.
+Bootstrap installs Traefik unconditionally today; the ingress controller is not configurable from the bootstrap config. Swapping to a different controller post-install is possible but out of scope for this guide.
 
 ### TLS certificate
 
@@ -149,7 +149,7 @@ kubectl rollout status deployment/butler-console-server -n butler-system
 ```
 
 :::warning
-Only set `BUTLER_TRUST_PROXY_HEADERS=true` when you are confident the ingress strips client-supplied `X-Forwarded-*` headers and sets its own. Traefik, nginx-ingress, and Envoy do this by default. Verify by curling the ingress from outside the cluster with a spoofed `X-Forwarded-Host` header and checking the access log on the ingress pod.
+Only set `BUTLER_TRUST_PROXY_HEADERS=true` when you are confident the ingress strips client-supplied `X-Forwarded-*` headers and sets its own. Traefik, nginx-ingress, and Envoy can all be configured to do this; check your deployment's forwarded-headers settings (for example, nginx-ingress `use-forwarded-headers` defaults to `false`, which has the effect of ignoring upstream values and writing its own; Traefik requires explicit trusted-IP configuration on the entrypoint). Verify by curling the ingress from outside the cluster with a spoofed `X-Forwarded-Host` header and checking the access log or the response on the ingress pod.
 :::
 
 :::tip GitOps path
@@ -162,7 +162,12 @@ These are env vars on the `butler-console-server` Deployment, which is Helm-mana
 
 ## 3. Configure SSO
 
-Butler supports OIDC (Google Workspace, Microsoft Entra, Okta, Keycloak, and any standards-compliant provider). Create an `IdentityProvider` CRD and register the callback URL with your IdP.
+Butler supports OIDC (Google Workspace, Microsoft Entra, Okta, Keycloak, and any standards-compliant provider). There are two related pieces you may need to configure:
+
+- **`butler-console-server` environment variables**: the server builds its OIDC provider from `BUTLER_OIDC_*` env vars once at startup. These drive the active SSO login flow.
+- **`IdentityProvider` CRD**: a cluster-scoped record used by the Teams handler to validate `identityProvider: <name>` references in group-sync rules, and displayed in the console's admin UI. It is not read by the auth code path today; creating one does not enable SSO on its own.
+
+Enabling SSO means setting env vars. Creating the CRD is optional and only necessary if you plan to reference a named IdP from `Team.spec.access.groups` group-sync rules.
 
 ### Register the OIDC client with your IdP
 
@@ -174,9 +179,41 @@ https://console.yourdomain/api/auth/callback
 
 Note the issuer URL, client ID, and client secret. Google Workspace additionally requires an Admin SDK service account for group fetching (groups are not in Google OIDC tokens).
 
-### Apply the IdentityProvider
+### Set the OIDC environment variables on `butler-console-server`
 
-The Secret lives in the same namespace as the IdentityProvider (cluster-scoped resources look up referenced Secrets in `butler-system` by default; set `spec.oidc.clientSecretRef.namespace` explicitly if you store it elsewhere). The Secret must have a key named `client-secret`.
+Store the client secret in a Secret and reference it from the Deployment rather than baking it into the env literal. The example below uses a Secret + `envFrom` on the Helm-managed chart; if you are editing the live Deployment, use `kubectl set env --from=secret/...` for the client secret and plain `--env` for the others.
+
+```bash
+kubectl -n butler-system create secret generic butler-oidc \
+  --from-literal=BUTLER_OIDC_CLIENT_SECRET='<from-idp>'
+
+kubectl -n butler-system set env deployment/butler-console-server \
+  BUTLER_OIDC_ENABLED=true \
+  BUTLER_OIDC_ISSUER_URL=https://accounts.google.com \
+  BUTLER_OIDC_CLIENT_ID='<from-idp>' \
+  BUTLER_OIDC_REDIRECT_URL=https://console.yourdomain/api/auth/callback \
+  BUTLER_OIDC_GROUPS_CLAIM=groups \
+  BUTLER_OIDC_EMAIL_CLAIM=email
+
+kubectl -n butler-system set env deployment/butler-console-server \
+  --from=secret/butler-oidc
+
+kubectl -n butler-system rollout restart deployment/butler-console-server
+```
+
+Google Workspace only: add `GOOGLE_SERVICE_ACCOUNT_JSON` (the service account key JSON) and `GOOGLE_ADMIN_EMAIL` (an admin user for domain-wide delegation) so `butler-server` can fetch groups via the Admin SDK.
+
+Verify the provider is now advertised:
+
+```bash
+curl -sS https://console.yourdomain/api/auth/providers | jq .providers
+```
+
+Expect an entry with your configured provider (for example `[{"name":"Google","type":"oidc",...}]`). An empty array means the env vars did not land or the rollout did not complete.
+
+### Optional: create the IdentityProvider CRD
+
+Create this only if you plan to use group-sync rules that name this provider. The CRD is reconciled by the console's admin CRUD handlers; the auth code path does not consume it today.
 
 ```yaml
 apiVersion: v1
@@ -196,7 +233,7 @@ spec:
   type: oidc
   displayName: "Company SSO"
   oidc:
-    issuerURL: https://login.microsoftonline.com/<tenant-id>/v2.0
+    issuerURL: https://accounts.google.com
     clientID: <from-idp>
     clientSecretRef:
       name: company-sso-secret
@@ -210,23 +247,25 @@ spec:
     emailClaim: email
 ```
 
-`spec.oidc.redirectURL` is required and must match the callback URL registered with your IdP exactly. `spec.oidc.clientSecretRef.namespace` is optional and defaults to `butler-system`.
+`spec.oidc.redirectURL` is a required field on the CRD schema. `spec.oidc.clientSecretRef.namespace` is optional; when unset, the admin handlers resolve the Secret in `butler-system` (`config.SystemNamespace`).
 
-:::tip Console UI path
-`Admin → Identity Providers → Create`. The form accepts the same fields shown above (type, issuer URL, client ID, client secret, redirect URL, scopes, claim mappings). The console writes the same `IdentityProvider` CRD. Use this path for ongoing changes once the console is reachable.
-:::
-
-:::tip GitOps path
-Commit both the `Secret` and the `IdentityProvider` YAML to your Flux repo (for example `platform/identity-providers/company-sso.yaml`). Run the `client-secret` value through SOPS or your secret-management layer before commit. Flux reconciles the CRD exactly as `kubectl apply` would.
-:::
-
-After applying, confirm the resource is accepted:
+Confirm the resource was accepted:
 
 ```bash
 butleradm idp get company-sso
 ```
 
-The server picks up new IdentityProviders without a restart. Provider-specific guides (Google Workspace with Admin SDK group fetching, Microsoft Entra, Okta) are tracked as separate reference pages and are not yet published.
+:::tip Console UI path
+`Admin → Identity Providers → Create`. The form writes the `IdentityProvider` CRD. **This does not by itself enable SSO**; the env vars above are the switch. Create the CRD here if you want a record for group-sync rules or UI visibility.
+:::
+
+:::tip GitOps path
+The env var configuration belongs in the `butler-console` chart values in your Flux repo (`server.env`/`server.envFrom` depending on chart version). The `IdentityProvider` CRD is a separate manifest that Flux reconciles independently. Run the client secret through SOPS or your secret-management layer before commit.
+:::
+
+:::note Current gap
+The `IdentityProvider` CRD exists as a data model, but `butler-server` does not read it into its running OIDC provider; the provider is built from env vars once at startup. For SSO to be active, env vars are required. Provider-specific reference pages (Google Workspace Admin SDK, Microsoft Entra, Okta) are tracked separately and are not yet published.
+:::
 
 ## 4. Create Your Admin User
 
@@ -257,7 +296,7 @@ Create the User CRD:
 butleradm user create --email admin@yourdomain --admin
 ```
 
-The CLI creates the resource with `spec.isPlatformAdmin: true` but does not mint the password-set invite URL. The easiest way to get one is through the console UI once it's reachable: sign in as the bootstrap `admin`, open the new user's page, and click **Regenerate invite**.
+The CLI creates the resource with `spec.isPlatformAdmin: true` but does not mint the password-set invite URL. The easiest way to get one is through the console UI once it's reachable: sign in as the bootstrap `admin`, go to `Admin → Users`, and click **Resend Invite** on the row for the new user. (When creating a user through the console, the invite URL is shown in a modal immediately after creation; `Resend Invite` is how you get a fresh URL for an already-created user.)
 
 If the console UI is not reachable yet, do it via the HTTP API. The invite endpoint requires a session cookie, so log in first, then call it:
 
@@ -290,10 +329,14 @@ kubectl -n butler-system set env deployment/butler-console-server \
 kubectl -n butler-system rollout restart deployment/butler-console-server
 ```
 
-The `User` CRD named `admin` remains; delete it separately if you don't want to keep it as a break-glass internal account.
+The `User` CRD named `admin` remains after the env vars are removed, but it has no password and no referenced password Secret; nobody can authenticate as it until an invite is regenerated for it and a password is set. Delete it if you do not want it sitting dormant:
+
+```bash
+kubectl delete user admin
+```
 
 :::tip Console UI path
-`Admin → Users → Create`. The form produces the same `User` CRD that `butleradm user create` does. Each user row has a `Regenerate invite` action that calls `POST /api/admin/users/{name}/invite` and shows the one-time URL in the UI; no curl or cookie juggling required. For SSO users, the same page offers a toggle for `isPlatformAdmin`.
+`Admin → Users` lists users and exposes `Add New User` (which creates the same `User` CRD that `butleradm user create` does) and `Resend Invite` per row (which calls `POST /api/admin/users/{name}/invite` and shows the one-time URL in a modal). No curl or cookie juggling required. Promoting a user to platform admin is not a UI toggle today and requires `kubectl patch` as shown above.
 :::
 
 :::tip GitOps path (partial)
@@ -384,9 +427,10 @@ With the platform reachable, authenticated, and tuned:
 | CLI verification URL shows `localhost:8080` | `BUTLER_BASE_URL` is unset or pods have not restarted since you set it. |
 | CLI verification URL uses `http://` despite a TLS ingress | `BUTLER_TRUST_PROXY_HEADERS` is not `true`, or the ingress is not forwarding `X-Forwarded-Proto`. |
 | Session cookie not persisted after login | `BUTLER_SECURE_COOKIES` is `true` but the connection to the browser is HTTP. Terminate TLS before the request reaches the server. |
-| OIDC callback returns "invalid redirect URI" | The OAuth client in your IdP is registered with a different callback URL than the server advertises. Must be exactly `https://<BUTLER_BASE_URL>/api/auth/callback`. |
+| OIDC callback returns "invalid redirect URI" | The OAuth client in your IdP is registered with a different callback URL than `BUTLER_OIDC_REDIRECT_URL`. Match them exactly; the path is `/api/auth/callback` on your public hostname. |
+| Configured an `IdentityProvider` CRD but SSO login button still missing | The CRD does not drive auth today. Set the `BUTLER_OIDC_*` env vars on `butler-console-server` and roll the Deployment (step 3). |
 | Certificate stuck in `Pending` | `kubectl describe certificate butler-console-tls -n butler-system`. Check the cert-manager logs and the `ClusterIssuer` status. |
-| `butleradm user create` succeeds but the user has no way to set a password | The CLI only creates the User resource; the invite URL comes from the server's `/api/admin/users/{name}/invite` endpoint (the Regenerate invite button in the console). See section 4. |
+| `butleradm user create` succeeds but the user has no way to set a password | The CLI only creates the User resource; the invite URL comes from the server's `/api/admin/users/{name}/invite` endpoint (the `Resend Invite` button in the console, or the modal shown on create). See section 4. |
 | `/api/admin/users/.../invite` returns `unauthorized` | The endpoint requires a session cookie, not HTTP basic auth. Log in first via `POST /api/auth/login` with `{"username":...,"password":...}` and reuse the `butler_session` cookie. |
 | `/api/admin/users/.../invite` returns an invite URL pointing at localhost | `BUTLER_BASE_URL` is unset on the server. The invite URL is constructed at server startup from this value. Set it per step 2 and roll the Deployment. |
 

--- a/docs/getting-started/post-bootstrap.md
+++ b/docs/getting-started/post-bootstrap.md
@@ -16,23 +16,41 @@ kubectl get nodes
 
 ## 1. Expose the Console
 
-The bootstrap installs `butler-console-server` with a `Service` of type `ClusterIP`. You expose it through the ingress controller that bootstrap installs (Traefik by default) with a matching DNS record and TLS certificate.
+Bootstrap already installs an Ingress for the console. You change its host to one you own, add TLS, and create a DNS record pointing at the ingress controller's LoadBalancer IP.
+
+### What bootstrap installed
+
+Inspect the Ingress the bootstrap controller created:
+
+```bash
+kubectl -n butler-system get ingress butler-console -o yaml
+```
+
+Expect a resource with `ingressClassName: traefik`, a placeholder host matching your cluster name (for example `butler.butler-hvstr-test.local`), and three path rules:
+
+| Path | Backend Service | Purpose |
+|---|---|---|
+| `/api` | `butler-console-server:8080` | REST API |
+| `/ws` | `butler-console-server:8080` | Terminal and cluster-watch WebSocket |
+| `/` | `butler-console-frontend:80` | Static web UI |
+
+Do not delete this Ingress and create a new one. Do not create a second Ingress that overlaps. Edit the existing resource in place.
 
 ### DNS
 
-Create an A or CNAME record that points `console.yourdomain` at the ingress LoadBalancer IP. If you configured `loadBalancerPool` during bootstrap, the ingress controller has already received an IP from that pool. The ingress installed by default is Traefik, in the `traefik` namespace:
+Bootstrap installs Traefik as the default ingress controller in the `traefik` namespace. Its LoadBalancer IP comes from the MetalLB pool declared in `network.loadBalancerPool` (typically the first IP of the pool):
 
 ```bash
-kubectl get svc -n traefik traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+kubectl -n traefik get svc traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
 ```
 
-If you chose a different ingress controller during bootstrap, substitute the namespace and Service name.
+Create an A or CNAME record pointing `console.yourdomain` at that IP. If you plan to expose tenant-cluster API servers via shared ingress later, also create a wildcard `*.k8s.yourdomain` pointing at the same IP.
 
-If you plan to expose tenant-cluster API servers on shared ingress later, also create a wildcard record `*.k8s.yourdomain` pointing at the same IP.
+If you chose a different ingress controller during bootstrap, substitute its namespace and Service name; the Ingress `ingressClassName` must match.
 
 ### TLS certificate
 
-`cert-manager` is installed during bootstrap. Create a `ClusterIssuer` and an `Ingress` that references it. The example below uses Let's Encrypt HTTP-01:
+`cert-manager` is installed during bootstrap in the `cert-manager` namespace. It does not ship with a `ClusterIssuer` by default; create one first:
 
 ```yaml
 apiVersion: cert-manager.io/v1
@@ -49,49 +67,31 @@ spec:
       - http01:
           ingress:
             ingressClassName: traefik
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: butler-console
-  namespace: butler-system
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-spec:
-  ingressClassName: traefik
-  rules:
-    - host: console.yourdomain
-      http:
-        paths:
-          - path: /api
-            pathType: Prefix
-            backend:
-              service:
-                name: butler-console-server
-                port:
-                  number: 8080
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: butler-console-frontend
-                port:
-                  number: 80
-  tls:
-    - hosts:
-        - console.yourdomain
-      secretName: butler-console-tls
 ```
 
-The console ships as two Deployments: a static frontend (`butler-console-frontend`) and the API server (`butler-console-server`). The Ingress routes `/api` to the server and everything else to the frontend. If you prefer to manage the Ingress through Helm, the `butler-console` chart exposes equivalent `ingress.*` values.
+For air-gapped or internal-only deployments, replace the `ClusterIssuer` body with `selfSigned: {}` and skip the solver.
 
-For air-gapped or internal-only deployments, replace the `ClusterIssuer` with a self-signed issuer and skip the `http01` solver.
+### Update the Ingress host and TLS
 
-Wait for the certificate to be ready before continuing:
+Patch the bootstrap-created Ingress to use your real hostname and reference the `ClusterIssuer`. This preserves the `/api`, `/ws`, and `/` path rules:
 
 ```bash
-kubectl get certificate -n butler-system butler-console-tls -w
+kubectl -n butler-system annotate ingress butler-console \
+  cert-manager.io/cluster-issuer=letsencrypt-prod --overwrite
+
+kubectl -n butler-system patch ingress butler-console --type=json -p='[
+  {"op":"replace","path":"/spec/rules/0/host","value":"console.yourdomain"},
+  {"op":"add","path":"/spec/tls","value":[{"hosts":["console.yourdomain"],"secretName":"butler-console-tls"}]}
+]'
 ```
+
+Wait for the certificate to issue before continuing:
+
+```bash
+kubectl -n butler-system get certificate butler-console-tls -w
+```
+
+If you manage the install with Helm, set `ingress.hosts[0].host`, `ingress.tls`, and `ingress.annotations` in the chart values instead of patching the Ingress directly.
 
 ## 2. Configure `butler-server` for the Public URL
 
@@ -163,6 +163,7 @@ spec:
     clientID: <from-idp>
     clientSecretRef:
       name: company-sso-secret
+    redirectURL: https://console.yourdomain/api/auth/callback
     scopes:
       - openid
       - profile
@@ -171,6 +172,8 @@ spec:
     groupsClaim: groups
     emailClaim: email
 ```
+
+`spec.oidc.redirectURL` is required and must match the callback URL registered with your IdP exactly. `spec.oidc.clientSecretRef.namespace` is optional and defaults to `butler-system`.
 
 After applying, confirm the resource is accepted:
 
@@ -182,49 +185,67 @@ The server picks up new IdentityProviders without a restart. Provider-specific g
 
 ## 4. Create Your Admin User
 
-The bootstrap creates a legacy admin account from `BUTLER_ADMIN_USERNAME` and `BUTLER_ADMIN_PASSWORD`. Use it once to create a real `User` resource for yourself, then retire the legacy account.
+Bootstrap creates two things you can authenticate as:
+
+1. A legacy admin session sourced from `BUTLER_ADMIN_USERNAME` and `BUTLER_ADMIN_PASSWORD` on the `butler-console-server` Deployment. The password is generated and stored in the `butler-console-admin` Secret.
+2. A `User` resource named `admin` with `spec.authType: internal` and `spec.isPlatformAdmin: true`. This is a real CRD record tied to the legacy credentials.
+
+Either way, you should log in once as the bootstrap admin, create a real user for yourself, then retire the legacy credentials.
 
 ### Option A: SSO user
 
-If you configured SSO in the previous step, log in to the console at `https://console.yourdomain` using SSO. Butler auto-creates a `User` resource for you on first login (name derived from your email, `spec.authType: sso`). Then promote that user to platform admin with `kubectl`:
+If you configured SSO in the previous step, log in to the console at `https://console.yourdomain` using SSO. Butler auto-creates a `User` resource for you on first login (name derived from your email, `spec.authType: sso`). Then promote that user to platform admin:
 
 ```bash
-# Resource names use the email local part plus a hash suffix.
-# List to find yours, then patch it.
 kubectl get users
 kubectl patch user <resource-name> --type=merge \
   -p '{"spec":{"isPlatformAdmin":true}}'
 ```
 
-A dedicated `butleradm user promote` command is on the roadmap; until it lands, the `kubectl patch` path above is the supported workflow.
+A dedicated `butleradm user promote` command is roadmap-tracked; until it lands, the `kubectl patch` path above is the supported workflow.
 
 ### Option B: Internal user (password)
 
-Create the User CRD via the CLI:
+Create the User CRD:
 
 ```bash
 butleradm user create --email admin@yourdomain --admin
 ```
 
-The CLI creates the resource with `spec.isPlatformAdmin: true`. It does not itself mint the password-set invite URL. To get the invite URL, call the console's admin endpoint with the legacy admin credentials (the console UI exposes this as a "Regenerate invite" action per user):
+The CLI creates the resource with `spec.isPlatformAdmin: true` but does not mint the password-set invite URL. The easiest way to get one is through the console UI once it's reachable: sign in as the bootstrap `admin`, open the new user's page, and click **Regenerate invite**.
+
+If the console UI is not reachable yet, do it via the HTTP API. The invite endpoint requires a session cookie, so log in first, then call it:
 
 ```bash
-curl -u admin:<legacy-password> \
-  -X POST https://console.yourdomain/api/admin/users/<resource-name>/regenerate-invite
+# Grab the generated bootstrap password
+ADMIN_PASSWORD=$(kubectl -n butler-system get secret butler-console-admin \
+  -o jsonpath='{.data.admin-password}' | base64 -d)
+
+# Log in; persist the butler_session cookie
+curl -sS -c /tmp/butler-cj -X POST \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"admin\",\"password\":\"$ADMIN_PASSWORD\"}" \
+  https://console.yourdomain/api/auth/login
+
+# Request an invite URL for the new user, reusing the cookie
+curl -sS -b /tmp/butler-cj -X POST \
+  https://console.yourdomain/api/admin/users/<resource-name>/invite
 ```
 
-The response body contains the one-time URL. Send it to the user. They open it in a browser, set a password, and sign in.
+The response body is `{"inviteUrl":"..."}`. Send the URL to the user; it's one-time, opens a password-set form, and signs them in afterward.
 
 ### Retire the legacy admin
 
 Once your real account works, remove the legacy credentials from the Deployment:
 
 ```bash
-kubectl set env deployment/butler-console-server -n butler-system \
+kubectl -n butler-system set env deployment/butler-console-server \
   BUTLER_ADMIN_USERNAME- \
   BUTLER_ADMIN_PASSWORD-
-kubectl rollout restart deployment/butler-console-server -n butler-system
+kubectl -n butler-system rollout restart deployment/butler-console-server
 ```
+
+The `User` CRD named `admin` remains; delete it separately if you don't want to keep it as a break-glass internal account.
 
 ## 5. Tune `ButlerConfig`
 
@@ -238,7 +259,7 @@ Fields worth reviewing:
 
 | Field | Default | Notes |
 |---|---|---|
-| `spec.multiTenancy.mode` | `Disabled` | Set to `Optional` to allow `TenantCluster` resources to attach to a `Team` but not require it. Set to `Enforced` to require every cluster to belong to a `Team` with quota enforcement. |
+| `spec.multiTenancy.mode` | `Optional` (bootstrap sets this; CRD-level default if the field is unset is `Disabled`) | `Disabled` means no Team scoping. `Optional` lets `TenantCluster` resources attach to a `Team` but does not require it. `Enforced` requires every cluster to belong to a `Team` with quota enforcement. |
 | `spec.defaultNamespace` | `butler-tenants` | Namespace for TenantClusters in `Disabled` or `Optional` mode when no Team is specified. |
 | `spec.defaultProviderConfigRef` | (unset) | References the default `ProviderConfig` for new tenant clusters that do not specify one. |
 | `spec.defaultTeamLimits` | (unset) | Platform-wide per-Team defaults (`maxClusters`, `maxWorkersPerCluster`). Admins can override per Team. |
@@ -298,7 +319,8 @@ With the platform reachable, authenticated, and tuned:
 | Session cookie not persisted after login | `BUTLER_SECURE_COOKIES` is `true` but the connection to the browser is HTTP. Terminate TLS before the request reaches the server. |
 | OIDC callback returns "invalid redirect URI" | The OAuth client in your IdP is registered with a different callback URL than the server advertises. Must be exactly `https://<BUTLER_BASE_URL>/api/auth/callback`. |
 | Certificate stuck in `Pending` | `kubectl describe certificate butler-console-tls -n butler-system`. Check the cert-manager logs and the `ClusterIssuer` status. |
-| `butleradm user create` succeeds but the user has no way to set a password | The CLI only creates the User resource; the invite URL comes from the server's `/api/admin/users/{name}/regenerate-invite` endpoint. See section 4. |
-| `/api/admin/users/.../regenerate-invite` returns `server misconfigured: cannot determine public URL` | `BUTLER_BASE_URL` is unset. Set it in step 2. |
+| `butleradm user create` succeeds but the user has no way to set a password | The CLI only creates the User resource; the invite URL comes from the server's `/api/admin/users/{name}/invite` endpoint (the Regenerate invite button in the console). See section 4. |
+| `/api/admin/users/.../invite` returns `unauthorized` | The endpoint requires a session cookie, not HTTP basic auth. Log in first via `POST /api/auth/login` with `{"username":...,"password":...}` and reuse the `butler_session` cookie. |
+| `/api/admin/users/.../invite` returns an invite URL pointing at localhost | `BUTLER_BASE_URL` is unset on the server. The invite URL is constructed at server startup from this value. Set it per step 2 and roll the Deployment. |
 
 See [Troubleshooting](../troubleshooting/) for broader platform issues.

--- a/docs/getting-started/post-bootstrap.md
+++ b/docs/getting-started/post-bootstrap.md
@@ -1,0 +1,288 @@
+---
+title: Post-Bootstrap Configuration
+sidebar_position: 7
+---
+
+# Post-Bootstrap Configuration
+
+After `butleradm bootstrap` finishes, the management cluster runs but is not yet reachable from outside the cluster network, has no TLS, and has only a legacy admin account. Work through the sections below before inviting users or creating tenant clusters.
+
+Every step on this page runs against the management cluster's kubeconfig:
+
+```bash
+export KUBECONFIG=~/.butler/<cluster-name>-kubeconfig
+kubectl get nodes
+```
+
+## 1. Expose the Console
+
+The bootstrap installs `butler-console-server` with a `Service` of type `ClusterIP`. You expose it through the ingress controller that bootstrap installs (Traefik by default) with a matching DNS record and TLS certificate.
+
+### DNS
+
+Create an A or CNAME record that points `console.yourdomain` at the ingress LoadBalancer IP. If you configured `loadBalancerPool` during bootstrap, the ingress controller has already received an IP from that pool:
+
+```bash
+kubectl get svc -n kube-system traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+```
+
+If you plan to expose tenant-cluster API servers on shared ingress later, also create a wildcard record `*.k8s.yourdomain` pointing at the same IP.
+
+### TLS certificate
+
+`cert-manager` is installed during bootstrap. Create a `ClusterIssuer` and an `Ingress` that references it. The example below uses Let's Encrypt HTTP-01:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    email: you@yourdomain
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-prod-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: traefik
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: butler-console
+  namespace: butler-system
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: console.yourdomain
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: butler-console-server
+                port:
+                  number: 8080
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: butler-console-frontend
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - console.yourdomain
+      secretName: butler-console-tls
+```
+
+The console ships as two Deployments: a static frontend (`butler-console-frontend`) and the API server (`butler-console-server`). The Ingress routes `/api` to the server and everything else to the frontend. If you prefer to manage the Ingress through Helm, the `butler-console` chart exposes equivalent `ingress.*` values.
+
+For air-gapped or internal-only deployments, replace the `ClusterIssuer` with a self-signed issuer and skip the `http01` solver.
+
+Wait for the certificate to be ready before continuing:
+
+```bash
+kubectl get certificate -n butler-system butler-console-tls -w
+```
+
+## 2. Configure `butler-server` for the Public URL
+
+The server emits its public URL in several places: the CLI device-flow verification link, invite emails, and OIDC callback hints. By default the server derives this URL from the incoming request, but you must still tell it to trust the ingress-supplied forwarded headers.
+
+Set three environment variables on the `butler-console-server` Deployment. If you are managing the install with Helm, set them in the chart values; otherwise edit the Deployment directly:
+
+```bash
+kubectl set env deployment/butler-console-server -n butler-system \
+  BUTLER_BASE_URL=https://console.yourdomain \
+  BUTLER_TRUST_PROXY_HEADERS=true \
+  BUTLER_SECURE_COOKIES=true
+```
+
+| Variable | Value | Reason |
+|---|---|---|
+| `BUTLER_BASE_URL` | `https://console.yourdomain` | Canonical public URL. Used for invite links and as the fallback when request derivation is not possible. |
+| `BUTLER_TRUST_PROXY_HEADERS` | `true` | Tells the server to honor `X-Forwarded-Proto` and `X-Forwarded-Host` set by the ingress. Without this, `https` flows show up as `http` in emitted URLs. |
+| `BUTLER_SECURE_COOKIES` | `true` | Sets the `Secure` flag on session cookies. Required once TLS is active. |
+
+Restart to pick up the new values:
+
+```bash
+kubectl rollout restart deployment/butler-console-server -n butler-system
+kubectl rollout status deployment/butler-console-server -n butler-system
+```
+
+:::warning
+Only set `BUTLER_TRUST_PROXY_HEADERS=true` when you are confident the ingress strips client-supplied `X-Forwarded-*` headers and sets its own. Traefik, nginx-ingress, and Envoy do this by default. Verify by curling the ingress from outside the cluster with a spoofed `X-Forwarded-Host` header and checking the access log on the ingress pod.
+:::
+
+## 3. Configure SSO
+
+Butler supports OIDC (Google Workspace, Microsoft Entra, Okta, Keycloak, and any standards-compliant provider). Create an `IdentityProvider` CRD and register the callback URL with your IdP.
+
+### Register the OIDC client with your IdP
+
+Create an OAuth client in your IdP and set the redirect URL to:
+
+```
+https://console.yourdomain/api/auth/callback
+```
+
+Note the issuer URL, client ID, and client secret. Google Workspace additionally requires an Admin SDK service account for group fetching (groups are not in Google OIDC tokens).
+
+### Apply the IdentityProvider
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: IdentityProvider
+metadata:
+  name: company-sso
+spec:
+  displayName: "Company SSO"
+  issuerURL: https://login.microsoftonline.com/<tenant-id>/v2.0
+  clientID: <from-idp>
+  clientSecretRef:
+    name: company-sso-secret
+    key: client-secret
+  scopes:
+    - openid
+    - profile
+    - email
+    - groups
+  groupsClaim: groups
+  emailClaim: email
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: company-sso-secret
+  namespace: butler-system
+type: Opaque
+stringData:
+  client-secret: <from-idp>
+```
+
+Provider-specific references:
+
+- [Google Workspace (Admin SDK + OIDC)](../reference/sso-google.md)
+- [Microsoft Entra (Azure AD)](../reference/sso-entra.md)
+- [Okta](../reference/sso-okta.md)
+
+After applying, test discovery:
+
+```bash
+butleradm idp test company-sso
+```
+
+The server picks up new IdentityProviders without a restart.
+
+## 4. Create Your Admin User
+
+The bootstrap creates a legacy admin account from `BUTLER_ADMIN_USERNAME` and `BUTLER_ADMIN_PASSWORD`. Use it once to create a real `User` resource for yourself, then rotate or disable the legacy account.
+
+### Option A: SSO user
+
+If you configured SSO in the previous step, log in to the console at `https://console.yourdomain` using SSO. Butler auto-creates a `User` for you on first login. Then grant platform admin:
+
+```bash
+butleradm user promote <your-email> --platform-admin
+```
+
+### Option B: Internal user (password)
+
+```bash
+butleradm user invite admin@yourdomain --platform-admin
+```
+
+The command prints a one-time invite URL. Open it in a browser, set a password, and sign in.
+
+### Retire the legacy admin
+
+Once your real account works, remove or rotate the legacy credentials in the Deployment:
+
+```bash
+kubectl set env deployment/butler-console-server -n butler-system \
+  BUTLER_ADMIN_USERNAME- \
+  BUTLER_ADMIN_PASSWORD-
+kubectl rollout restart deployment/butler-console-server -n butler-system
+```
+
+## 5. Tune `ButlerConfig`
+
+`ButlerConfig` is the cluster-scoped singleton that controls platform-wide defaults. Bootstrap creates it with sensible defaults, but review the values before onboarding teams.
+
+```bash
+kubectl edit butlerconfig butler
+```
+
+Fields worth reviewing:
+
+| Field | Default | Notes |
+|---|---|---|
+| `spec.multiTenancyMode` | `Optional` | Set to `Enforced` to require every `TenantCluster` to belong to a `Team` with quota enforcement. |
+| `spec.defaultProvider` | (unset) | Sets the default `ProviderConfig` for new tenant clusters that do not specify one. |
+| `spec.teamLimits` | (unset) | Platform-wide per-team caps on CPU, memory, storage, and cluster count. |
+| `spec.defaultControlPlaneResources` | bootstrap defaults | Default CPU and memory for `TenantControlPlane` apiserver, controller-manager, and scheduler pods. |
+| `spec.controlPlaneExposure` | `LoadBalancer` | How tenant API servers are reached. `Ingress` or `Gateway` modes share a single IP. |
+
+Apply changes with `kubectl apply` or `kubectl edit`; the controller reconciles in seconds.
+
+## 6. Verify
+
+### Web console
+
+Open `https://console.yourdomain`. Sign in via SSO or the internal admin account you created. You should see the dashboard with the management cluster listed.
+
+### CLI login
+
+```bash
+butlerctl login --server https://console.yourdomain
+```
+
+The command prints a one-time user code and opens your browser to the approval URL. Confirm the code matches, approve, and the CLI reports a successful login:
+
+```
+Logged in as you@yourdomain
+  Teams: ...
+  Active team: ...
+  Credentials saved to ~/.butler/credentials.json
+```
+
+:::tip
+If the verification URL points at `http://localhost:8080` instead of your real URL, step 2 did not take. Check `kubectl set env` ran against the right Deployment and that the pods restarted.
+:::
+
+### Auth endpoint curl
+
+```bash
+curl -sS https://console.yourdomain/healthz
+curl -sS https://console.yourdomain/api/auth/providers | jq
+```
+
+The first returns `ok`; the second lists your configured `IdentityProvider` resources.
+
+## Next Steps
+
+With the platform reachable, authenticated, and tuned:
+
+1. [Create your first tenant cluster](./first-tenant-cluster.md)
+2. [Tour the console](./console.md)
+3. [Day-2 operations](../operations/): upgrades, monitoring, backup, scaling
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| CLI verification URL shows `localhost:8080` | `BUTLER_BASE_URL` is unset or pods have not restarted since you set it. |
+| CLI verification URL uses `http://` despite a TLS ingress | `BUTLER_TRUST_PROXY_HEADERS` is not `true`, or the ingress is not forwarding `X-Forwarded-Proto`. |
+| Session cookie not persisted after login | `BUTLER_SECURE_COOKIES` is `true` but the connection to the browser is HTTP. Terminate TLS before the request reaches the server. |
+| OIDC callback returns "invalid redirect URI" | The OAuth client in your IdP is registered with a different callback URL than the server advertises. Must be exactly `https://<BUTLER_BASE_URL>/api/auth/callback`. |
+| Certificate stuck in `Pending` | `kubectl describe certificate butler-console-tls -n butler-system`. Check the cert-manager logs and the `ClusterIssuer` status. |
+| `butleradm user invite` fails with "server misconfigured" | `BUTLER_BASE_URL` is unset and the command runs outside a request context. Set it via step 2 and retry. |
+
+See [Troubleshooting](../troubleshooting/) for broader platform issues.


### PR DESCRIPTION
## Summary

New `docs/getting-started/post-bootstrap.md` walks operators through the six setup steps that are required after `butleradm bootstrap` completes but that bootstrap itself cannot infer:

1. **Expose the Console** — DNS record, ingress resource, cert-manager ClusterIssuer + TLS cert.
2. **Configure butler-server for the Public URL** — `BUTLER_BASE_URL`, `BUTLER_TRUST_PROXY_HEADERS`, `BUTLER_SECURE_COOKIES`.
3. **Configure SSO** — OIDC callback registration with the IdP, apply `IdentityProvider` CRD + client secret.
4. **Create your admin user** — SSO auto-create + `butleradm user promote`, or `butleradm user invite`, then retire the legacy admin.
5. **Tune ButlerConfig** — multi-tenancy mode, default provider, team limits, control plane resource defaults, exposure mode.
6. **Verify** — web console login, `butlerctl login`, auth endpoint curls.

Followed by a troubleshooting table mapping common post-bootstrap symptoms to the config field or step that was missed.

## Why now

`butler-server` v0.5.5 (merged yesterday) changes the device-flow verification URI to derive from the incoming request instead of advertising `http://localhost:8080` when config is unset. That fix made the localhost redirect disappear, but the full working state still requires operator action: pointing DNS, installing TLS, and setting `BUTLER_TRUST_PROXY_HEADERS=true` so the server honors the ingress's `X-Forwarded-Proto` (without which the emitted URL uses `http` even though the browser reached the ingress over `https`). This doc is what an operator reaches for to complete that configuration.

## Sidebar changes

- New page at `sidebar_position: 7`.
- `first-tenant-cluster.md` bumps from 7 to 8.
- `console.md` bumps from 8 to 9.
- `getting-started/README.md` "After Bootstrap" section puts the new page first in the ordered list.

## What this doc does not cover (out of scope)

- Monitoring, alerting, backup strategy — belongs in `docs/operations/`.
- Network design (IPAM pool planning, VIP placement, LB pool sizing) — provider guides already cover this.
- Advanced SSO (SCIM provisioning, group sync policies, nested group resolution) — deserves its own reference page; linked placeholders exist for provider-specific `sso-google.md`, `sso-entra.md`, `sso-okta.md`.
- CLI-side loopback warning — flagged as a follow-up on the device-auth PR; would give operators an early signal if the verification URL still points at localhost after this checklist is complete.

## Test plan

- [x] Markdown renders (no stray syntax, code fences closed, tables valid).
- [x] No AI-isms, no emojis, second person, present tense, active voice per the `butlerlabs-docs` writing conventions.
- [x] `Let's Encrypt` product name kept (not the banned `let's` conversational).
- [x] Internal links use relative paths within the same instance.
- [ ] Once merged and the fetch-docs job runs, the page appears under `/butler/getting-started/post-bootstrap/` on docs.butlerlabs.dev.

## Follow-ups

- Provider-specific SSO references (`sso-google.md`, `sso-entra.md`, `sso-okta.md`) are linked but do not exist yet. File separate PRs per IdP.
- Add a one-line pointer in the `butleradm bootstrap` success output in `butler-cli` so operators are led here without having to hunt the docs site.