### PR TITLE
docs: addon catalog Phase 1 - architecture, CRD reference, operations guide

### DIFF
--- a/docs/architecture/addon-system.md
+++ b/docs/architecture/addon-system.md
@@ -19,54 +19,105 @@ metadata:
 spec:
   displayName: "Cilium"
   description: "eBPF-based networking, observability, and security"
-  category: networking
-  platform: true  # Required for cluster operation
-  
+  category: cni
+  platform: true
+  tier: infrastructure
+  icon: "🔌"
+  iconData: "PHN2ZyB4bWxucz0i..."  # base64-encoded SVG
+
   chart:
     repository: https://helm.cilium.io
     name: cilium
     defaultVersion: "1.17.0"
-    
-  # Default values applied to all installations
-  defaultValues:
-    operator:
-      replicas: 1
-    hubble:
-      enabled: true
-      relay:
+
+  defaults:
+    namespace: kube-system
+    values:
+      operator:
+        replicas: 1
+      hubble:
         enabled: true
-        
-  # Values that can be overridden by users
-  configurableValues:
-    - path: hubble.enabled
-      description: "Enable Hubble observability"
-      type: boolean
-    - path: operator.replicas
-      description: "Number of operator replicas"
-      type: integer
-      
-  # Dependencies on other addons
-  dependencies: []
-  
-  # Incompatible addons
-  conflicts:
-    - calico
-    - flannel
+        relay:
+          enabled: true
+
+  dependsOn: []
+
+  links:
+    documentation: https://docs.cilium.io
+    source: https://github.com/cilium/cilium
+    homepage: https://cilium.io
 ```
 
 ### AddonDefinition Fields
 
-| Field | Description |
-|-------|-------------|
-| `displayName` | Human-readable name |
-| `description` | Addon description |
-| `category` | Category (networking, storage, monitoring, etc.) |
-| `platform` | If true, required for cluster operation |
-| `chart` | Helm chart details |
-| `defaultValues` | Default Helm values |
-| `configurableValues` | User-overridable values |
-| `dependencies` | Required addons |
-| `conflicts` | Incompatible addons |
+| Field | Type | Description |
+|-------|------|-------------|
+| `displayName` | string | Human-readable name shown in the Console |
+| `description` | string | What the addon does (max 512 characters) |
+| `category` | enum | Grouping for catalog display (see [categories](#categories)) |
+| `platform` | boolean | If true, installed during cluster creation and cannot be removed via UI |
+| `tier` | enum | `infrastructure` or `apps` -- controls GitOps export placement (see [Tier Classification](#tier-classification)) |
+| `icon` | string | Emoji fallback icon (max 8 characters) |
+| `iconData` | string | Base64-encoded SVG logo (see [Icon Resolution](#icon-resolution)) |
+| `chart` | object | Helm chart repository, name, and default version |
+| `defaults` | object | Installation defaults: namespace, release name, timeout, Helm values |
+| `dependsOn` | array | Addon names that must be installed first |
+| `links` | object | URLs for documentation, homepage, and source code |
+| `maintainer` | object | Maintainer name and email |
+
+### Categories
+
+| Category | Description |
+|----------|-------------|
+| `cni` | Container networking interface |
+| `loadbalancer` | LoadBalancer service implementations |
+| `storage` | Persistent volume provisioners |
+| `certmanager` | Certificate management |
+| `ingress` | Ingress controllers |
+| `observability` | Monitoring, logging, and tracing |
+| `backup` | Cluster backup and disaster recovery |
+| `gitops` | GitOps continuous delivery |
+| `security` | Secrets management and policy |
+| `dns` | External DNS management |
+| `database` | Database operators |
+| `messaging` | Message brokers and event streaming |
+| `service-mesh` | Service mesh and traffic management |
+| `other` | Uncategorized addons |
+
+### Tier Classification
+
+Every addon belongs to one of two tiers:
+
+**infrastructure** -- Foundational cluster services that other workloads depend on. Networking, storage, certificate management, secrets operators, and service meshes fall here. When Butler exports a cluster configuration to a GitOps repository, infrastructure addons are placed in a separate directory so they can be applied before application workloads.
+
+**apps** -- Application-level tools that run on top of infrastructure. Monitoring dashboards, log aggregators, backup tools, and message brokers fall here. These are deployed after infrastructure addons in GitOps exports.
+
+If `tier` is not set explicitly, Butler infers it:
+
+- Platform addons (`platform: true`) default to `infrastructure`
+- All other addons default to `apps`
+
+You can override the inferred tier. For example, Prometheus Operator and Flux are not platform addons but are classified as `infrastructure` because other workloads depend on their CRDs.
+
+### Icon Resolution
+
+Butler Console renders addon icons using a three-step fallback chain:
+
+1. **`iconData`** -- If present, decoded as an SVG image and rendered inline. This is the preferred approach for product logos.
+2. **`icon`** -- If `iconData` is empty, the `icon` field is rendered as text (typically an emoji like `🔒`).
+3. **Fallback** -- If neither field is set, Butler displays a generic package icon (📦).
+
+The `iconData` field accepts a base64-encoded SVG. To encode an SVG file:
+
+```bash
+# Linux
+base64 -w 0 logo.svg
+
+# macOS
+base64 -i logo.svg | tr -d '\n'
+```
+
+The encoded string goes directly into `spec.iconData` -- do not include a `data:` URI prefix. Maximum length is 131,072 characters.
 
 ## TenantAddon
 
@@ -81,8 +132,8 @@ metadata:
 spec:
   clusterRef:
     name: my-cluster
-  addon: prometheus
-  version: "25.0.0"
+  addon: prometheus-operator
+  version: "72.6.2"
   values:
     server:
       retention: 30d
@@ -98,14 +149,14 @@ stateDiagram-v2
     Pending --> Installing: Controller picks up
     Installing --> Installed: Helm install success
     Installing --> Failed: Helm install failed
-    
+
     Installed --> Upgrading: Version/values change
     Upgrading --> Installed: Upgrade success
     Upgrading --> Failed: Upgrade failed
-    
+
     Installed --> Uninstalling: Delete TenantAddon
     Uninstalling --> [*]: Helm uninstall complete
-    
+
     Failed --> Installing: Retry
 ```
 
