### PR TITLE
docs: team environments concept, reference, and getting-started updates

### DIFF
--- a/docs/concepts/addons.md
+++ b/docs/concepts/addons.md
@@ -1,6 +1,6 @@
 ---
 title: Addons
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Addons

--- a/docs/concepts/environments.md
+++ b/docs/concepts/environments.md
@@ -1,0 +1,206 @@
+---
+title: Environments
+sidebar_position: 7
+---
+
+# Environments
+
+Environments are logical subdivisions within a [Team](./multi-tenancy.md). Use them to separate dev from prod, carve out per-user sandboxes, or group shared utility clusters — without creating a new Team for each slice.
+
+An environment lives in `Team.spec.environments[]` as a named slot with optional quotas, access overrides, and default cluster shape. TenantClusters opt into an environment by carrying the label `butler.butlerlabs.dev/environment: <env-name>`. The label is stamped automatically by the console and CLI when an environment is selected at cluster-create time.
+
+Environments are not a separate tenancy boundary. Team roles still apply; environment access can only elevate a member's role within that env, never reduce it. Team admins remain admins everywhere in the team.
+
+## When to use environments
+
+Reach for environments when:
+
+- The team runs workloads at different risk tiers (dev, staging, prod) and you want per-tier quotas.
+- Individual engineers need sandbox clusters capped at one per person.
+- You want different default cluster shapes per tier (small dev clusters, larger prod clusters).
+- Only a subset of team members should be able to create production clusters.
+
+If the team operates a single homogeneous workload with no tier distinctions, leaving `spec.environments` empty is fine. The label requirement only kicks in once at least one env is defined.
+
+## The four fields
+
+Each environment in `spec.environments[]` has four configurable fields. Only `name` is required.
+
+### name
+
+Operator-chosen identifier. Used as the value of the `butler.butlerlabs.dev/environment` label on TenantClusters. Must match Kubernetes label-value syntax (alphanumeric plus `-`, `_`, `.`; alphanumeric anchors; up to 63 characters). Immutable after creation — rename by delete-and-recreate.
+
+### description
+
+Free-text blurb shown in the console env list and the environment context in the cluster create form. Not interpreted by the controller or webhook; purely operator documentation.
+
+### limits
+
+Per-env quota caps on top of the team's total ceiling:
+
+- `maxClusters` — maximum TenantClusters allowed in this environment.
+- `maxClustersPerMember` — per-individual cap. Prevents any single user from consuming an environment's cluster count on their own.
+
+Both are optional. An unset cap means no environment-level limit; the team-wide `resourceLimits.maxClusters` still applies.
+
+### access
+
+Additive-only RBAC overrides. Lists users or groups with an env-specific role that overrides their team role **within this environment only**. The role can only be equal to or higher than the team role — env access cannot reduce a team admin to operator.
+
+### clusterDefaults
+
+Default values applied when a TenantCluster is created in this env without specifying the field itself. Env defaults override team-level `spec.clusterDefaults` on conflicts. Supported fields match the team cluster defaults (`kubernetesVersion`, `workerCount`, `workerCPU`, `workerMemoryGi`, `workerDiskGi`).
+
+## Per-member cap semantics
+
+`maxClustersPerMember` is identity-based, not role-based. The admission webhook counts TenantClusters in the target env owned by the requesting user (via the `butler.butlerlabs.dev/owner` annotation the controller promotes from the `butler.butlerlabs.dev/creator-email` annotation at create time). A user over their personal cap gets rejected regardless of whether they are team admin, operator, or viewer.
+
+"Member" here means any authenticated identity that creates clusters. Platform admins are subject to the cap too if they create on behalf of themselves; the cap does not exempt any role.
+
+The cap only enforces when the creator email is known. Console and CLI creates stamp the annotation automatically (the console via server impersonation, the CLI via direct identity forwarding). TenantClusters created by raw `kubectl apply` must carry the annotation explicitly or the admission webhook rejects them when the target env has a per-member cap set.
+
+## Additive-only access inheritance
+
+Team roles provide a baseline. An env's access block can elevate a specific user or group for that env only:
+
+```
+Team access:
+  alice@example.com: operator
+  bob@example.com:   admin
+
+Environment prod.access:
+  alice@example.com: admin
+```
+
+Effective roles for alice:
+
+| Environment | Role |
+|---|---|
+| dev (no env override) | operator |
+| prod (env elevates her) | admin |
+
+Bob stays admin everywhere because team roles apply wherever env access does not elevate further. Reducing Bob to operator in an env has no effect — the session layer takes the higher of the two roles.
+
+Env access entries must reference users or groups who already appear in `Team.spec.access`. Introducing a new identity through an env access block is rejected by the admission webhook; use the team access list to grant initial team membership, then elevate through an env if needed.
+
+## Cluster defaults hierarchy
+
+When a TenantCluster is created, each field resolves through three layers:
+
+1. Explicit value in the TenantCluster spec, if set.
+2. Environment's `clusterDefaults[field]`, if the TC is in an env and the env sets it.
+3. Team's `spec.clusterDefaults[field]`, if the team sets it.
+
+The console cluster-create form reflects this layering: when you select an environment, fields the env overrides flip to the env value with a "from env default" hint; fields only the team sets show a "from team default" hint. Typing over a field opts out of the hierarchy for that field only.
+
+## Mutation authority
+
+Environments have a split edit model:
+
+| Field | Who can change it |
+|---|---|
+| `Team.spec.resourceLimits` | Platform admins only |
+| `Team.spec.environments[].limits` | Team admins of the team, and platform admins |
+| All other env fields | Team admins of the team, and platform admins |
+
+The admission webhook enforces this. Team admins cannot raise their own team ceiling — only a platform admin can edit `resourceLimits` — but they can adjust per-env caps within that ceiling on their own.
+
+## Migration for existing clusters
+
+Clusters that existed before the team had any environments defined remain without the env label. They continue to work and count against the team's total `maxClusters`, but are not accounted under any env's cap.
+
+Moving an existing cluster into an environment uses the `butler.butlerlabs.dev/migration-operation` annotation. The console's **Change Environment** action (per-cluster) and **Migrate clusters...** action (bulk) both set this annotation automatically. The CLI's `butleradm env migrate` command does the same. Direct `kubectl` edits to the env label are rejected without the annotation — the annotation is what tells the webhook this is an intentional migration rather than a stray label change.
+
+## Worked example
+
+A team `payments` runs its workloads across two environments:
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: Team
+metadata:
+  name: payments
+spec:
+  access:
+    users:
+      - name: alice@example.com
+        role: admin
+      - name: bob@example.com
+        role: operator
+      - name: carol@example.com
+        role: operator
+  resourceLimits:
+    maxClusters: 20
+  clusterDefaults:
+    kubernetesVersion: v1.31.0
+    workerCount: 2
+    workerCPU: 2
+    workerMemoryGi: 4
+  environments:
+    - name: dev
+      description: Developer sandboxes and integration testing
+      limits:
+        maxClustersPerMember: 2
+      clusterDefaults:
+        workerMemoryGi: 2
+    - name: prod
+      description: Customer-facing payments processing
+      limits:
+        maxClusters: 6
+        maxClustersPerMember: 1
+      access:
+        users:
+          - name: bob@example.com
+            role: admin
+      clusterDefaults:
+        workerCount: 3
+        workerCPU: 4
+        workerMemoryGi: 8
+```
+
+### Effective access
+
+| User | dev role | prod role | Why |
+|---|---|---|---|
+| alice | admin | admin | Team admin; env access block not needed |
+| bob | operator | admin | Env prod elevates him |
+| carol | operator | operator | No env override |
+
+### Effective cluster defaults in dev
+
+| Field | Value | Source |
+|---|---|---|
+| kubernetesVersion | v1.31.0 | team |
+| workerCount | 2 | team |
+| workerCPU | 2 | team |
+| workerMemoryGi | 2 | env (env overrides team) |
+
+### Effective cluster defaults in prod
+
+| Field | Value | Source |
+|---|---|---|
+| kubernetesVersion | v1.31.0 | team |
+| workerCount | 3 | env |
+| workerCPU | 4 | env |
+| workerMemoryGi | 8 | env |
+
+### Quota math
+
+- Team ceiling: 20 clusters.
+- Env prod cap: 6; env dev cap: unset (only a per-member cap).
+- Per-member cap: 2 in dev, 1 in prod.
+
+Scenarios:
+
+- Carol has 2 clusters in dev, wants a 3rd in dev: rejected, hits her per-member dev cap.
+- Carol has 2 clusters in dev, wants 1 in prod: allowed, different env scope.
+- Bob has 1 cluster in prod, wants a 2nd in prod: rejected, hits his per-member prod cap.
+- Team has 6 prod clusters across all members: next prod create rejected for everyone until one is deleted, regardless of per-member cap.
+- Team has 20 clusters total across dev and prod: next create in any env rejected, team ceiling reached.
+
+## See also
+
+- [Team CRD Reference](../reference/crds/team.md) — full schema including `EnvironmentSpec`, `EnvironmentLimits`, and `EnvironmentAccess` shapes.
+- [butleradm env](../reference/cli/butleradm.md#butleradm-env) — CLI for env lifecycle.
+- [butlerctl cluster --environment](../reference/cli/butlerctl.md#butlerctl-cluster-create) — create a cluster in a specific env.
+- [Multi-Tenancy](./multi-tenancy.md) — the team-level tenancy boundary envs subdivide.

--- a/docs/concepts/environments.md
+++ b/docs/concepts/environments.md
@@ -5,7 +5,7 @@ sidebar_position: 7
 
 # Environments
 
-Environments are logical subdivisions within a [Team](./multi-tenancy.md). Use them to separate dev from prod, carve out per-user sandboxes, or group shared utility clusters — without creating a new Team for each slice.
+Environments are logical subdivisions within a [Team](./multi-tenancy.md). Use them to separate dev from prod, carve out per-user sandboxes, or group shared utility clusters without creating a new Team for each slice.
 
 An environment lives in `Team.spec.environments[]` as a named slot with optional quotas, access overrides, and default cluster shape. TenantClusters opt into an environment by carrying the label `butler.butlerlabs.dev/environment: <env-name>`. The label is stamped automatically by the console and CLI when an environment is selected at cluster-create time.
 
@@ -28,7 +28,7 @@ Each environment in `spec.environments[]` has four configurable fields. Only `na
 
 ### name
 
