### PR TITLE
ci: harden link-check against transient external failures

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -33,6 +33,10 @@ jobs:
             --verbose
             --no-progress
             --root-dir docs
+            --max-retries 5
+            --retry-wait-time 3
+            --timeout 30
+            --user-agent "Mozilla/5.0 (compatible; lychee link checker)"
             --scheme https
             --scheme http
             --exclude "^https://wiki.linuxfoundation.org/dco"


### PR DESCRIPTION
Follow-up to #35. link-check passed on that PR but failed on the main push when three `kubernetes.io` links hit transient "connection failed" network errors (valid links, reachable minutes earlier on the PR run).

External link checking is inherently flaky. Adds `--max-retries 5`, `--retry-wait-time 3`, `--timeout 30`, and a browser `--user-agent` so transient blips and UA-based blocks are ridden out rather than failing the build. The links themselves are valid and stay checked.