### PR TITLE
docs: document in-flight growth deduction in IPAM

### DIFF
--- a/docs/architecture/ipam.md
+++ b/docs/architecture/ipam.md
@@ -511,8 +511,8 @@ On each reconcile of a Ready cluster with elastic IPAM enabled:
 
 1. `reconcileElasticIPAM()` lists all LB IPAllocations for the tenant.
 2. It connects to the tenant cluster and builds a Service inventory: all Services of type LoadBalancer, their external IPs, and their age.
-3. If any Service has been Pending without an externalIP for longer than 30 seconds, growth fires.
-4. **Batch assessment**: The controller counts all Pending Services at once and creates enough growth allocations to cover all of them. If three Services are Pending, growth creates allocations for all three rather than handling one per reconcile cycle.
+3. If any Service has been Pending without an externalIP for longer than 30 seconds, growth fires — but only after accounting for in-flight supply. Growth allocations that are still Pending (awaiting fulfillment by the NetworkPool controller) or Allocated but not yet consumed by any Service (MetalLB propagation in progress) are subtracted from the demand count. This prevents redundant growth when a watch-triggered reconcile fires shortly after creating a growth allocation.
+4. **Batch assessment**: The controller counts all Pending Services at once, subtracts in-flight supply, and creates enough growth allocations to cover the remaining demand. If three Services are Pending and one growth allocation is already in flight, growth creates allocations for the remaining two.
 5. Each growth allocation is quota-checked (`totalAllocated + growthIncrement <= maxLoadBalancerIPs`) and capacity-checked against the pool.
 6. Growth allocations are labeled `allocation-role: growth` and named `{namespace}-{name}-lb-{N}`.
 

--- a/docs/troubleshooting/networking.md
+++ b/docs/troubleshooting/networking.md
@@ -80,7 +80,8 @@ kubectl logs -n butler-system -l app.kubernetes.io/name=butler-controller --tail
 1. **Not elastic mode** -- Growth only fires with `allocationMode: elastic`. Static mode allocates once at creation.
 2. **Quota reached** -- Total allocated IPs equal `maxLoadBalancerIPs`. Increase the quota or delete unused Services.
 3. **Service too new** -- The controller waits 30 seconds after Service creation before treating it as a demand signal. Wait and check again.
-4. **Tenant API unreachable** -- The controller skips elastic IPAM when it cannot connect to the tenant. Check tenant control plane health.
+4. **In-flight supply covers demand** -- If a growth allocation was recently created and is still Pending or Allocated but not yet consumed by a Service, the controller deducts it from the demand count. This is normal during MetalLB propagation (up to ~37 seconds). Check `kubectl get ipallocation -n butler-system -l butler.butlerlabs.dev/tenant=<cluster-name>` for recent growth allocations in Pending or Allocated phase.
+5. **Tenant API unreachable** -- The controller skips elastic IPAM when it cannot connect to the tenant. Check tenant control plane health.
 
 ## Console Not Loading
 


### PR DESCRIPTION
## Summary

- Update demand-driven growth section in `architecture/ipam.md` to describe the in-flight supply deduction added in butlerdotdev/butler-controller#95.
- Add "in-flight supply covers demand" as a diagnosis item in `troubleshooting/networking.md` for the "growth not firing" scenario.

## Test plan

- [ ] Docs site builds without errors