@@ -120,17 +171,17 @@ sequenceDiagram
     participant TC as TenantCluster
     participant Helm
     participant Tenant as Tenant Cluster
-    
+
     User->>API: Create TenantAddon
     API->>Controller: Watch event
-    
+
     Controller->>AD: Get AddonDefinition
     Controller->>TC: Get cluster kubeconfig
-    
+
     Controller->>Controller: Merge values<br/>(defaults + user)
     Controller->>Helm: Install chart
     Helm->>Tenant: Deploy resources
-    
+
     Tenant-->>Controller: Resources ready
     Controller->>API: Update status: Installed
 ```
@@ -156,39 +207,55 @@ ManagementAddons are cluster-scoped and managed by platform administrators.
 
 ## Built-in Addons
 
-Butler ships with these AddonDefinitions:
+Butler ships with 27 AddonDefinitions across two tiers.
 
-### Networking
+### Platform Addons
 
-| Addon | Description | Default Version |
-|-------|-------------|-----------------|
-| cilium | eBPF-based CNI with Hubble | 1.17.0 |
-| metallb | LoadBalancer for bare metal | 0.14.9 |
+Platform addons are installed automatically during cluster creation and cannot be removed through the Console.
 
-### Storage
+| Addon | Display Name | Category | Description |
+|-------|-------------|----------|-------------|
+| cilium | Cilium | cni | eBPF-based networking with Hubble observability |
+| metallb | MetalLB | loadbalancer | LoadBalancer services for bare-metal clusters |
+| cert-manager | cert-manager | certmanager | X.509 certificate management |
+| longhorn | Longhorn | storage | Distributed block storage |
+| traefik | Traefik | ingress | Ingress controller and reverse proxy |
+| metrics-server | Metrics Server | observability | Cluster resource metrics for HPA and `kubectl top` |
 
-| Addon | Description | Default Version |
-|-------|-------------|-----------------|
-| longhorn | Distributed block storage | 1.7.2 |
+### Infrastructure-Tier Optional Addons
 
-### Certificates
+These are not installed automatically but are classified as infrastructure because other workloads may depend on their CRDs or services.
 
-| Addon | Description | Default Version |
-|-------|-------------|-----------------|
-| cert-manager | Certificate management | 1.16.2 |
+| Addon | Display Name | Category | Description |
+|-------|-------------|----------|-------------|
+| cnpg | CloudNativePG | database | PostgreSQL operator with automated failover |
+| external-dns | ExternalDNS | dns | Synchronize Kubernetes Services/Ingresses with DNS providers |
+| external-secrets | External Secrets Operator | security | Sync secrets from external stores (Vault, AWS SSM, etc.) |
+| flux | Flux CD | gitops | GitOps continuous delivery for Kubernetes |
+| istio | Istio | service-mesh | Service mesh with traffic management and mTLS |
+| linkerd | Linkerd | service-mesh | Lightweight service mesh focused on simplicity |
+| prometheus-operator | Prometheus Operator | observability | Monitoring stack operator with ServiceMonitor CRDs |
+| sealed-secrets | Sealed Secrets | security | Encrypt secrets for safe storage in Git |
 
-### Ingress
+### Application-Tier Optional Addons
 
-| Addon | Description | Default Version |
-|-------|-------------|-----------------|
-| traefik | Ingress controller | 34.3.0 |
+Application-level tools that run on top of infrastructure.
 
-### Monitoring
-
-| Addon | Description | Default Version |
-|-------|-------------|-----------------|
-| prometheus | Monitoring and alerting | 25.0.0 |
-| victoria-metrics | Long-term metrics storage | 0.25.0 |
+| Addon | Display Name | Category | Description |
+|-------|-------------|----------|-------------|
+| argocd | Argo CD | gitops | Declarative GitOps continuous delivery |
+| jaeger | Jaeger | observability | Distributed tracing backend |
+| loki | Grafana Loki | observability | Log aggregation with label-based indexing |
+| nats | NATS | messaging | Cloud-native messaging system |
+| otel-collector | OpenTelemetry Collector | observability | Vendor-agnostic telemetry data pipeline |
+| rabbitmq | RabbitMQ | messaging | Message broker with AMQP support |
+| redis | Redis | database | In-memory data store and cache |
+| tempo | Grafana Tempo | observability | Distributed tracing with object storage backend |
+| vector-agent | Vector Agent | observability | Node-level log and metrics collector |
+| vector-aggregator | Vector Aggregator | observability | Centralized log processing and routing |
+| velero | Velero | backup | Cluster backup, restore, and migration |
+| victoria-logs | Victoria Logs | observability | Log management with VictoriaMetrics |
+| victoria-metrics | Victoria Metrics | observability | Long-term metrics storage compatible with Prometheus |
 
 ## Custom Addons
 
@@ -203,23 +270,50 @@ metadata:
   name: internal-app
 spec:
   displayName: "Internal Application"
-  description: "Company internal application"
-  category: application
-  
+  description: "Company-specific deployment platform"
+  category: other
+  tier: apps
+  iconData: "PHN2ZyB4bWxucz0i..."  # base64-encoded company logo
+
   chart:
     repository: https://charts.internal.company.com
     name: internal-app
     defaultVersion: "2.1.0"
-    
-  defaultValues:
-    replicaCount: 2
-    
-  configurableValues:
-    - path: replicaCount
-      description: "Number of replicas"
-      type: integer
-      minimum: 1
-      maximum: 10
+
+  defaults:
+    namespace: internal
+    createNamespace: true
+    timeout: "15m"
+    values:
+      replicaCount: 2
+
+  links:
+    documentation: https://wiki.internal.company.com/internal-app
+```
+
+To create a custom addon with an icon, encode your SVG logo:
+
+```bash
+# Encode the SVG
+ICON=$(base64 -i logo.svg | tr -d '\n')
+
+# Create the AddonDefinition (via Console or kubectl)
+kubectl apply -f - <<EOF
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: AddonDefinition
+metadata:
+  name: my-tool
+spec:
+  displayName: "My Tool"
+  description: "Internal monitoring dashboard"
+  category: observability
+  tier: apps
+  iconData: "$ICON"
+  chart:
+    repository: https://charts.company.com
+    name: my-tool
+    defaultVersion: "1.0.0"
+EOF
 ```
 
 ### Private Helm Repositories