-Operator-chosen identifier. Used as the value of the `butler.butlerlabs.dev/environment` label on TenantClusters. Must match Kubernetes label-value syntax (alphanumeric plus `-`, `_`, `.`; alphanumeric anchors; up to 63 characters). Immutable after creation — rename by delete-and-recreate.
+Operator-chosen identifier. Used as the value of the `butler.butlerlabs.dev/environment` label on TenantClusters. Must match Kubernetes label-value syntax (alphanumeric plus `-`, `_`, `.`; alphanumeric anchors; up to 63 characters). Immutable after creation; rename by delete-and-recreate.
 
 ### description
 
@@ -38,14 +38,14 @@ Free-text blurb shown in the console env list and the environment context in the
 
 Per-env quota caps on top of the team's total ceiling:
 
-- `maxClusters` — maximum TenantClusters allowed in this environment.
-- `maxClustersPerMember` — per-individual cap. Prevents any single user from consuming an environment's cluster count on their own.
+- `maxClusters`: maximum TenantClusters allowed in this environment.
+- `maxClustersPerMember`: per-individual cap. Prevents any single user from consuming an environment's cluster count on their own.
 
 Both are optional. An unset cap means no environment-level limit; the team-wide `resourceLimits.maxClusters` still applies.
 
 ### access
 
