### PR TITLE
ci: run link-check on a schedule, not on every push/PR

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,15 +1,12 @@
 name: Link Check
 
+# External link checking is inherently flaky: checking ~160 links against
+# dozens of third-party sites means some site intermittently resets or refuses
+# the connection from a CI runner on any given run. Gating every push/PR on that
+# produces red noise unrelated to the change. So this runs on a weekly schedule
+# (to catch real link rot, reviewed by a maintainer) and on demand. The
+# deterministic markdownlint workflow remains the per-commit docs gate.
 on:
-  push:
-    branches: [main]
-    paths:
-      - '**.md'
-      - '.github/workflows/link-check.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - '**.md'
   schedule:
     # Run weekly on Sunday at midnight
     - cron: '0 0 * * 0'


### PR DESCRIPTION
Follow-up to #35/#36. After fixing the 20 real link errors, the only remaining failures are **transient third-party network errors** — a different site each run (`kubernetes.io`, then `helm.sh`, both "connection reset/failed" on valid links). Retries didn't help because it's a different site each time.

Checking ~160 external links against dozens of third-party sites on every push will always have some transient failure; with `fail: true` that's unavoidable red noise. So link-check now runs **weekly + on demand** (catches real rot, maintainer-reviewed) instead of gating every commit. The deterministic **markdownlint** check remains the per-commit docs gate.

Net: per-commit CI is now green and deterministic; link rot is still caught on a schedule.