@@ -252,5 +346,6 @@ spec:
 ## See Also
 
 - [Concepts: Addons](../concepts/addons.md) -- Addon types and CRD overview
+- [AddonDefinition CRD Reference](../reference/crds/addondefinition.md) -- Full field specification
+- [Addon Catalog Operations](../operations/addon-catalog.md) -- Using the Console addon catalog
 - [Tenant Lifecycle](tenant-lifecycle.md) -- How addons are installed during cluster creation
-- [Getting Started](../getting-started/) -- Install your first addon

--- a/docs/concepts/addons.md
+++ b/docs/concepts/addons.md
@@ -35,7 +35,7 @@ Users install and remove these through TenantCluster spec, the Console, or direc
 
 Three CRDs drive the addon system:
 
-**AddonDefinition** -- Cluster-scoped catalog entries. Each definition specifies a Helm chart repository, chart name, available versions, default values, and whether the addon is a platform requirement. Platform admins manage the catalog.
+**AddonDefinition** -- Cluster-scoped catalog entries. Each definition specifies a Helm chart repository, chart name, available versions, default values, and whether the addon is a platform requirement. Definitions can also carry a `tier` (infrastructure or apps) that controls GitOps export ordering, and an `iconData` field with a base64-encoded SVG logo for display in the Console. Platform admins manage the catalog.
 
 **TenantAddon** -- Namespaced resources that represent an addon installed on a specific tenant cluster. Butler creates TenantAddons from `TenantCluster.spec.addons` or users can create them directly. The butler-controller installs the Helm chart on the tenant cluster and tracks its health.
 