-Additive-only RBAC overrides. Lists users or groups with an env-specific role that overrides their team role **within this environment only**. The role can only be equal to or higher than the team role — env access cannot reduce a team admin to operator.
+Additive-only RBAC overrides. Lists users or groups with an env-specific role that overrides their team role **within this environment only**. The role can only be equal to or higher than the team role; env access cannot reduce a team admin to operator.
 
 ### clusterDefaults
 
@@ -58,6 +58,12 @@ Default values applied when a TenantCluster is created in this env without speci
 "Member" here means any authenticated identity that creates clusters. Platform admins are subject to the cap too if they create on behalf of themselves; the cap does not exempt any role.
 
 The cap only enforces when the creator email is known. Console and CLI creates stamp the annotation automatically (the console via server impersonation, the CLI via direct identity forwarding). TenantClusters created by raw `kubectl apply` must carry the annotation explicitly or the admission webhook rejects them when the target env has a per-member cap set.
+
+The rejection message on a breach reads:
+
+```
+user "carol@example.com" already owns 2 cluster(s) in environment "dev"; env limits to 2 per member
+```
 
 ## Additive-only access inheritance
 
@@ -79,7 +85,7 @@ Effective roles for alice:
 | dev (no env override) | operator |
 | prod (env elevates her) | admin |
 
-Bob stays admin everywhere because team roles apply wherever env access does not elevate further. Reducing Bob to operator in an env has no effect — the session layer takes the higher of the two roles.
+Bob stays admin everywhere because team roles apply wherever env access does not elevate further. Reducing Bob to operator in an env has no effect; the session layer takes the higher of the two roles.
 
 Env access entries must reference users or groups who already appear in `Team.spec.access`. Introducing a new identity through an env access block is rejected by the admission webhook; use the team access list to grant initial team membership, then elevate through an env if needed.
 
