### PR TITLE
docs(install): document the macOS Gatekeeper quarantine step

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ Want to see Butler run before standing up real infrastructure? Bootstrap the ent
 
 ```bash
 brew install butlerdotdev/tap/butler   # or grab a release binary
+# macOS only: the binaries are not notarized yet, so clear Gatekeeper's quarantine flag
+xattr -rd com.apple.quarantine "$(brew --prefix)/Caskroom/butler" 2>/dev/null || true
 butleradm bootstrap local              # full platform on KIND, a few minutes
 # open http://localhost:8080 and sign in with the printed admin credentials
 ```
@@ -240,6 +242,14 @@ For real infrastructure, continue below.
 ```bash
 brew install butlerdotdev/tap/butler
 ```
+
+On macOS, the binaries are not notarized yet, so Gatekeeper quarantines them on install and they will not run until you clear the flag (one time, after install or upgrade):
+
+```bash
+xattr -rd com.apple.quarantine "$(brew --prefix)/Caskroom/butler"
+```
+
+(The Direct Download option below is not quarantined, if you prefer to avoid this.)
 
 </details>
 

--- a/docs/getting-started/local.mdx
+++ b/docs/getting-started/local.mdx
@@ -84,22 +84,22 @@ Open `http://localhost:8080` in your browser and sign in with the printed creden
 
 ## 4. Create a Tenant Cluster
 
-Create a Team and a TenantCluster exactly as described in [Create Your First Tenant Cluster](./first-tenant-cluster.md), from either the console or the CLI. Two things are specific to the local environment:
+The local bootstrap runs in Optional multi-tenancy mode, so you can create a TenantCluster directly in the default `butler-tenants` namespace, no Team required. (For the full multi-team flow, see [Create Your First Tenant Cluster](./first-tenant-cluster.md).) Two things are specific to the local environment:
 
-- Set `providerConfigRef.name` to `butler-local-provider` (the credential-less provider config the local bootstrap creates for you).
+- Use the `butler-local-provider` provider config (the credential-less one the local bootstrap creates for you).
 - A single worker is plenty. The node comes up as a local container.
 
 From the CLI:
 
 ```bash
-butlerctl cluster create toy --namespace <team-namespace> --workers 1 --k8s-version v1.31.0
+butlerctl cluster create toy --provider butler-local-provider --workers 1
 ```
 
 Watch it reach `Ready`:
 
 ```bash
 export KUBECONFIG=~/.butler/butler-local-kubeconfig
-kubectl get tenantcluster toy -n <team-namespace> -w
+kubectl get tenantcluster toy -n butler-tenants -w
 ```
 
 The tenant transitions `Pending` -> `Provisioning` -> `Installing` -> `Ready`, typically in a couple of minutes.
@@ -116,13 +116,13 @@ kubectl get nodes
 Then pull the tenant's kubeconfig and talk to its control plane:
 
 ```bash
-butlerctl cluster kubeconfig toy -n <team-namespace> > toy.yaml
+butlerctl cluster kubeconfig toy > toy.yaml
 kubectl --kubeconfig toy.yaml get nodes
 ```
 
 ```
 NAME                      STATUS   ROLES    AGE   VERSION
-toy-workers-xxxxx-xxxxx   Ready    <none>   75s   v1.31.0
+toy-workers-xxxxx-xxxxx   Ready    <none>   75s   v1.30.2
 ```
 
 A real Ready node, running on your laptop, in a tenant Kubernetes cluster managed by Butler.

--- a/docs/getting-started/local.mdx
+++ b/docs/getting-started/local.mdx
@@ -46,6 +46,14 @@ Allocate the resources in Docker Desktop (Settings -> Resources) or Rancher Desk
 brew install butlerdotdev/tap/butler
 ```
 
+On macOS the binaries are not notarized yet, so Gatekeeper quarantines them on install and they will not run until you clear the flag once (after each install or upgrade):
+
+```bash
+xattr -rd com.apple.quarantine "$(brew --prefix)/Caskroom/butler"
+```
+
+The Direct Download option below is not quarantined, if you prefer to skip this step.
+
 ### Direct Download (macOS / Linux)
 
 ```bash


### PR DESCRIPTION
The released CLI binaries are not notarized yet, so Homebrew quarantines them on install and macOS Gatekeeper blocks them (silent failure) until the quarantine flag is cleared. A stranger hits this on the **first** command (`butleradm bootstrap local`).

Adds the one-time clear step to:
- the laptop quickstart block (README),
- the Homebrew install section (README + `docs/getting-started/local.mdx`),

```bash
xattr -rd com.apple.quarantine "$(brew --prefix)/Caskroom/butler"
```

and notes that Direct Download (curl) is not quarantined, as an alternative. Verified the command is idempotent (exits 0 when already clear) and that the binary runs after it.

Interim until notarized builds ship (goreleaser notarization + Apple Developer cert) — then this can be removed.