@@ -67,4 +67,6 @@ Each addon's `version` field is required. Butler does not auto-select versions.
 ## See Also
 
 - [Architecture > Addon System](../architecture/addon-system.md) -- Installation sequence, dependency resolution, and controller flow
+- [AddonDefinition CRD Reference](../reference/crds/addondefinition.md) -- Full field specification
+- [Addon Catalog Operations](../operations/addon-catalog.md) -- Using the Console to browse and manage addons
 - [TenantCluster Reference](../reference/crds/tenantcluster.md) -- Addon spec fields

--- a/docs/operations/addon-catalog.md
+++ b/docs/operations/addon-catalog.md
@@ -1,0 +1,155 @@
+---
+title: Addon Catalog
+sidebar_position: 6
+---
+
+# Addon Catalog
+
+Butler Console provides three views for managing addons. Each view serves a different scope and audience.
+
+## Admin Addon Catalog
+
+**Path:** Admin > Addon Catalog
+
+The catalog lists every AddonDefinition in the cluster. Platform administrators use it to review available addons, add custom definitions, and check which addons are built-in versus custom.
+
+Each entry shows the addon's icon, display name, category, tier, and description. Built-in addons (shipped with Butler) are read-only -- they can be viewed but not edited or deleted through the Console. Custom addons can be created, edited, and removed.
+
+### Browsing the Catalog
+
+The catalog grid groups addons by category. Use the search bar to filter by name or description, or the category tabs to narrow the view. Each addon card shows:
+
+- **Icon** -- Product logo (from `iconData`) or emoji fallback
+- **Display name** and addon name
+- **Category** badge (e.g., observability, security)
+- **Tier** badge -- `infrastructure` or `apps`
+- **Source** -- `builtin` for addons shipped with Butler, `custom` for user-created definitions
+
+Click an addon card to view its full definition, including chart details, default values, dependencies, and available versions.
+
+### Adding a Custom Addon
+
+Click **Create Addon** to open the creation form. Fill in:
+
+1. **Name** -- A lowercase slug used as the AddonDefinition resource name (e.g., `my-monitoring-tool`). Cannot be changed after creation.
+2. **Display Name** -- Human-readable name shown in the catalog.
+3. **Description** -- What the addon does.
+4. **Category** -- Select from the category dropdown.
+5. **Chart Repository** -- The Helm chart repository URL (e.g., `https://charts.company.com`).
+6. **Chart Name** -- The chart name within the repository.
+7. **Default Version** -- The chart version to install by default.
+8. **Tier** -- Select `infrastructure` or `apps`, or leave on Auto to let Butler infer it.
+
+Optionally, set an icon by encoding your SVG logo:
+
+```bash
+# macOS
+base64 -i logo.svg | tr -d '\n' | pbcopy
+
+# Linux
+base64 -w 0 logo.svg | xclip -selection clipboard
+```
+
+Paste the encoded string into the **Icon Data** field.
+
+Common issues when creating custom addons:
+
+- **Chart not reachable** -- Butler validates the chart repository URL. If the repository requires authentication, create a credentials Secret first (see [Private Helm Repositories](../architecture/addon-system.md#private-helm-repositories)).
+- **Name collision** -- Addon names must be unique across the cluster. Check existing names with `kubectl get addondefinitions`.
+- **Large SVGs** -- The `iconData` field has a 128 KB limit. Simplify complex logos or use the `icon` emoji field instead.
+
+## Management Cluster Addons
+
+**Path:** Admin > Management
+
+The management view shows addons installed on the management cluster itself. These are typically observability and platform tools -- Victoria Metrics for long-term metrics, Grafana for dashboards, and similar infrastructure services.
+
+### Installing a Management Addon
+
+Click **Install Addon** to browse the catalog filtered to addons suitable for the management cluster. Select an addon, choose a version, and optionally override default values.
+
+Management addons are cluster-scoped ManagementAddon resources. Only platform administrators can install or remove them.
+
+### Viewing Status
+
+Each installed addon shows its current phase:
+
+| Phase | Meaning |
+|-------|---------|
+| **Installed** | Helm release is deployed and healthy |
+| **Installing** | Helm install is in progress |
+| **Upgrading** | A version or values change is being applied |
+| **Failed** | The Helm operation encountered an error. Check the addon detail view for the error message |
+| **Uninstalling** | The addon is being removed |
+
+## Tenant Cluster Addons
+
+**Path:** Cluster detail > Addons tab
+
+The addons tab on a cluster detail page shows three sections:
+
+### Platform Addons
+
+Read-only list of addons installed during cluster creation (Cilium, MetalLB, cert-manager, etc.). These cannot be removed through the Console. The list shows the installed version and health status.
+
+### Installed Optional Addons
+
+Addons that a user has installed on this cluster. Each entry shows the addon icon, version, and status. From here you can:
+
+- **View values** -- See the Helm values applied to the release.
+- **Edit values** -- Modify Helm values and trigger an upgrade.
+- **Change version** -- Select a different version from the available versions list.
+- **Uninstall** -- Remove the addon from the cluster.
+
+### Available Addons
+
+Addons from the catalog that are not yet installed on this cluster. Click **Install** to add one. Butler creates a TenantAddon resource and the controller handles the Helm installation.
+
+## Tier Classification Guidance
+
+When creating custom addons, choosing the right tier affects GitOps export ordering.
+
+**Use `infrastructure` when:**
+
+- The addon provides CRDs that other workloads consume (e.g., database operators, certificate issuers, secrets managers)
+- The addon must be running before application workloads can start
+- Removing the addon would break dependent services
+
+**Use `apps` when:**
+
+- The addon is a standalone tool with no downstream dependents
+- The addon consumes infrastructure but does not provide it
+- Other workloads do not reference the addon's CRDs or services
+
+For reference, here is how the built-in addons are classified:
+
+| Tier | Reasoning | Examples |
+|------|-----------|---------|
+| `infrastructure` | Provides CRDs or services that other addons depend on | Cilium (CNI), cert-manager (Certificates), Flux (GitOps CRDs), External Secrets (SecretStore CRD), CloudNativePG (Cluster CRD) |
+| `apps` | Standalone tools with no downstream dependents | Tempo (tracing), Velero (backup), Redis (cache), Jaeger (tracing), Victoria Metrics (metrics storage) |
+
+## Status Reference
+
+Addon status in the Console is indicated by color-coded badges:
+
+| Status | Color | Description |
+|--------|-------|-------------|
+| Installed | Green | Helm release is deployed and running |
+| Installing | Blue | Initial Helm install in progress |
+| Upgrading | Blue | Version or values change being applied |
+| Failed | Red | Helm operation failed. Expand the addon detail for the error message |
+| Pending | Yellow | Addon created but not yet picked up by the controller |
+| Uninstalling | Yellow | Helm uninstall in progress |
+
+For failed addons, the detail view shows the Helm error output. Common causes:
+
+- **Image pull errors** -- The chart references a container image not accessible from the cluster. Check network policies and registry credentials.
+- **Timeout** -- The Helm operation exceeded the configured timeout. Increase `defaults.timeout` in the AddonDefinition or check for resource constraints.
+- **Dependency not met** -- An addon listed in `dependsOn` is not installed. Install the dependency first.
+- **Values conflict** -- Invalid Helm values. Check the chart's `values.yaml` for the correct schema.
+
+## See Also
+
+- [Architecture > Addon System](../architecture/addon-system.md) -- How the addon system works internally
+- [AddonDefinition CRD Reference](../reference/crds/addondefinition.md) -- Full field specification
+- [Concepts: Addons](../concepts/addons.md) -- Addon types and CRD overview

--- a/docs/reference/crds/README.md
+++ b/docs/reference/crds/README.md
@@ -48,7 +48,7 @@ Butler extends the Kubernetes API with Custom Resource Definitions (CRDs) under 
 
 | CRD | Scope | Short Name | Description |
 |-----|-------|------------|-------------|
-| AddonDefinition | Cluster | `ad` | Addon catalog entry |
+| [AddonDefinition](./addondefinition.md) | Cluster | `ad` | Addon catalog entry |
 | TenantAddon | Namespaced | `ta` | Addon on tenant cluster |
 | ManagementAddon | Cluster | `ma` | Addon on management cluster |
 

--- a/docs/reference/crds/addondefinition.md
+++ b/docs/reference/crds/addondefinition.md
@@ -1,0 +1,149 @@
+---
+title: AddonDefinition
+sidebar_position: 10
+---
+
+An AddonDefinition is a cluster-scoped catalog entry that describes an addon available for installation on tenant or management clusters.
+
+## API Version
+
+`butler.butlerlabs.dev/v1alpha1`
+
+## Scope
+
+Cluster
+
+## Short Name
+
+`ad`
+
+## Description
+
+Each AddonDefinition specifies a Helm chart, its default configuration, and metadata used by Butler Console for catalog display. Platform administrators manage the catalog by creating, updating, or removing AddonDefinitions. Butler ships with 27 built-in definitions; organizations can add their own.
+
+When a user installs an addon on a cluster, Butler creates a TenantAddon or ManagementAddon that references the AddonDefinition by name. The butler-controller uses the definition to locate the Helm chart, merge default values with user overrides, and install the release.
+
+## Specification
+
+### Full Example
+
+```yaml
+apiVersion: butler.butlerlabs.dev/v1alpha1
+kind: AddonDefinition
+metadata:
+  name: prometheus-operator
+spec:
+  displayName: "Prometheus Operator"
+  description: "Monitoring stack operator providing ServiceMonitor and PrometheusRule CRDs"
+  category: observability
+  platform: false
+  tier: infrastructure
+
+  icon: "📊"
+  iconData: "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA..."
+
+  chart:
+    repository: https://prometheus-community.github.io/helm-charts
+    name: kube-prometheus-stack
+    defaultVersion: "72.6.2"
+    availableVersions:
+      - "72.6.2"
+      - "71.0.0"
+      - "65.8.0"
+
+  defaults:
+    namespace: monitoring
+    releaseName: prometheus
+    createNamespace: true
+    timeout: "10m"
+    values:
+      grafana:
+        enabled: false
+      alertmanager:
+        enabled: true
+
+  dependsOn:
+    - cert-manager
+
+  links:
+    documentation: https://prometheus-operator.dev/docs/
+    source: https://github.com/prometheus-operator/prometheus-operator
+    homepage: https://prometheus-operator.dev
+
+  maintainer:
+    name: "Platform Team"
+    email: "platform@example.com"
+```
+
+### Spec Fields
+
+#### Required
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `displayName` | string (1-64 chars) | Human-readable name displayed in the Console catalog |
+| `description` | string (1-512 chars) | What the addon does |
+| `category` | enum | Catalog grouping. One of: `cni`, `loadbalancer`, `storage`, `certmanager`, `ingress`, `observability`, `backup`, `gitops`, `security`, `dns`, `database`, `messaging`, `service-mesh`, `other` |
+| `chart.repository` | string | Helm chart repository URL (must start with `http://` or `https://`) |
+| `chart.name` | string | Chart name within the repository |
+| `chart.defaultVersion` | string | Chart version used when a TenantAddon does not specify one |
+
+#### Optional
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `platform` | boolean | `false` | Platform addons are installed during cluster creation and cannot be removed through the Console |
+| `tier` | enum | inferred | `infrastructure` or `apps`. Controls directory placement in GitOps exports. Platform addons default to `infrastructure`; all others default to `apps` |
+| `icon` | string (max 8 chars) | — | Emoji or short text icon. Used as fallback when `iconData` is not set |
+| `iconData` | string (max 131072 chars) | — | Base64-encoded SVG image. Takes priority over `icon` for catalog display |
+| `chart.availableVersions` | string[] | — | Other chart versions known to work. Populates the version dropdown in the Console |
+| `defaults.namespace` | string | addon name | Kubernetes namespace for the Helm release |
+| `defaults.releaseName` | string | addon name | Helm release name |
+| `defaults.createNamespace` | boolean | `true` | Whether Butler creates the target namespace if it does not exist |
+| `defaults.timeout` | string | `10m` | Timeout for Helm install and upgrade operations |
+| `defaults.values` | object | — | Default Helm values. Users can override these in `TenantAddon.spec.values` |
+| `dependsOn` | string[] | — | Names of AddonDefinitions that must be installed before this addon |
+| `links.documentation` | string | — | URL to the addon's documentation |
+| `links.homepage` | string | — | URL to the addon's project homepage |
+| `links.source` | string | — | URL to the addon's source code |
+| `maintainer.name` | string | — | Maintainer name |
+| `maintainer.email` | string | — | Maintainer email |
+
+### iconData Format
+
+The `iconData` field stores a product logo as a base64-encoded SVG string. Butler Console decodes it and renders the image inline in the addon catalog, cluster addon lists, and detail views.
+
+To encode an SVG file:
+
+```bash
+# Linux
+base64 -w 0 logo.svg
+
+# macOS
+base64 -i logo.svg | tr -d '\n'
+```
+
+Paste the output directly into `spec.iconData`. Do not include a `data:` URI prefix -- Butler Console adds the appropriate prefix when rendering.
+
+Keep SVGs clean and reasonably sized. Logos from CNCF projects are typically under 10 KB encoded. The hard limit is 128 KB (131,072 characters).
+
+### Tier Inference
+
+When `tier` is omitted:
+
+| Condition | Inferred Tier |
+|-----------|--------------|
+| `platform: true` | `infrastructure` |
+| `platform: false` or unset | `apps` |
+
+Set `tier` explicitly when the default does not match. For example, Flux and External Secrets are optional addons but classified as `infrastructure` because other workloads depend on their CRDs being present.
+
+## Status
+
+AddonDefinitions do not have a status subresource. Their presence in the cluster makes them available in the catalog. Removing an AddonDefinition does not affect already-installed TenantAddons or ManagementAddons that reference it, but prevents new installations.
+
+## See Also
+
+- [Architecture > Addon System](../../architecture/addon-system.md) -- Lifecycle, installation flow, and built-in addon catalog
+- [Addon Catalog Operations](../../operations/addon-catalog.md) -- Using the Console to browse and manage addons
+- [TenantCluster](./tenantcluster.md) -- Addon fields in the TenantCluster spec


### PR DESCRIPTION
## Summary

Documents the addon catalog system shipped in addon catalog Phase 1 across butler-server v0.11.0, butler-addons 0.6.0, and butler-console v0.10.1.

**Updated:**
- `docs/architecture/addon-system.md` -- Added `iconData`, `tier` classification, icon resolution chain, and expanded built-in addons from 6 to all 27 with tier grouping
- `docs/concepts/addons.md` -- Added tier and iconData mention to AddonDefinition description, cross-references to new pages
- `docs/reference/crds/README.md` -- Linked AddonDefinition to new dedicated CRD page

**Added:**
- `docs/reference/crds/addondefinition.md` -- Full CRD reference: every spec field, iconData format specification, tier inference behavior, example YAML
- `docs/operations/addon-catalog.md` -- Operator guide covering three Console views (admin catalog, management addons, tenant cluster addons), custom addon creation with iconData, tier classification guidance, status reference

## Cross-references

All five files cross-reference each other where appropriate. The architecture page covers "how it works," the CRD reference covers "what each field does," and the operations guide covers "how to use it in the Console."

## Test plan

- [ ] Verify docs build passes (Docusaurus)
- [ ] Confirm sidebar positioning (addon-system at 4, addondefinition at 10, addon-catalog at 6)
- [ ] Check cross-references resolve between pages
- [ ] Spot-check built-in addon table against butler-charts templates