@@ -103,13 +109,33 @@ Environments have a split edit model:
 | `Team.spec.environments[].limits` | Team admins of the team, and platform admins |
 | All other env fields | Team admins of the team, and platform admins |
 
-The admission webhook enforces this. Team admins cannot raise their own team ceiling — only a platform admin can edit `resourceLimits` — but they can adjust per-env caps within that ceiling on their own.
+The admission webhook enforces this. Team admins cannot raise their own team ceiling (only a platform admin can edit `resourceLimits`), but they can adjust per-env caps within that ceiling on their own.
+
+When a team admin or platform admin attempts a resourceLimits mutation they are not authorized for, the webhook replies verbatim with:
+
+```
+spec.resourceLimits may only be modified by platform admins; user "alice@example.com" is not a platform admin
+```
+
+An operator on a team who attempts to edit env limits receives:
+
+```
+spec.environments[].limits may only be modified by team admins of "payments" or platform admins; user "bob@example.com" is neither
+```
+
+butler-server surfaces the message verbatim as the `message` field of a structured 403 (`reason: "webhook-denied"`); the console renders it inline on the form that triggered the denial.
 
 ## Migration for existing clusters
 
 Clusters that existed before the team had any environments defined remain without the env label. They continue to work and count against the team's total `maxClusters`, but are not accounted under any env's cap.
 
-Moving an existing cluster into an environment uses the `butler.butlerlabs.dev/migration-operation` annotation. The console's **Change Environment** action (per-cluster) and **Migrate clusters...** action (bulk) both set this annotation automatically. The CLI's `butleradm env migrate` command does the same. Direct `kubectl` edits to the env label are rejected without the annotation — the annotation is what tells the webhook this is an intentional migration rather than a stray label change.
+Moving an existing cluster into an environment uses the `butler.butlerlabs.dev/migration-operation` annotation. The console's **Change Environment** action (per-cluster) and **Migrate clusters...** action (bulk) both set this annotation automatically. The CLI's `butleradm env migrate` command does the same. Direct `kubectl` edits to the env label are rejected without the annotation; the annotation is what tells the webhook this is an intentional migration rather than a stray label change.
+
+The webhook message on a missing annotation is:
+
+```
+env label changes require the "butler.butlerlabs.dev/migration-operation" annotation set to "true"; use `butleradm env migrate`
+```
 
 ## Worked example
 
@@ -200,7 +226,7 @@ Scenarios:
 
 ## See also
 
