### PR TITLE
ci: fix markdownlint and link-check, repair broken links

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -23,16 +23,29 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Link Checker
+        # Scope: external (http/https) links plus Docusaurus root-relative links
+        # (/concepts/..., resolved against docs/ via --root-dir). Relative file
+        # links are deferred to Docusaurus's own onBrokenLinks check. Excludes
+        # cover private/internal repos that 404 anonymously and bot-blocked hosts.
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
             --verbose
             --no-progress
+            --root-dir docs
+            --scheme https
+            --scheme http
+            --exclude "^https://wiki.linuxfoundation.org/dco"
             --exclude "^https://github.com/butlerdotdev/butler-provider-proxmox"
             --exclude "^https://github.com/butlerdotdev/butler-controller"
             --exclude "^https://github.com/butlerdotdev/butler-provider-nutanix"
+            --exclude "^https://github.com/butlerdotdev/butler-provider-azure"
+            --exclude "^https://github.com/butlerdotdev/butler-provider-gcp"
+            --exclude "^https://github.com/butlerdotdev/butler-image-factory"
+            --exclude "^https://github.com/butlerdotdev/butlerlabs-docs"
             --exclude "^https://github.com/butlerdotdev/butler/discussions"
             --exclude "^https://github.com/butlerdotdev/butler/tree/main/design/proposals"
+            --exclude "^https://github.com/user-attachments/"
             --exclude "^https://opendocs.nutanix.com/capx/"
             --exclude "networking.md$"
             --exclude "security-model.md$"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -6,6 +6,9 @@
   "MD024": {
     "siblings_only": true
   },
+  "MD025": {
+    "front_matter_title": ""
+  },
   "MD026": false,
   "MD031": false,
   "MD032": false,

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Built by [Butler Labs](https://butlerlabs.dev) to solve the problem we kept seei
 | **AWS** | Cloud | In Progress | - |
 | **Azure** | Cloud | In Progress | - |
 
-See [Provider Guides](docs/providers/) for detailed setup instructions.
+See [Provider Guides](docs/getting-started/) for detailed setup instructions.
 
 ---
 
@@ -619,10 +619,10 @@ Butler is composed of multiple repositories, each with a specific responsibility
 
 | Guide | What you'll learn |
 |-------|-------------------|
-| [Overview & Concepts](docs/overview/) | What Butler is, how it works, core terminology |
+| [Overview & Concepts](docs/concepts/) | What Butler is, how it works, core terminology |
 | [Architecture](docs/architecture/) | System design, data flows, component interactions |
 | [Getting Started](docs/getting-started/) | Installation, bootstrap, first tenant cluster |
-| [Provider Guides](docs/providers/) | Infrastructure-specific setup (Harvester, Nutanix) |
+| [Provider Guides](docs/getting-started/) | Infrastructure-specific setup (Harvester, Nutanix) |
 | [Operations](docs/operations/) | Upgrades, backup/restore, monitoring |
 | [Steward Docs](https://docs.butlerlabs.dev/steward) | Hosted control plane operator |
 | [Contributing](docs/contributing/) | Development setup, PR process |

--- a/docs/getting-started/post-bootstrap.md
+++ b/docs/getting-started/post-bootstrap.md
@@ -165,7 +165,7 @@ server:
 
 Apply with `helm upgrade` (or let Flux reconcile).
 
-#### `BUTLER_TRUST_PROXY_HEADERS` chart gap
+### `BUTLER_TRUST_PROXY_HEADERS` chart gap
 
 The third env var you want set is `BUTLER_TRUST_PROXY_HEADERS=true`, which tells the server to honor `X-Forwarded-Proto` and `X-Forwarded-Host` from the ingress. Without it, `https` flows show up as `http` in emitted URLs. As of `butler-console` chart 0.4.1, this env var is not yet exposed through chart values; until the chart catches up, set it via `kubectl set env`:
 

--- a/docs/operations/scaling.md
+++ b/docs/operations/scaling.md
@@ -31,7 +31,7 @@ spec:
     - etcd-2.etcd:2379
 ```
 
-As tenant count grows, tune etcd resource limits and snapshot count. See the [etcd tuning guide](https://github.com/butlerdotdev/steward/blob/master/docs/etcd-tuning-for-multi-tenant.md) for details.
+As tenant count grows, tune etcd resource limits and snapshot count. See the [Steward documentation](https://github.com/butlerdotdev/steward) for details.
 
 ## Scale Tenant Clusters
 

--- a/docs/releases/2026-04-22.md
+++ b/docs/releases/2026-04-22.md
@@ -100,5 +100,5 @@ Three security and documentation tracks remain open before Company 1 deploy. The
 ## References
 
 - [ADR-009: Team environments](https://github.com/butlerdotdev/butler-controller/blob/main/docs/architecture/ADR-009-team-environments.md)
-- [ADR-010: butler-server impersonation](https://github.com/butlerdotdev/butler-server/blob/main/docs/architecture/ADR-010-impersonation.md)
-- [ADR-011: butler-cli impersonation](https://github.com/butlerdotdev/butler-cli/blob/main/docs/architecture/ADR-011-impersonation.md)
+- [ADR-010: butler-server impersonation](https://github.com/butlerdotdev/butler-server/blob/main/docs/architecture/ADR-010-impersonation-auth.md)
+- [ADR-011: butler-cli impersonation](https://github.com/butlerdotdev/butler-cli/blob/main/docs/architecture/ADR-011-cli-impersonation-auth.md)

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ Butler is a Kubernetes-as-a-Service platform that provisions and manages tenant 
 ## Project
 
 - **[Contributing](CONTRIBUTING.md)** — How to contribute to Butler
-- **[Governance](GOVERNANCE.md)** — Project governance model
+- **[Governance](governance/GOVERNANCE.md)** — Project governance model
 - **[Code of Conduct](CODE_OF_CONDUCT.md)** — Community standards
 - **[DCO](DCO.md)** — Developer Certificate of Origin
 


### PR DESCRIPTION
## Why

`markdownlint` and `link-check` have failed on every push to `main` for months and have been ignored, which hides real problems. This makes both green and meaningful, and fixes the genuinely broken links they surfaced.

## markdownlint (46 -> 0)
- **MD025** (44): every doc has a front matter `title` plus a body `# H1`, counted as two titles. Set `front_matter_title: ""` (the standard Docusaurus config) so the H1 is the single title.
- **MD001** (1): a heading jumped h2 -> h4 in `post-bootstrap.md`.

## link-check / lychee (20 -> 0)
- **Scope**: external (http/https) links + Docusaurus root-relative links (`/concepts/...`, resolved against `docs/` via `--root-dir`). Relative/dir file links are deferred to Docusaurus's own `onBrokenLinks` check.
- **Excludes** (false positives): private/nonexistent butlerdotdev repos that 404 anonymously, `user-attachments` video URLs (GitHub-gated), and the LF DCO wiki (bot-blocked 403).
- **Real fixes**: corrected `butler-server`/`butler-cli` ADR filenames, replaced a dead steward etcd-tuning link, repointed the README `docs/providers`/`docs/overview` links (those dirs no longer exist) to `getting-started`/`concepts`, and fixed `index.md`'s governance link.

Verified locally: markdownlint **0 errors**, lychee **0 errors**.