### PR TITLE
docs: addon failure troubleshooting and IPAM note

### DIFF
--- a/docs/operations/ipam.md
+++ b/docs/operations/ipam.md
@@ -90,7 +90,9 @@ When a new TenantCluster is created with elastic IPAM, operators can expect:
 
 ### What a fresh tenant looks like
 
-On bootstrap, a fresh tenant cluster running the default addon set (Cilium, MetalLB, cert-manager, Longhorn, Traefik) has one LB Service: Traefik. This consumes 1 of the 2 initially allocated IPs. The second IP sits as idle headroom until a workload creates another LB Service.
+On bootstrap, a fresh tenant cluster running the default addon set (Cilium, MetalLB, cert-manager, Longhorn, Traefik) has one LB Service: Traefik. This consumes 1 of the initially allocated IPs.
+
+If Traefik failed to install during initial addon setup, the cluster reaches Ready phase but the `AddonsReady` condition is `False`. The controller retries the install during steady-state reconciliation. Until Traefik is installed, no platform LB Service exists on the tenant, and the allocated IPs sit unused. See [Troubleshooting: Addons](../troubleshooting/addons.md#platform-addon-install-failed) for diagnosis.
 
 ```bash
 # On a fresh tenant cluster

--- a/docs/troubleshooting/addons.md
+++ b/docs/troubleshooting/addons.md
@@ -21,6 +21,33 @@ kubectl describe pod -n kube-system -l k8s-app=cilium
 1. **Missing kernel modules** -- Cilium requires eBPF support. Verify the node OS version supports eBPF (Talos 1.7+ and all supported OS types include it).
 2. **Resource constraints** -- Cilium agent requests CPU and memory on each node. If nodes are undersized, increase `workers.machineTemplate.cpu` and `workers.machineTemplate.memory` in the TenantCluster spec.
 
+## Platform Addon Install Failed
+
+**Symptoms:** `AddonsReady` condition is `False` with reason `AddonInstallFailed`. The cluster reaches `Ready` phase but has one or more missing platform addons (cert-manager, longhorn, metallb, traefik).
+
+**Diagnosis:**
+
+```bash
+# Check which addons failed
+kubectl get tc <cluster-name> -n <namespace> -o jsonpath='{.status.observedState.addons}' | jq .
+
+# Check condition message for the failure list
+kubectl get tc <cluster-name> -n <namespace> -o jsonpath='{.status.conditions[?(@.type=="AddonsReady")]}'
+
+# Check events for specific errors
+kubectl get events -n <namespace> --field-selector involvedObject.name=<cluster-name> \
+  --sort-by='.lastTimestamp' | grep AddonInstallFailed
+```
+
+**Solutions:**
+
+1. **Transient failure (network, timeout)** -- The controller retries failed addons automatically during steady-state reconciliation. Check events for `AddonRetrySucceeded` to confirm self-healing. The retry interval is capped at 10 minutes for clusters with failed addons.
+2. **Helm chart repository unreachable** -- The management cluster needs network access to the Helm chart repositories. Check DNS and firewall rules from the controller pod.
+3. **Tenant API server unreachable** -- Platform addon installs require a working kubeconfig for the tenant cluster. Verify the control plane is healthy and the admin-kubeconfig secret exists in the tenant namespace.
+4. **MetalLB without IP allocation** -- MetalLB install requires an allocated IP pool. If the IPAllocation is still `Pending`, MetalLB install will fail and retry once the allocation is fulfilled.
+
+**Note:** Cilium (CNI) failures are fatal and block cluster progression. Non-CNI addon failures (cert-manager, longhorn, metallb, traefik) allow the cluster to reach Ready phase. The steady-state loop retries these on each reconcile.
+
 ## Addon Stuck in "Installing"
 
 **Diagnosis:**


### PR DESCRIPTION
## Summary

- Add troubleshooting section for platform addon install failures (AddonsReady condition, AddonInstallFailed events, automatic retry)
- Add note to IPAM operations about Traefik install failures and IP utilization impact

Accompanies butlerdotdev/butler-controller#93.

## Test plan

- [ ] Docs site builds cleanly
- [ ] Links resolve correctly