-- [Team CRD Reference](../reference/crds/team.md) — full schema including `EnvironmentSpec`, `EnvironmentLimits`, and `EnvironmentAccess` shapes.
-- [butleradm env](../reference/cli/butleradm.md#butleradm-env) — CLI for env lifecycle.
-- [butlerctl cluster --environment](../reference/cli/butlerctl.md#butlerctl-cluster-create) — create a cluster in a specific env.
-- [Multi-Tenancy](./multi-tenancy.md) — the team-level tenancy boundary envs subdivide.
+- [Team CRD Reference](../reference/crds/team.md): full schema including `EnvironmentSpec` and `EnvironmentLimits`. Env access reuses the team-level `TeamAccess` type.
+- [butleradm env](../reference/cli/butleradm.md#butleradm-env): CLI for env lifecycle.
+- [butlerctl cluster --environment](../reference/cli/butlerctl.md#butlerctl-cluster-create): create a cluster in a specific env.
+- [Multi-Tenancy](./multi-tenancy.md): the team-level tenancy boundary envs subdivide.

--- a/docs/concepts/multi-tenancy.md
+++ b/docs/concepts/multi-tenancy.md
@@ -65,8 +65,13 @@ Teams support resource limits to prevent any single team from consuming the enti
 
 Butler tracks current usage against these limits in the Team's status.
 
+## Environments
+
+Teams can optionally subdivide into named [environments](./environments.md) (dev, prod, per-user sandboxes). Each environment carries its own quotas, access overrides, and default cluster shape, sharing the team's overall ceiling.
+
 ## See Also
 
+- [Environments](./environments.md) -- Subdivisions within a team with per-env quotas and access
 - [Architecture > Multi-Tenancy Implementation](../architecture/multi-tenancy.md) -- Kubernetes RBAC mapping and namespace creation flow
 - [Team CRD Reference](../reference/crds/team.md) -- Full Team specification
 - [ButlerConfig Reference](../reference/crds/butlerconfig.md) -- Multi-tenancy mode configuration

--- a/docs/concepts/networking.md
+++ b/docs/concepts/networking.md
@@ -1,6 +1,6 @@
 ---
 title: Networking and IPAM
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Networking and IPAM

--- a/docs/getting-started/console.md
+++ b/docs/getting-started/console.md
@@ -53,12 +53,12 @@ The console surfaces envs in several places:
 
 - **Environment picker** in the header, next to the team picker. Switching scopes the active session to one env; the cluster list, create form, and mutation handlers all pick up the selection. "All environments" is the default and clears the scope.
 - **Cluster list** groups by env when the team has any defined and the header picker is on "All environments". Each section shows its cap, utilization, and a per-member-cap badge when set. Sections are collapsible and the state persists per team.
-- **Create cluster form** shows an env selector when the team has envs. Env `clusterDefaults` pre-fill worker/version fields; overridden fields carry a "from env default" hint. Per-member cap visibility renders "You own N of M clusters in env X" near the picker — red when at cap, with submit disabled.
+- **Create cluster form** shows an env selector when the team has envs. Env `clusterDefaults` pre-fill worker/version fields; overridden fields carry a "from env default" hint. Per-member cap visibility renders "You own N of M clusters in env X" near the picker, shown red when at cap, with submit disabled.
 - **Change environment** action on each cluster detail page moves a single cluster between envs. Sets the migration-operation annotation automatically.
 - **Migrate clusters...** action on the Environments page bulk-migrates unlabeled or cross-env clusters with per-cluster progress, retry-on-failure, and relabel warnings when the source filter crosses envs.
 - **Admin cluster list** at `/admin/clusters` adds grouping chips (Environment, Team, or both for nested team → env layout).
 
-Webhook denials from env mutations render inline on whichever form triggered them — per-member cap breaches, team-admin-only edits, env-label immutability without the migration annotation — rather than as generic toasts, so operators see the rejection text next to the field that failed.
+Webhook denials from env mutations render inline on whichever form triggered them (per-member cap breaches, team-admin-only edits, env-label immutability without the migration annotation) rather than as generic toasts, so operators see the rejection text next to the field that failed.
 
 ## Next Steps
 

--- a/docs/getting-started/console.md
+++ b/docs/getting-started/console.md
@@ -45,6 +45,21 @@ The Images page lists OS images available from Butler Image Factory. Create Imag
 
 Platform administrators can create teams, assign users with roles (admin, operator, viewer), and set resource quotas.
 
+### Manage Environments
+
+Teams that opt into [environments](../concepts/environments.md) get a dedicated **Environments** item in the team sidebar under Workloads. Team admins and platform admins can create, edit, and delete envs from there; the rest of the team sees the read-only list.
+
+The console surfaces envs in several places:
+
+- **Environment picker** in the header, next to the team picker. Switching scopes the active session to one env; the cluster list, create form, and mutation handlers all pick up the selection. "All environments" is the default and clears the scope.
+- **Cluster list** groups by env when the team has any defined and the header picker is on "All environments". Each section shows its cap, utilization, and a per-member-cap badge when set. Sections are collapsible and the state persists per team.
+- **Create cluster form** shows an env selector when the team has envs. Env `clusterDefaults` pre-fill worker/version fields; overridden fields carry a "from env default" hint. Per-member cap visibility renders "You own N of M clusters in env X" near the picker — red when at cap, with submit disabled.
+- **Change environment** action on each cluster detail page moves a single cluster between envs. Sets the migration-operation annotation automatically.
+- **Migrate clusters...** action on the Environments page bulk-migrates unlabeled or cross-env clusters with per-cluster progress, retry-on-failure, and relabel warnings when the source filter crosses envs.
+- **Admin cluster list** at `/admin/clusters` adds grouping chips (Environment, Team, or both for nested team → env layout).
+
+Webhook denials from env mutations render inline on whichever form triggered them — per-member cap breaches, team-admin-only edits, env-label immutability without the migration annotation — rather than as generic toasts, so operators see the rejection text next to the field that failed.
+
 ## Next Steps
 
 - **[Concepts](../concepts/)** -- Understand Butler's architecture and multi-tenancy model.

--- a/docs/getting-started/post-bootstrap.md
+++ b/docs/getting-started/post-bootstrap.md
@@ -473,7 +473,7 @@ With the platform reachable, authenticated, and tuned:
 2. [Tour the console](./console.md)
 3. [Day-2 operations](../operations/): upgrades, monitoring, backup, scaling
 
-Optional: if the team plans to operate at multiple risk tiers (dev, prod) or wants per-user sandbox caps, define [environments](../concepts/environments.md) on the team before users start creating clusters. Environments are optional — a team with no environments works fine; adding them later is supported but existing clusters stay outside env accounting until migrated.
+Optional: if the team plans to operate at multiple risk tiers (dev, prod) or wants per-user sandbox caps, define [environments](../concepts/environments.md) on the team before users start creating clusters. Environments are optional: a team with no environments works fine. Adding them later is supported but existing clusters stay outside env accounting until migrated.
 
 ## Troubleshooting
 

--- a/docs/getting-started/post-bootstrap.md
+++ b/docs/getting-started/post-bootstrap.md
@@ -473,6 +473,8 @@ With the platform reachable, authenticated, and tuned:
 2. [Tour the console](./console.md)
 3. [Day-2 operations](../operations/): upgrades, monitoring, backup, scaling
 
+Optional: if the team plans to operate at multiple risk tiers (dev, prod) or wants per-user sandbox caps, define [environments](../concepts/environments.md) on the team before users start creating clusters. Environments are optional — a team with no environments works fine; adding them later is supported but existing clusters stay outside env accounting until migrated.
+
 ## Troubleshooting
 
 | Symptom | Check |

--- a/docs/reference/cli/butleradm.md
+++ b/docs/reference/cli/butleradm.md
@@ -359,6 +359,147 @@ butleradm provider add <name> --type <type> [flags]
 
 ---
 
+## butleradm env
+
+Manage team [environments](../../concepts/environments.md). An environment is a named slot within a Team that optionally caps cluster count, per-member cluster count, and default cluster shape.
+
+All env subcommands require `--team <name>`.
+
+### butleradm env list
+
+List environments on a team with live cluster counts.
+
+```bash
+butleradm env list --team <team> [flags]
+```
+
+**Flags:**
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--team` | | Team name (required) |
+| `--output` | `-o` | Output format: `table` (default), `json`, `yaml` |
+
+### butleradm env create
+
+Append an environment to a team.
+
+```bash
+butleradm env create <name> --team <team> [flags]
+```
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--team` | Team name (required) |
+| `--description` | Free-text description shown in the env list and console |
+| `--max-clusters` | Maximum TenantClusters in this env (0 = no cap) |
+| `--max-clusters-per-member` | Per-user cap inside this env (0 = no cap) |
+| `--cluster-default` | Repeatable `key=value` default. Keys: `kubernetesVersion`, `workerCount`, `workerCPU`, `workerMemoryGi`, `workerDiskGi` |
+| `--access-user` | Repeatable `email:role`. Role must be `admin`, `operator`, or `viewer` |
+| `--access-group` | Repeatable `name:role` or `name:role:identityProvider` |
+
+**Examples:**
+
+```bash
+# Minimal: name only
+butleradm env create staging --team payments
+
+# With caps
+butleradm env create sandbox --team payments --max-clusters-per-member 1
+butleradm env create prod --team payments --max-clusters 10
+
+# Full shape
+butleradm env create prod --team payments \
+  --description "production workloads" \
+  --cluster-default kubernetesVersion=v1.31.0 \
+  --cluster-default workerCount=3 \
+  --access-user alice@example.com:admin \
+  --access-group sre:admin
+```
+
+### butleradm env update
+
+Patch an environment in place. Unset flags leave fields unchanged; the env name is immutable.
+
+```bash
+butleradm env update <name> --team <team> [flags]
+```
+
+**Flags:** same as `env create`, plus:
+
+| Flag | Description |
+|------|-------------|
+| `--clear-limits` | Remove the entire limits block |
+| `--clear-cluster-defaults` | Remove the entire clusterDefaults block |
+| `--clear-access` | Remove the entire access block (users and groups) |
+
+Partial clears use the same flags as set, with an empty value:
+
+```bash
+# Clear one cluster-default key, keep others
+butleradm env update prod --team payments --cluster-default workerCount=
+
+# Remove one access-user entry, keep others
+butleradm env update prod --team payments --access-user alice@example.com:
+
+# Remove one access-group entry (by name + idp match)
+butleradm env update prod --team payments --access-group developers::okta
+```
+
+### butleradm env delete
+
+Remove an environment from a team.
+
+```bash
+butleradm env delete <name> --team <team> [flags]
+```
+
+**Flags:**
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--team` | | Team name (required) |
+| `--force` / `--yes` | `-y` | Skip confirmation prompt |
+
+Clusters that carried the deleted env's label remain but are no longer accounted under any env's cap. They continue to count against the team's total `maxClusters`.
+
+### butleradm env migrate
+
+Bulk-label existing TenantClusters into a target env. Use this after adding envs to a team that already has clusters; the pre-existing clusters stay unlabeled until migrated.
+
+```bash
+butleradm env migrate --team <team> --environment <env> [NAMES...] [flags]
+```
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--team` | Team name (required) |
+| `--environment` | Target env name (required) |
+| `--all` | Migrate every unlabeled cluster in the team namespace |
+| `--relabel` | Also rewrite clusters already carrying a different env label (requires extra confirmation) |
+| `--force` / `-y` | Skip the confirmation prompt |
+
+**Examples:**
+
+```bash
+# Migrate every unlabeled cluster into prod
+butleradm env migrate --team payments --environment prod --all
+
+# Migrate specific clusters
+butleradm env migrate --team payments --environment prod web-1 web-2
+
+# Relabel clusters already in dev into staging
+butleradm env migrate --team payments --environment staging --relabel --all
+```
+
+The migration writes both the env label and the `butler.butlerlabs.dev/migration-operation: "true"` annotation the admission webhook requires for env-label mutations.
+
+---
+
 ## butleradm version
 
 Print version information.

--- a/docs/reference/cli/butlerctl.md
+++ b/docs/reference/cli/butlerctl.md
@@ -40,6 +40,7 @@ butlerctl cluster list [flags]
 |------|-------|-------------|
 | `--all-namespaces` | `-A` | List clusters in all namespaces |
 | `--namespace` | `-n` | List clusters in specific namespace |
+| `--environment` | | Filter to clusters in the given [environment](../../concepts/environments.md). Shows an ENV column when any cluster in the result carries the env label |
 
 **Examples:**
 
@@ -91,6 +92,7 @@ butlerctl cluster create <name> [flags]
 | `--dry-run` | | Preview TenantCluster YAML without creating | `false` |
 | `--wait` | | Wait for cluster to reach Ready | `false` |
 | `--timeout` | | Timeout for --wait | `15m` |
+| `--environment` | | Place the cluster in the given [team environment](../../concepts/environments.md). Required when the team has any environments defined. Stamps `butler.butlerlabs.dev/environment: <env>` label and applies env `clusterDefaults` to unset fields. | |
 
 Control plane resource flags (all optional, override ButlerConfig defaults):
 

--- a/docs/reference/crds/team.md
+++ b/docs/reference/crds/team.md
@@ -38,6 +38,7 @@ The Team controller reconciles the following:
 | `resourceLimits` | TeamResourceLimits | No | — | Limits on team resource consumption |
 | `providerConfigRef` | LocalObjectReference | No | — | Default provider for team clusters |
 | `clusterDefaults` | ClusterDefaults | No | — | Default values for new TenantClusters |
+| `environments` | []EnvironmentSpec | No | — | Named subdivisions within the team; see [Environments](../../concepts/environments.md) |
 
 ### TeamAccess
 
@@ -118,6 +119,31 @@ Default values applied to new TenantClusters created in this team when the corre
 | `workerMemoryGi` | int32 | Default memory per worker (GiB) |
 | `workerDiskGi` | int32 | Default disk size per worker (GiB) |
 | `defaultAddons` | []string | Addons installed by default on new clusters |
+
+### EnvironmentSpec
+
+A named subdivision within the team. TenantClusters opt into an environment by carrying the `butler.butlerlabs.dev/environment` label. See the [Environments concept page](../../concepts/environments.md) for semantics.
+
+| Field | Type | Required | Validation | Description |
+|-------|------|----------|------------|-------------|
+| `name` | string | Yes | K8s label-value pattern, 1-63 chars | Identifier; immutable after creation |
+| `description` | string | No | — | Free-text blurb; not interpreted by the controller |
+| `limits` | EnvironmentLimits | No | — | Per-env quota caps |
+| `access` | TeamAccess | No | — | Additive-only role overrides within this env |
+| `clusterDefaults` | ClusterDefaults | No | — | Defaults applied when TCs are created in this env without the field set; overrides team-level `clusterDefaults` on conflicts |
+
+`environments` is listed as a map in the CRD schema with `listMapKey: name`; duplicate names are rejected at the apiserver.
+
+### EnvironmentLimits
+
+All fields optional. Unset means no env-level cap; team-level `resourceLimits.maxClusters` still applies.
+
+| Field | Type | Validation | Description |
+|-------|------|------------|-------------|
+| `maxClusters` | *int32 | min: 0 | Maximum TenantClusters in this env. 0 means no cap |
+| `maxClustersPerMember` | *int32 | min: 0 | Per-individual cap; rejects a create when the requesting user already owns this many clusters in the env. 0 means no cap |
+
+The per-member cap keys on the `butler.butlerlabs.dev/owner` annotation (promoted by the controller from `butler.butlerlabs.dev/creator-email` that the server or CLI stamps at create time). Direct `kubectl apply` creates without the creator-email annotation are rejected when the target env has a per-member cap set.
 
 ### ProviderConfigRef
 

--- a/docs/reference/crds/team.md
+++ b/docs/reference/crds/team.md
@@ -111,14 +111,14 @@ All fields are optional. When a limit is not set, no enforcement is applied for 
 
 Default values applied to new TenantClusters created in this team when the corresponding field is not explicitly set.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `kubernetesVersion` | string | Default Kubernetes version |
-| `workerCount` | int32 | Default number of worker nodes |
-| `workerCPU` | resource.Quantity | Default CPU per worker |
-| `workerMemoryGi` | int32 | Default memory per worker (GiB) |
-| `workerDiskGi` | int32 | Default disk size per worker (GiB) |
-| `defaultAddons` | []string | Addons installed by default on new clusters |
+| Field | Type | Validation | Description |
+|-------|------|------------|-------------|
+| `kubernetesVersion` | string | | Default Kubernetes version |
+| `workerCount` | *int32 | min: 0 | Default number of worker nodes |
+| `workerCPU` | *int32 | min: 1 | Default CPU cores per worker |
+| `workerMemoryGi` | *int32 | min: 1 | Default memory per worker (GiB) |
+| `workerDiskGi` | *int32 | min: 10 | Default disk size per worker (GiB) |
+| `defaultAddons` | []string | | Addons installed by default on new clusters |
 
 ### EnvironmentSpec
 


### PR DESCRIPTION
## Summary

Docs for ADR-009 Team Environments. Five commits on \`docs/team-environments\`; joins the coordinated release with butler-api PR #28, butler-controller PR #46, butler-server PR #43, butler-cli PR #34, butler-console PR #43, and butler-console PR #44.

### Content

- **\`docs/concepts/environments.md\`** (new, sidebar_position: 7). Defines environments as named subdivisions of a Team with four optional fields (name, description, limits, access, clusterDefaults). Covers per-member cap semantics, additive-only access inheritance, cluster-defaults hierarchy, mutation-authority split (platform-admin \`resourceLimits\` vs team-admin env limits), migration for existing clusters. Worked example: payments team with dev + prod envs showing effective-access table and quota-math scenarios. Includes verbatim webhook rejection messages for per-member cap breach, platform-admin-required resourceLimits edit, team-admin-required env-limits edit, and env-label change without migration-operation annotation (strings read directly from butler-controller webhooks so operator support-ticket searches match).
- **\`docs/concepts/multi-tenancy.md\`**: new \`## Environments\` section + See Also link.
- **\`docs/concepts/addons.md\`, \`docs/concepts/networking.md\`**: sidebar_position cascade (7→8, 8→9) to make room for environments at 7.
- **\`docs/getting-started/post-bootstrap.md\`**: optional Next Steps bullet pointing at environments.
- **\`docs/getting-started/console.md\`**: \`### Manage Environments\` subsection covering EnvSwitcher, cluster list grouping, create form env selector with clusterDefaults pre-fill and per-member cap visibility, Change Environment per-cluster action, Migrate clusters bulk modal, admin grouping chips, inline webhook denials.
- **\`docs/reference/cli/butleradm.md\`**: \`butleradm env\` section covering list/create/update/delete/migrate with full flag tables and examples.
- **\`docs/reference/cli/butlerctl.md\`**: \`--environment\` flag rows on \`cluster list\` and \`cluster create\`.
- **\`docs/reference/crds/team.md\`**: environments row in Spec table, EnvironmentSpec + EnvironmentLimits subsections with Validation column. Also corrects pre-existing ClusterDefaults type mismatch (workerCount/CPU/MemoryGi/DiskGi are \`*int32\`, not \`resource.Quantity\`; surfaces min validation, workerDiskGi=10).

### Review cleanup folded in

- Em-dash cleanup in new prose (environments.md, console.md, post-bootstrap.md). Pre-existing table \"—\" placeholders in team.md kept per repo convention.
- Dangling type reference fix: \`EnvironmentAccess\` → \`TeamAccess\` (env access reuses the team-level type).
- Verbatim webhook messages added to environments.md so support-ticket searches match.

## Test plan

- [x] Distinguished-engineer review pass against shipped artifacts (butler-api types, butler-controller webhooks, butler-cli env commands, butler-console UI) — all docs trace to source.
- [x] Banned-word scan clean across all six touched files.
- [x] Worked example walks through ADR-009 gates (Alice/Bob/Carol role resolution, Carol hits dev per-member cap, Bob hits prod per-member cap, team 6 prod reaches env cap, team 20 reaches team ceiling).
- [x] Sidebar positions cascade correctly without collisions.